### PR TITLE
Gate sync notification on actual changes; add reader notifications; iPad desktop reader

### DIFF
--- a/DraftView.Application.Tests/Services/ReadingProgressServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReadingProgressServiceTests.cs
@@ -6,6 +6,7 @@ using DraftView.Domain.Enumerations;
 using DraftView.Domain.Exceptions;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
+using DraftView.Domain.Notifications;
 
 namespace DraftView.Application.Tests.Services;
 
@@ -17,16 +18,20 @@ namespace DraftView.Application.Tests.Services;
 /// </summary>
 public class ReadingProgressServiceTests
 {
-    private readonly Mock<IReadEventRepository> _readEventRepo = new();
-    private readonly Mock<ISectionRepository>   _sectionRepo   = new();
-    private readonly Mock<IPassageAnchorService> _passageAnchorService = new();
-    private readonly Mock<IUnitOfWork>          _unitOfWork    = new();
+    private readonly Mock<IReadEventRepository>          _readEventRepo       = new();
+    private readonly Mock<ISectionRepository>            _sectionRepo         = new();
+    private readonly Mock<IPassageAnchorService>         _passageAnchorService = new();
+    private readonly Mock<IUnitOfWork>                   _unitOfWork          = new();
+    private readonly Mock<IUserRepository>               _userRepo            = new();
+    private readonly Mock<IAuthorNotificationRepository> _notificationRepo    = new();
 
     private ReadingProgressService CreateSut() => new(
         _readEventRepo.Object,
         _sectionRepo.Object,
         _passageAnchorService.Object,
-        _unitOfWork.Object);
+        _unitOfWork.Object,
+        _userRepo.Object,
+        _notificationRepo.Object);
 
     private static Section MakePublishedSection(Guid projectId)
     {
@@ -644,5 +649,244 @@ public class ReadingProgressServiceTests
             10,
             "content-hash",
             "#scene");
+    }
+
+    // ---------------------------------------------------------------------------
+    // RecordOpen — reader notifications
+    // ---------------------------------------------------------------------------
+
+    private static Section MakePublishedDocument(Guid projectId, string title = "Scene 1")
+    {
+        var s = Section.CreateDocument(projectId, Guid.NewGuid().ToString(),
+            title, null, 0, "<p>x</p>", "h", "First Draft");
+        s.PublishAsPartOfChapter("h");
+        return s;
+    }
+
+    private static ReadEvent MakeOldReadEvent(Guid sectionId, Guid userId, int daysAgo)
+    {
+        var ev = ReadEvent.Create(sectionId, userId);
+        typeof(ReadEvent)
+            .GetProperty(nameof(ReadEvent.LastOpenedAt))!
+            .SetValue(ev, DateTime.UtcNow.AddDays(-daysAgo));
+        return ev;
+    }
+
+    private void SetupNotificationDeps(User author, User reader, Guid userId, Section section)
+    {
+        _userRepo.Setup(r => r.GetAuthorAsync(default)).ReturnsAsync(author);
+        _userRepo.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(reader);
+        _sectionRepo.Setup(r => r.GetByIdAsync(section.Id, default)).ReturnsAsync(section);
+        _readEventRepo.Setup(r => r.GetByUserIdAsync(userId, default))
+            .ReturnsAsync(new List<ReadEvent>());
+        _sectionRepo.Setup(r => r.GetPublishedByProjectIdAsync(section.ProjectId, default))
+            .ReturnsAsync(new List<Section> { section });
+        _readEventRepo.Setup(r => r.HasReadAsync(section.Id, userId, default)).ReturnsAsync(false);
+    }
+
+    [Fact]
+    public async Task RecordOpenAsync_FirstOpen_DocumentSection_WritesReaderReadNewSceneNotification()
+    {
+        var projectId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        var section   = MakePublishedDocument(projectId);
+        var author    = User.Create("a@test.com", "Author Name", Role.Author);
+        var reader    = User.Create("r@test.com", "Reader Name", Role.BetaReader);
+        var sut       = CreateSut();
+
+        _readEventRepo.Setup(r => r.GetAsync(section.Id, userId, default)).ReturnsAsync((ReadEvent?)null);
+        SetupNotificationDeps(author, reader, userId, section);
+
+        await sut.RecordOpenAsync(section.Id, userId);
+
+        _notificationRepo.Verify(
+            r => r.AddAsync(It.Is<AuthorNotification>(n =>
+                n.EventType == NotificationEventType.ReaderReadNewScene &&
+                n.AuthorId  == author.Id &&
+                n.Title.Contains("Reader Name") &&
+                n.Title.Contains(section.Title)),
+                default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordOpenAsync_FirstOpen_FolderSection_DoesNotWriteNotification()
+    {
+        var projectId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        var folder    = Section.CreateFolder(projectId, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
+        var sut       = CreateSut();
+
+        _readEventRepo.Setup(r => r.GetAsync(folder.Id, userId, default)).ReturnsAsync((ReadEvent?)null);
+        _readEventRepo.Setup(r => r.GetByUserIdAsync(userId, default)).ReturnsAsync(new List<ReadEvent>());
+        _sectionRepo.Setup(r => r.GetByIdAsync(folder.Id, default)).ReturnsAsync(folder);
+
+        await sut.RecordOpenAsync(folder.Id, userId);
+
+        _notificationRepo.Verify(r => r.AddAsync(It.IsAny<AuthorNotification>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task RecordOpenAsync_RepeatOpen_DoesNotWriteReaderReadNewSceneNotification()
+    {
+        var projectId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        var section   = MakePublishedDocument(projectId);
+        var existing  = ReadEvent.Create(section.Id, userId);
+        var sut       = CreateSut();
+
+        _readEventRepo.Setup(r => r.GetAsync(section.Id, userId, default)).ReturnsAsync(existing);
+
+        await sut.RecordOpenAsync(section.Id, userId);
+
+        _notificationRepo.Verify(r => r.AddAsync(It.IsAny<AuthorNotification>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task RecordOpenAsync_FirstOpen_WithPreviousEventsOlderThan7Days_WritesReaderReturnedNotification()
+    {
+        var projectId  = Guid.NewGuid();
+        var userId     = Guid.NewGuid();
+        var section    = MakePublishedDocument(projectId);
+        var oldSection = Guid.NewGuid();
+        var author     = User.Create("a@test.com", "Author Name", Role.Author);
+        var reader     = User.Create("r@test.com", "Reader Name", Role.BetaReader);
+        var sut        = CreateSut();
+
+        var oldEvent = MakeOldReadEvent(oldSection, userId, daysAgo: 10);
+
+        _readEventRepo.Setup(r => r.GetAsync(section.Id, userId, default)).ReturnsAsync((ReadEvent?)null);
+        _userRepo.Setup(r => r.GetAuthorAsync(default)).ReturnsAsync(author);
+        _userRepo.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(reader);
+        _sectionRepo.Setup(r => r.GetByIdAsync(section.Id, default)).ReturnsAsync(section);
+        _readEventRepo.Setup(r => r.GetByUserIdAsync(userId, default))
+            .ReturnsAsync(new List<ReadEvent> { oldEvent });
+        _sectionRepo.Setup(r => r.GetPublishedByProjectIdAsync(section.ProjectId, default))
+            .ReturnsAsync(new List<Section> { section });
+        _readEventRepo.Setup(r => r.HasReadAsync(section.Id, userId, default)).ReturnsAsync(false);
+
+        await sut.RecordOpenAsync(section.Id, userId);
+
+        _notificationRepo.Verify(
+            r => r.AddAsync(It.Is<AuthorNotification>(n =>
+                n.EventType == NotificationEventType.ReaderReturned &&
+                n.AuthorId  == author.Id &&
+                n.Title.Contains("Reader Name")),
+                default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordOpenAsync_FirstOpen_WithPreviousEventsWithin7Days_DoesNotWriteReaderReturned()
+    {
+        var projectId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        var section   = MakePublishedDocument(projectId);
+        var author    = User.Create("a@test.com", "Author Name", Role.Author);
+        var reader    = User.Create("r@test.com", "Reader Name", Role.BetaReader);
+        var sut       = CreateSut();
+
+        var recentEvent = MakeOldReadEvent(Guid.NewGuid(), userId, daysAgo: 3);
+
+        _readEventRepo.Setup(r => r.GetAsync(section.Id, userId, default)).ReturnsAsync((ReadEvent?)null);
+        _userRepo.Setup(r => r.GetAuthorAsync(default)).ReturnsAsync(author);
+        _userRepo.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(reader);
+        _sectionRepo.Setup(r => r.GetByIdAsync(section.Id, default)).ReturnsAsync(section);
+        _readEventRepo.Setup(r => r.GetByUserIdAsync(userId, default))
+            .ReturnsAsync(new List<ReadEvent> { recentEvent });
+        _sectionRepo.Setup(r => r.GetPublishedByProjectIdAsync(section.ProjectId, default))
+            .ReturnsAsync(new List<Section> { section });
+        _readEventRepo.Setup(r => r.HasReadAsync(section.Id, userId, default)).ReturnsAsync(false);
+
+        await sut.RecordOpenAsync(section.Id, userId);
+
+        _notificationRepo.Verify(
+            r => r.AddAsync(It.Is<AuthorNotification>(n =>
+                n.EventType == NotificationEventType.ReaderReturned),
+                default),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RecordOpenAsync_FirstOpen_NoPreviousEvents_DoesNotWriteReaderReturned()
+    {
+        var projectId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        var section   = MakePublishedDocument(projectId);
+        var author    = User.Create("a@test.com", "Author Name", Role.Author);
+        var reader    = User.Create("r@test.com", "Reader Name", Role.BetaReader);
+        var sut       = CreateSut();
+
+        _readEventRepo.Setup(r => r.GetAsync(section.Id, userId, default)).ReturnsAsync((ReadEvent?)null);
+        SetupNotificationDeps(author, reader, userId, section);
+
+        await sut.RecordOpenAsync(section.Id, userId);
+
+        _notificationRepo.Verify(
+            r => r.AddAsync(It.Is<AuthorNotification>(n =>
+                n.EventType == NotificationEventType.ReaderReturned),
+                default),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RecordOpenAsync_FirstOpen_ReaderNowCaughtUp_WritesReaderFinishedManuscriptNotification()
+    {
+        var projectId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        var section   = MakePublishedDocument(projectId);
+        var author    = User.Create("a@test.com", "Author Name", Role.Author);
+        var reader    = User.Create("r@test.com", "Reader Name", Role.BetaReader);
+        var sut       = CreateSut();
+
+        _readEventRepo.Setup(r => r.GetAsync(section.Id, userId, default)).ReturnsAsync((ReadEvent?)null);
+        _userRepo.Setup(r => r.GetAuthorAsync(default)).ReturnsAsync(author);
+        _userRepo.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(reader);
+        _sectionRepo.Setup(r => r.GetByIdAsync(section.Id, default)).ReturnsAsync(section);
+        _readEventRepo.Setup(r => r.GetByUserIdAsync(userId, default)).ReturnsAsync(new List<ReadEvent>());
+        _sectionRepo.Setup(r => r.GetPublishedByProjectIdAsync(section.ProjectId, default))
+            .ReturnsAsync(new List<Section> { section });
+        // After adding the new ReadEvent the reader has read this section
+        _readEventRepo.Setup(r => r.HasReadAsync(section.Id, userId, default)).ReturnsAsync(true);
+
+        await sut.RecordOpenAsync(section.Id, userId);
+
+        _notificationRepo.Verify(
+            r => r.AddAsync(It.Is<AuthorNotification>(n =>
+                n.EventType == NotificationEventType.ReaderFinishedManuscript &&
+                n.AuthorId  == author.Id &&
+                n.Title.Contains("Reader Name")),
+                default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordOpenAsync_FirstOpen_ReaderNotCaughtUp_DoesNotWriteReaderFinishedManuscript()
+    {
+        var projectId   = Guid.NewGuid();
+        var userId      = Guid.NewGuid();
+        var section     = MakePublishedDocument(projectId);
+        var unread      = MakePublishedDocument(projectId, "Scene 2");
+        var author      = User.Create("a@test.com", "Author Name", Role.Author);
+        var reader      = User.Create("r@test.com", "Reader Name", Role.BetaReader);
+        var sut         = CreateSut();
+
+        _readEventRepo.Setup(r => r.GetAsync(section.Id, userId, default)).ReturnsAsync((ReadEvent?)null);
+        _userRepo.Setup(r => r.GetAuthorAsync(default)).ReturnsAsync(author);
+        _userRepo.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(reader);
+        _sectionRepo.Setup(r => r.GetByIdAsync(section.Id, default)).ReturnsAsync(section);
+        _readEventRepo.Setup(r => r.GetByUserIdAsync(userId, default)).ReturnsAsync(new List<ReadEvent>());
+        _sectionRepo.Setup(r => r.GetPublishedByProjectIdAsync(section.ProjectId, default))
+            .ReturnsAsync(new List<Section> { section, unread });
+        _readEventRepo.Setup(r => r.HasReadAsync(section.Id, userId, default)).ReturnsAsync(true);
+        _readEventRepo.Setup(r => r.HasReadAsync(unread.Id, userId, default)).ReturnsAsync(false);
+
+        await sut.RecordOpenAsync(section.Id, userId);
+
+        _notificationRepo.Verify(
+            r => r.AddAsync(It.Is<AuthorNotification>(n =>
+                n.EventType == NotificationEventType.ReaderFinishedManuscript),
+                default),
+            Times.Never);
     }
 }

--- a/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
@@ -790,6 +790,77 @@ public class ScrivenerSyncServiceTests
             Times.Never);
     }
 
+    [Fact]
+    public async Task ParseProjectAsync_DoesNotWriteNotification_WhenNothingChanges()
+    {
+        var project = MakeProject();
+        project.UpdateDropboxCursor("cursor-old");
+        var existingFolder = Section.CreateFolder(project.Id, "ROOT-001", "Manuscript", null, 0);
+        var sut = CreateSut();
+
+        SetupPathResolver(project);
+        SetupParserWithTree(project, new ParsedBinderNode
+        {
+            Uuid = "ROOT-001", Title = "Manuscript",
+            NodeType = ParsedNodeType.Folder, Children = new()
+        });
+
+        _sectionRepo.Setup(r => r.GetByScrivenerUuidAsync(project.Id, "ROOT-001", default))
+            .ReturnsAsync(existingFolder);
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, default))
+            .ReturnsAsync(new List<Section> { existingFolder });
+        _fileDownloader.Setup(x => x.ListChangedEntriesAsync(project.AuthorId, "cursor-old", default))
+            .ReturnsAsync((new List<DropboxChangedEntry>(), "cursor-new"));
+
+        await sut.ParseProjectAsync(project.Id);
+
+        _notificationRepo.Verify(
+            r => r.AddAsync(It.IsAny<AuthorNotification>(), default),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ParseProjectAsync_WritesNotification_WhenContentHashChanges()
+    {
+        var project = MakeProject();
+        project.UpdateDropboxCursor("cursor-old");
+        var author = User.Create("author@example.com", "Author", Role.Author);
+        var existingScene = Section.CreateDocument(project.Id, "SCEN-001", "Scene 1", null, 0, "<p>Old</p>", "oldhash", "First Draft");
+        var sut = CreateSut();
+
+        SetupPathResolver(project);
+        SetupParserWithTree(project, new ParsedBinderNode
+        {
+            Uuid = "ROOT-001", Title = "Manuscript",
+            NodeType = ParsedNodeType.Folder,
+            Children = new List<ParsedBinderNode>
+            {
+                new() { Uuid = "SCEN-001", Title = "Scene 1", NodeType = ParsedNodeType.Document, SortOrder = 0, Children = new() }
+            }
+        });
+
+        _sectionRepo.Setup(r => r.GetByScrivenerUuidAsync(project.Id, "ROOT-001", default))
+            .ReturnsAsync((Section?)null);
+        _sectionRepo.Setup(r => r.GetByScrivenerUuidAsync(project.Id, "SCEN-001", default))
+            .ReturnsAsync(existingScene);
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, default))
+            .ReturnsAsync(new List<Section> { existingScene });
+        _converter.Setup(c => c.ConvertAsync(It.IsAny<string>(), "SCEN-001", default))
+            .ReturnsAsync(new RtfConversionResult { Html = "<p>New</p>", Hash = "newhash" });
+        _fileDownloader.Setup(x => x.ListChangedEntriesAsync(project.AuthorId, "cursor-old", default))
+            .ReturnsAsync((new List<DropboxChangedEntry>(), "cursor-new"));
+        _userRepo.Setup(r => r.GetAuthorAsync(default)).ReturnsAsync(author);
+
+        await sut.ParseProjectAsync(project.Id);
+
+        _notificationRepo.Verify(
+            r => r.AddAsync(It.Is<AuthorNotification>(n =>
+                n.AuthorId == author.Id &&
+                n.EventType == NotificationEventType.SyncCompleted),
+                default),
+            Times.Once);
+    }
+
     // ---------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------

--- a/DraftView.Application/Services/ReadingProgressService.cs
+++ b/DraftView.Application/Services/ReadingProgressService.cs
@@ -4,6 +4,7 @@ using DraftView.Domain.Enumerations;
 using DraftView.Domain.Exceptions;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
+using DraftView.Domain.Notifications;
 
 namespace DraftView.Application.Services;
 
@@ -11,8 +12,12 @@ public class ReadingProgressService(
     IReadEventRepository readEventRepo,
     ISectionRepository sectionRepo,
     IPassageAnchorService passageAnchorService,
-    IUnitOfWork unitOfWork) : IReadingProgressService
+    IUnitOfWork unitOfWork,
+    IUserRepository userRepo,
+    IAuthorNotificationRepository notificationRepo) : IReadingProgressService
 {
+    private static readonly TimeSpan ReturnThreshold = TimeSpan.FromDays(7);
+
     public async Task RecordOpenAsync(
         Guid sectionId, Guid userId, CancellationToken ct = default)
     {
@@ -20,8 +25,13 @@ public class ReadingProgressService(
 
         if (existing is null)
         {
+            var previousEvents = (await readEventRepo.GetByUserIdAsync(userId, ct))
+                ?? Array.Empty<ReadEvent>();
+
             var readEvent = ReadEvent.Create(sectionId, userId);
             await readEventRepo.AddAsync(readEvent, ct);
+
+            await WriteReaderNotificationsAsync(sectionId, userId, previousEvents, ct);
         }
         else
         {
@@ -29,6 +39,63 @@ public class ReadingProgressService(
         }
 
         await unitOfWork.SaveChangesAsync(ct);
+    }
+
+    private async Task WriteReaderNotificationsAsync(
+        Guid sectionId, Guid userId,
+        IReadOnlyList<ReadEvent> previousEvents, CancellationToken ct)
+    {
+        var section = await sectionRepo.GetByIdAsync(sectionId, ct);
+        if (section?.NodeType != NodeType.Document)
+            return;
+
+        var author = await userRepo.GetAuthorAsync(ct);
+        var reader = await userRepo.GetByIdAsync(userId, ct);
+        if (author is null || reader is null)
+            return;
+
+        var now = DateTime.UtcNow;
+
+        await notificationRepo.AddAsync(
+            AuthorNotification.Create(
+                author.Id,
+                NotificationEventType.ReaderReadNewScene,
+                $"{reader.DisplayName} read \"{section.Title}\" for the first time",
+                null,
+                $"/Author/Section/{sectionId}",
+                now),
+            ct);
+
+        if (previousEvents.Count > 0)
+        {
+            var lastActive = previousEvents.Max(e => e.LastOpenedAt);
+            if (now - lastActive >= ReturnThreshold)
+            {
+                var daysAway = (int)(now - lastActive).TotalDays;
+                await notificationRepo.AddAsync(
+                    AuthorNotification.Create(
+                        author.Id,
+                        NotificationEventType.ReaderReturned,
+                        $"{reader.DisplayName} is reading again — last active {daysAway} days ago",
+                        null,
+                        null,
+                        now),
+                    ct);
+            }
+        }
+
+        if (await IsCaughtUpAsync(userId, section.ProjectId, ct))
+        {
+            await notificationRepo.AddAsync(
+                AuthorNotification.Create(
+                    author.Id,
+                    NotificationEventType.ReaderFinishedManuscript,
+                    $"{reader.DisplayName} has finished reading the manuscript",
+                    null,
+                    "/Author/Readers",
+                    now),
+                ct);
+        }
     }
 
     public async Task<bool> IsCaughtUpAsync(

--- a/DraftView.Application/Services/ScrivenerSyncService.cs
+++ b/DraftView.Application/Services/ScrivenerSyncService.cs
@@ -24,6 +24,8 @@ public class ScrivenerSyncService(
     IAuthorNotificationRepository notificationRepo,
     IUserRepository userRepo) : ISyncService
 {
+    private bool _syncHadChanges;
+
     public async Task ParseProjectAsync(Guid projectId, CancellationToken ct = default)
     {
         var project = await projectRepo.GetByIdAsync(projectId, ct)
@@ -44,6 +46,8 @@ public class ScrivenerSyncService(
             return;
         }
 
+        _syncHadChanges = false;
+
         try
         {
             if (string.IsNullOrWhiteSpace(project.DropboxCursor))
@@ -55,17 +59,20 @@ public class ScrivenerSyncService(
                 await SyncUsingIncrementalListingAsync(project, ct);
             }
 
-            var author = await userRepo.GetAuthorAsync(ct);
-            if (author is not null)
+            if (_syncHadChanges)
             {
-                var notification = AuthorNotification.Create(
-                    author.Id,
-                    NotificationEventType.SyncCompleted,
-                    $"Sync completed for {project.Name}",
-                    null,
-                    null,
-                    DateTime.UtcNow);
-                await notificationRepo.AddAsync(notification, ct);
+                var author = await userRepo.GetAuthorAsync(ct);
+                if (author is not null)
+                {
+                    var notification = AuthorNotification.Create(
+                        author.Id,
+                        NotificationEventType.SyncCompleted,
+                        $"Sync completed for {project.Name}",
+                        null,
+                        null,
+                        DateTime.UtcNow);
+                    await notificationRepo.AddAsync(notification, ct);
+                }
             }
 
             project.UpdateSyncStatus(SyncStatus.Healthy, DateTime.UtcNow, null);
@@ -126,6 +133,7 @@ public class ScrivenerSyncService(
             existing = await CreateSectionAsync(node, parentId, projectId, scrivFolderPath, ct);
             await sectionRepo.AddAsync(existing, ct);
             created = true;
+            _syncHadChanges = true;
 
             if (created && node.NodeType == ParsedNodeType.Document)
             {
@@ -261,6 +269,7 @@ public class ScrivenerSyncService(
     {
         if (!section.IsSoftDeleted)
         {
+            _syncHadChanges = true;
             var descendants = await sectionRepo.GetAllDescendantsAsync(section.Id, ct);
             foreach (var descendant in descendants)
                 descendant.SoftDelete();
@@ -316,6 +325,7 @@ public class ScrivenerSyncService(
                 existing.UpdateContent(rtf.Html, rtf.Hash);
                 if (existing.IsPublished)
                     existing.MarkContentChanged();
+                _syncHadChanges = true;
             }
         }
     }

--- a/DraftView.Domain/Notifications/NotificationItemDto.cs
+++ b/DraftView.Domain/Notifications/NotificationItemDto.cs
@@ -5,7 +5,10 @@ public enum NotificationEventType
     NewComment,
     ReplyToAuthor,
     ReaderJoined,
-    SyncCompleted
+    SyncCompleted,
+    ReaderReadNewScene,
+    ReaderReturned,
+    ReaderFinishedManuscript
 }
 
 public sealed class NotificationItemDto

--- a/DraftView.Web/Controllers/BaseReaderController.cs
+++ b/DraftView.Web/Controllers/BaseReaderController.cs
@@ -428,7 +428,6 @@ public abstract class BaseReaderController(
             ua.Contains("Mobile",      StringComparison.OrdinalIgnoreCase) ||
             ua.Contains("Android",     StringComparison.OrdinalIgnoreCase) ||
             ua.Contains("iPhone",      StringComparison.OrdinalIgnoreCase) ||
-            ua.Contains("iPad",        StringComparison.OrdinalIgnoreCase) ||
             ua.Contains("iPod",        StringComparison.OrdinalIgnoreCase) ||
             ua.Contains("BlackBerry",  StringComparison.OrdinalIgnoreCase) ||
             ua.Contains("IEMobile",    StringComparison.OrdinalIgnoreCase) ||

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -416,6 +416,10 @@ public class ReaderController(
         if (chapter is null || !chapter.IsPublished)
             return NotFound();
 
+        // Scene (Document) URL — redirect to its parent chapter so the desktop layout loads correctly
+        if (chapter.NodeType == NodeType.Document && chapter.ParentId.HasValue)
+            return RedirectToAction("Read", new { id = chapter.ParentId.Value });
+
         var isModerator = user.Role == Role.Author;
 
         await ProgressService.RecordOpenAsync(id, user.Id);

--- a/DraftView.Web/Views/Reader/DesktopRead.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopRead.cshtml
@@ -1587,7 +1587,9 @@
                 if (persist) localStorage.setItem('dv-nav-collapsed', collapsed ? '1' : '0');
             }
 
-            if (localStorage.getItem('dv-nav-collapsed') === '1') {
+            var navPref = localStorage.getItem('dv-nav-collapsed');
+            var startNavCollapsed = navPref !== null ? navPref === '1' : false;
+            if (startNavCollapsed) {
                 setSidebarCollapsed(true, false);
             }
 
@@ -1605,7 +1607,9 @@
         var commentsBtn = document.getElementById('commentsToggleBtn');
 
         if (contentRow && commentsBtn) {
-            if (localStorage.getItem('dv-comments-visible') === 'hidden') {
+            var commentsPref = localStorage.getItem('dv-comments-visible');
+            var startCommentsHidden = commentsPref !== null ? commentsPref === 'hidden' : window.innerWidth < 900;
+            if (startCommentsHidden) {
                 contentRow.classList.add('comments-hidden');
                 commentsBtn.textContent = 'Show Comments';
             }


### PR DESCRIPTION
## Summary

- **Sync notifications**: `SyncCompleted` notification is now only written when `_syncHadChanges` is true (a new section was created, content hash changed, or a section was soft-deleted). No-op syncs produce no notification.
- **Reader notifications**: Three new `NotificationEventType` values (`ReaderReadNewScene`, `ReaderReturned`, `ReaderFinishedManuscript`) are written by `ReadingProgressService` on first open of a scene, return after ≥7 days away, and completing the full published manuscript respectively.
- **iPad desktop reader**: Removed `iPad` from `IsMobile()` so iPad users receive the full desktop reading experience with navigation sidebar and comments column. Added a Document→Chapter redirect in `DesktopRead` for any bookmarked scene URLs. On first load at viewport widths < 900px (portrait iPad 11"), the comments column defaults to hidden to avoid a cramped prose column; user preference persists via `localStorage`.

## Test plan

- [ ] No-op sync (Dropbox polled, no file changes) → no `SyncCompleted` notification created
- [ ] Sync that adds/updates/deletes a section → `SyncCompleted` notification created
- [ ] Reader opens a scene for the first time → `ReaderReadNewScene` notification
- [ ] Reader opens a scene after ≥7 day gap → `ReaderReturned` notification also created
- [ ] Reader opens the last unread scene → `ReaderFinishedManuscript` notification also created
- [ ] Open reader on iPad in landscape → both nav sidebar and comments column visible; "Hide Navigation" and "Hide Comments" buttons work
- [ ] Open reader on iPad in portrait (narrow) → comments column hidden by default, "Show Comments" button reveals it; preference persists on reload