### PR TITLE
chore: add /check-logs Claude Code command for production log inspection

### DIFF
--- a/.claude/commands/check-logs.md
+++ b/.claude/commands/check-logs.md
@@ -1,0 +1,31 @@
+# check-logs
+
+Check production logs for a systemd service on this server.
+
+## Usage
+
+```
+/check-logs [service] [options]
+```
+
+If no service is specified, default to `draftview`.
+
+## What to do
+
+1. If a service name is given as an argument, use it. Otherwise use `draftview`.
+
+2. Run `sudo systemctl status <service> --no-pager` and summarise the current state — is it active, failed, restarting? When did it last start?
+
+3. Run `sudo journalctl -u <service> -n 100 --no-pager` and report:
+   - Any ERROR or CRITICAL entries, with timestamps
+   - Any WARN entries that appear more than once
+   - The last 5 lines, verbatim, so the most recent activity is visible
+   - Whether the service appears healthy or not, with a one-line verdict
+
+4. If the word "errors" or "error" appears in the arguments, filter to `journalctl -u <service> -p err -n 50 --no-pager` instead and list every entry.
+
+5. If the word "nginx" appears in the arguments, also check `/var/log/nginx/error.log` (last 50 lines) and report any 5xx errors or upstream failures.
+
+6. If the word "follow" or "live" appears in the arguments, run `sudo journalctl -u <service> -f --no-pager` to stream in real time.
+
+7. After reporting, suggest the most likely next diagnostic step if anything looks wrong.


### PR DESCRIPTION
Adds `.claude/commands/check-logs.md` — a Claude Code slash command for inspecting production service logs.

## Summary

- Invoked as `/check-logs [service]` inside any Claude Code session on the production server
- Defaults to the `draftview` service
- Reports systemd service state, recent errors, and a health verdict
- Supports flags via natural language: `errors`, `nginx`, `follow`/`live`

## Usage (on production server)

Once Claude Code is installed (`npm install -g @anthropic-ai/claude-code`), run `claude` from any directory and invoke:

```
/check-logs
/check-logs nginx errors
/check-logs draftview follow
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGeQtD7jrU4VRRzUheEmZf)_