### PR TITLE
Reader Dashboard: Continue Reading CTA and per-chapter comment counts

### DIFF
--- a/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
@@ -1,0 +1,274 @@
+using Moq;
+using DraftView.Application.Services;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Tests.Services;
+
+public class ReaderDashboardServiceTests
+{
+    private static readonly Guid UserId    = Guid.NewGuid();
+    private static readonly Guid ProjectId = Guid.NewGuid();
+
+    private readonly Mock<IReadingProgressService> _progressService = new();
+    private readonly Mock<ISectionRepository>      _sectionRepo     = new();
+    private readonly Mock<ICommentRepository>      _commentRepo     = new();
+
+    private ReaderDashboardService CreateSut() => new(
+        _progressService.Object,
+        _sectionRepo.Object,
+        _commentRepo.Object);
+
+    // -----------------------------------------------------------------------
+    // GetCrossProjectResumeTargetAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ResumeTarget_EmptyProjects_ReturnsNull()
+    {
+        var result = await CreateSut().GetCrossProjectResumeTargetAsync(UserId, []);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ResumeTarget_NoReadEvents_ReturnsNull()
+    {
+        _progressService.Setup(s => s.GetLastReadEventAsync(UserId, ProjectId, default))
+            .ReturnsAsync((ReadEvent?)null);
+
+        var result = await CreateSut().GetCrossProjectResumeTargetAsync(UserId, [ProjectId]);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ResumeTarget_ReadEventOnScene_ReturnsChapterAndScene()
+    {
+        var chapter = Section.CreateFolder(ProjectId, "UUID-CH", "Chapter 1", null, 0);
+        chapter.MarkAsPublishedContainer();
+        var scene = Section.CreateDocument(ProjectId, "UUID-SC", "Scene 1",
+            chapter.Id, 0, "<p>x</p>", "h", null);
+        scene.PublishAsPartOfChapter("h");
+        var evt = ReadEvent.Create(scene.Id, UserId);
+
+        _progressService.Setup(s => s.GetLastReadEventAsync(UserId, ProjectId, default))
+            .ReturnsAsync(evt);
+        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+
+        var result = await CreateSut().GetCrossProjectResumeTargetAsync(UserId, [ProjectId]);
+
+        Assert.NotNull(result);
+        Assert.Equal(chapter.Id, result!.ChapterId);
+        Assert.Equal(scene.Id, result.SceneId);
+    }
+
+    [Fact]
+    public async Task ResumeTarget_ReadEventOnChapter_ReturnsChapterNoScene()
+    {
+        var chapter = Section.CreateFolder(ProjectId, "UUID-CH", "Chapter 1", null, 0);
+        chapter.MarkAsPublishedContainer();
+        var evt = ReadEvent.Create(chapter.Id, UserId);
+
+        _progressService.Setup(s => s.GetLastReadEventAsync(UserId, ProjectId, default))
+            .ReturnsAsync(evt);
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+
+        var result = await CreateSut().GetCrossProjectResumeTargetAsync(UserId, [ProjectId]);
+
+        Assert.NotNull(result);
+        Assert.Equal(chapter.Id, result!.ChapterId);
+        Assert.Null(result.SceneId);
+    }
+
+    [Fact]
+    public async Task ResumeTarget_MultipleProjects_ReturnsMostRecent()
+    {
+        var proj1 = Guid.NewGuid();
+        var proj2 = Guid.NewGuid();
+
+        var ch1 = Section.CreateFolder(proj1, "UUID-CH1", "Chapter A", null, 0);
+        ch1.MarkAsPublishedContainer();
+        var ch2 = Section.CreateFolder(proj2, "UUID-CH2", "Chapter B", null, 0);
+        ch2.MarkAsPublishedContainer();
+
+        var oldEvent    = ReadEvent.Create(ch1.Id, UserId);
+        await Task.Delay(5);
+        var recentEvent = ReadEvent.Create(ch2.Id, UserId);
+
+        _progressService.Setup(s => s.GetLastReadEventAsync(UserId, proj1, default)).ReturnsAsync(oldEvent);
+        _progressService.Setup(s => s.GetLastReadEventAsync(UserId, proj2, default)).ReturnsAsync(recentEvent);
+        _sectionRepo.Setup(r => r.GetByIdAsync(ch2.Id, default)).ReturnsAsync(ch2);
+
+        var result = await CreateSut().GetCrossProjectResumeTargetAsync(UserId, [proj1, proj2]);
+
+        Assert.NotNull(result);
+        Assert.Equal(ch2.Id, result!.ChapterId);
+    }
+
+    [Fact]
+    public async Task ResumeTarget_UnpublishedSection_ReturnsNull()
+    {
+        var chapter = Section.CreateFolder(ProjectId, "UUID-CH", "Chapter 1", null, 0);
+        // Not published
+        var evt = ReadEvent.Create(chapter.Id, UserId);
+
+        _progressService.Setup(s => s.GetLastReadEventAsync(UserId, ProjectId, default))
+            .ReturnsAsync(evt);
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+
+        var result = await CreateSut().GetCrossProjectResumeTargetAsync(UserId, [ProjectId]);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ResumeTarget_SceneWithUnpublishedParentChapter_ReturnsNull()
+    {
+        var chapter = Section.CreateFolder(ProjectId, "UUID-CH", "Chapter 1", null, 0);
+        // Not published
+        var scene = Section.CreateDocument(ProjectId, "UUID-SC", "Scene 1",
+            chapter.Id, 0, "<p>x</p>", "h", null);
+        scene.PublishAsPartOfChapter("h");
+        var evt = ReadEvent.Create(scene.Id, UserId);
+
+        _progressService.Setup(s => s.GetLastReadEventAsync(UserId, ProjectId, default))
+            .ReturnsAsync(evt);
+        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+
+        var result = await CreateSut().GetCrossProjectResumeTargetAsync(UserId, [ProjectId]);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ResumeTarget_SectionNotFound_ReturnsNull()
+    {
+        var sectionId = Guid.NewGuid();
+        var evt = ReadEvent.Create(sectionId, UserId);
+
+        _progressService.Setup(s => s.GetLastReadEventAsync(UserId, ProjectId, default))
+            .ReturnsAsync(evt);
+        _sectionRepo.Setup(r => r.GetByIdAsync(sectionId, default)).ReturnsAsync((Section?)null);
+
+        var result = await CreateSut().GetCrossProjectResumeTargetAsync(UserId, [ProjectId]);
+
+        Assert.Null(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetReaderChapterCommentCountsAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task CommentCounts_EmptyChapters_ReturnsEmptyDict()
+    {
+        var result = await CreateSut().GetReaderChapterCommentCountsAsync(UserId, []);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task CommentCounts_NoComments_ReturnsZeroPerChapter()
+    {
+        var chapterId = Guid.NewGuid();
+        _commentRepo.Setup(r => r.GetByAuthorIdAsync(UserId, default))
+            .ReturnsAsync([]);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([]);
+
+        var result = await CreateSut().GetReaderChapterCommentCountsAsync(UserId, [chapterId]);
+
+        Assert.Equal(0, result[chapterId]);
+    }
+
+    [Fact]
+    public async Task CommentCounts_RootCommentOnChapter_CountsOne()
+    {
+        var chapterId = Guid.NewGuid();
+        var comment = Comment.CreateRoot(chapterId, UserId, "Great!", Visibility.Public);
+
+        _commentRepo.Setup(r => r.GetByAuthorIdAsync(UserId, default))
+            .ReturnsAsync([comment]);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([]);
+
+        var result = await CreateSut().GetReaderChapterCommentCountsAsync(UserId, [chapterId]);
+
+        Assert.Equal(1, result[chapterId]);
+    }
+
+    [Fact]
+    public async Task CommentCounts_RootCommentOnScene_CountsTowardChapter()
+    {
+        var chapter = Section.CreateFolder(ProjectId, "UUID-CH", "Chapter 1", null, 0);
+        var scene   = Section.CreateDocument(ProjectId, "UUID-SC", "Scene 1", chapter.Id, 0, null, null, null);
+        var comment = Comment.CreateRoot(scene.Id, UserId, "Nice scene!", Visibility.Public);
+
+        _commentRepo.Setup(r => r.GetByAuthorIdAsync(UserId, default))
+            .ReturnsAsync([comment]);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapter.Id, default))
+            .ReturnsAsync([scene]);
+
+        var result = await CreateSut().GetReaderChapterCommentCountsAsync(UserId, [chapter.Id]);
+
+        Assert.Equal(1, result[chapter.Id]);
+    }
+
+    [Fact]
+    public async Task CommentCounts_Reply_NotCounted()
+    {
+        var chapterId     = Guid.NewGuid();
+        var root          = Comment.CreateRoot(chapterId, UserId, "Root", Visibility.Public);
+        var reply         = Comment.CreateReply(chapterId, UserId, root.Id,
+            Visibility.Public, "Reply text", Visibility.Public);
+
+        _commentRepo.Setup(r => r.GetByAuthorIdAsync(UserId, default))
+            .ReturnsAsync([root, reply]);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([]);
+
+        var result = await CreateSut().GetReaderChapterCommentCountsAsync(UserId, [chapterId]);
+
+        Assert.Equal(1, result[chapterId]);
+    }
+
+    [Fact]
+    public async Task CommentCounts_SoftDeletedComment_NotCounted()
+    {
+        var chapterId = Guid.NewGuid();
+        var comment   = Comment.CreateRoot(chapterId, UserId, "Deleted!", Visibility.Public);
+        comment.SoftDelete();
+
+        _commentRepo.Setup(r => r.GetByAuthorIdAsync(UserId, default))
+            .ReturnsAsync([comment]);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([]);
+
+        var result = await CreateSut().GetReaderChapterCommentCountsAsync(UserId, [chapterId]);
+
+        Assert.Equal(0, result[chapterId]);
+    }
+
+    [Fact]
+    public async Task CommentCounts_MultipleChapters_CorrectDistribution()
+    {
+        var ch1Id = Guid.NewGuid();
+        var ch2Id = Guid.NewGuid();
+        var c1a   = Comment.CreateRoot(ch1Id, UserId, "A", Visibility.Public);
+        var c1b   = Comment.CreateRoot(ch1Id, UserId, "B", Visibility.Public);
+        var c2    = Comment.CreateRoot(ch2Id, UserId, "C", Visibility.Public);
+
+        _commentRepo.Setup(r => r.GetByAuthorIdAsync(UserId, default))
+            .ReturnsAsync([c1a, c1b, c2]);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(ch1Id, default)).ReturnsAsync([]);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(ch2Id, default)).ReturnsAsync([]);
+
+        var result = await CreateSut().GetReaderChapterCommentCountsAsync(UserId, [ch1Id, ch2Id]);
+
+        Assert.Equal(2, result[ch1Id]);
+        Assert.Equal(1, result[ch2Id]);
+    }
+}

--- a/DraftView.Application/Services/ReaderDashboardService.cs
+++ b/DraftView.Application/Services/ReaderDashboardService.cs
@@ -1,0 +1,77 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Services;
+
+public class ReaderDashboardService(
+    IReadingProgressService progressService,
+    ISectionRepository sectionRepo,
+    ICommentRepository commentRepo) : IReaderDashboardService
+{
+    public async Task<ResumeTarget?> GetCrossProjectResumeTargetAsync(
+        Guid userId, IReadOnlyList<Guid> projectIds, CancellationToken ct = default)
+    {
+        if (projectIds.Count == 0)
+            return null;
+
+        ReadEvent? latest = null;
+        foreach (var projectId in projectIds)
+        {
+            var ev = await progressService.GetLastReadEventAsync(userId, projectId, ct);
+            if (ev is not null && (latest is null || ev.LastOpenedAt > latest.LastOpenedAt))
+                latest = ev;
+        }
+
+        if (latest is null)
+            return null;
+
+        var section = await sectionRepo.GetByIdAsync(latest.SectionId, ct);
+        if (section is null || !section.IsPublished)
+            return null;
+
+        if (section.NodeType == NodeType.Document && section.ParentId.HasValue)
+        {
+            var parent = await sectionRepo.GetByIdAsync(section.ParentId.Value, ct);
+            if (parent is null || !parent.IsPublished)
+                return null;
+            return new ResumeTarget(parent.Id, section.Id);
+        }
+
+        if (section.NodeType == NodeType.Folder)
+            return new ResumeTarget(section.Id, null);
+
+        return null;
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, int>> GetReaderChapterCommentCountsAsync(
+        Guid userId, IReadOnlyList<Guid> chapterIds, CancellationToken ct = default)
+    {
+        if (chapterIds.Count == 0)
+            return new Dictionary<Guid, int>();
+
+        var allComments = await commentRepo.GetByAuthorIdAsync(userId, ct);
+        var rootComments = allComments
+            .Where(c => c.ParentCommentId == null && !c.IsSoftDeleted)
+            .ToList();
+
+        var result = new Dictionary<Guid, int>();
+
+        foreach (var chapterId in chapterIds)
+        {
+            if (result.ContainsKey(chapterId))
+                continue;
+
+            var count = rootComments.Count(c => c.SectionId == chapterId);
+
+            var descendants = await sectionRepo.GetAllDescendantsAsync(chapterId, ct);
+            var descendantIds = descendants.Select(s => s.Id).ToHashSet();
+            count += rootComments.Count(c => descendantIds.Contains(c.SectionId));
+
+            result[chapterId] = count;
+        }
+
+        return result;
+    }
+}

--- a/DraftView.Domain/Interfaces/Services/IReaderDashboardService.cs
+++ b/DraftView.Domain/Interfaces/Services/IReaderDashboardService.cs
@@ -1,0 +1,23 @@
+namespace DraftView.Domain.Interfaces.Services;
+
+public record ResumeTarget(Guid ChapterId, Guid? SceneId);
+
+public interface IReaderDashboardService
+{
+    /// <summary>
+    /// Returns the most-recently-opened section across the given projects,
+    /// resolved to a (chapter, optional scene) target. Returns null when
+    /// the user has no read history across these projects, or the last-read
+    /// section is no longer published.
+    /// </summary>
+    Task<ResumeTarget?> GetCrossProjectResumeTargetAsync(
+        Guid userId, IReadOnlyList<Guid> projectIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the number of root comments (not replies, not soft-deleted)
+    /// the reader has placed on or within each chapter (chapter + its scenes).
+    /// Every requested chapterId appears as a key; zero when no comments found.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, int>> GetReaderChapterCommentCountsAsync(
+        Guid userId, IReadOnlyList<Guid> chapterIds, CancellationToken ct = default);
+}

--- a/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
@@ -43,6 +43,7 @@ public class ReaderControllerTests
     private readonly Mock<IHumanOverrideService> humanOverrideService = new();
     private readonly Mock<IPassageAnchorService> passageAnchorService = new();
     private readonly Mock<IAccessRequestRepository> accessRequestRepo = new();
+    private readonly Mock<IReaderDashboardService> readerDashboardService = new();
     private readonly Mock<ILogger<ReaderController>> logger = new();
 
     [Fact]
@@ -871,6 +872,7 @@ public class ReaderControllerTests
             humanOverrideService.Object,
             passageAnchorService.Object,
             accessRequestRepo.Object,
+            readerDashboardService.Object,
             logger.Object);
 
         controller.ControllerContext = new ControllerContext

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -27,12 +27,14 @@ public class ReaderController(
     IHumanOverrideService humanOverrideService,
     IPassageAnchorService passageAnchorService,
     IAccessRequestRepository accessRequestRepo,
+    IReaderDashboardService readerDashboardService,
     ILogger<ReaderController> logger)
     : BaseReaderController(projectRepo, sectionRepo, commentService, progressService,
                            userRepository, readerAccessRepo, humanOverrideService, passageAnchorService, logger)
 {
     private readonly IUserPreferencesRepository _userPreferencesRepo = userPreferencesRepo;
     private readonly IPassageAnchorService _passageAnchorService = passageAnchorService;
+    private readonly IReaderDashboardService _readerDashboardService = readerDashboardService;
     private static readonly Regex HtmlTagRegex = new("<[^>]+>", RegexOptions.Compiled);
     private static readonly Regex WhitespaceRegex = new("\\s+", RegexOptions.Compiled);
 
@@ -355,34 +357,6 @@ public class ReaderController(
                 .Select(a => a.ProjectId)
                 .ToList();
 
-        // Kindle-style resume — redirect to last read position across all projects
-        ReadEvent? resume = null;
-        foreach (var pid in projectIds)
-        {
-            var ev = await ProgressService.GetLastReadEventAsync(user.Id, pid);
-            if (ev is not null && (resume is null || ev.LastOpenedAt > resume.LastOpenedAt))
-                resume = ev;
-        }
-        if (resume is not null)
-        {
-            var resumeSection = await SectionRepo.GetByIdAsync(resume.SectionId);
-            if (resumeSection is not null && resumeSection.IsPublished)
-            {
-                // Scene (Document) — redirect to parent chapter
-                if (resumeSection.NodeType == NodeType.Document && resumeSection.ParentId.HasValue)
-                {
-                    var parentChapter = await SectionRepo.GetByIdAsync(resumeSection.ParentId.Value);
-                    if (parentChapter is not null && parentChapter.IsPublished)
-                        return Redirect(Url.Action("Read", new { id = parentChapter.Id }) + "#scene-" + resumeSection.Id);
-                }
-                // Chapter (Folder) — redirect directly
-                else if (resumeSection.NodeType == NodeType.Folder)
-                {
-                    return RedirectToAction("Read", new { id = resumeSection.Id });
-                }
-            }
-        }
-
         var visibleRequests = await accessRequestRepo.GetVisibleByReaderIdAsync(user.Id, DateTime.UtcNow.Date);
         var requestRows = new List<ReaderDashboardRequestViewModel>();
         foreach (var req in visibleRequests)
@@ -434,6 +408,25 @@ public class ReaderController(
                 ReadChapters      = chaptersWithProgress.Count(c => c.HasRead),
                 PublishedChapters = chaptersWithProgress
             });
+        }
+
+        // Populate comment counts via application service
+        var allChapterIds = viewModel.Projects
+            .SelectMany(p => p.PublishedChapters.Select(c => c.Chapter.Id))
+            .ToList();
+        var commentCounts = await _readerDashboardService.GetReaderChapterCommentCountsAsync(user.Id, allChapterIds);
+        foreach (var proj in viewModel.Projects)
+            foreach (var ch in proj.PublishedChapters)
+                if (commentCounts.TryGetValue(ch.Chapter.Id, out var count))
+                    ch.ReaderCommentCount = count;
+
+        // Resolve resume target via application service
+        var resumeTarget = await _readerDashboardService.GetCrossProjectResumeTargetAsync(user.Id, projectIds);
+        if (resumeTarget is not null)
+        {
+            viewModel.ContinueReadingUrl = resumeTarget.SceneId.HasValue
+                ? Url.Action("Read", new { id = resumeTarget.ChapterId }) + "#scene-" + resumeTarget.SceneId
+                : Url.Action("Read", new { id = resumeTarget.ChapterId });
         }
 
         return View("DesktopDashboard", viewModel);

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -109,6 +109,7 @@ namespace DraftView.Web.Extensions
             services.AddScoped<IChangeClassificationService, ChangeClassificationService>();
             services.AddScoped<IHtmlDiffService, HtmlDiffService>();
             services.AddScoped<ISectionDiffService, SectionDiffService>();
+            services.AddScoped<IReaderDashboardService, ReaderDashboardService>();
 
             return services;
         }

--- a/DraftView.Web/Models/ReaderViewModels.cs
+++ b/DraftView.Web/Models/ReaderViewModels.cs
@@ -147,12 +147,14 @@ public class DesktopDashboardViewModel
     public int TotalReadChapters => Projects.Sum(p => p.ReadChapters);
     public int TotalChapters => Projects.Sum(p => p.TotalChapters);
     public IReadOnlyList<ReaderDashboardRequestViewModel> AccessRequests { get; init; } = [];
+    public string? ContinueReadingUrl { get; set; }
 }
 
 public class DesktopChapterProgressViewModel
 {
     public Section Chapter { get; set; } = default!;
     public bool HasRead { get; set; }
+    public int ReaderCommentCount { get; set; }
 }
 
 public enum DiscoveryRequestStatus { None, Pending, Approved, Declined }

--- a/DraftView.Web/Views/Reader/DesktopDashboard.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopDashboard.cshtml
@@ -20,6 +20,10 @@
                 @:No manuscript available yet
             }
         </div>
+        @if (Model.ContinueReadingUrl is not null)
+        {
+            <a href="@Model.ContinueReadingUrl" class="reader-dashboard__continue-btn">Continue reading</a>
+        }
     </div>
 </div>
 
@@ -104,6 +108,7 @@ else
                                     <thead>
                                         <tr class="reader-dashboard__row">
                                             <th class="reader-dashboard__head">Chapter</th>
+                                            <th class="reader-dashboard__head reader-dashboard__head--comments">Comments</th>
                                             <th class="reader-dashboard__head">Status</th>
                                         </tr>
                                     </thead>
@@ -117,6 +122,16 @@ else
                                                        class="reader-dashboard__chapter-link">
                                                         @item.Chapter.Title
                                                     </a>
+                                                </td>
+                                                <td class="reader-dashboard__cell reader-dashboard__cell--comments">
+                                                    @if (item.ReaderCommentCount > 0)
+                                                    {
+                                                        <span class="reader-dashboard__comment-count">@item.ReaderCommentCount</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="reader-dashboard__comment-none">—</span>
+                                                    }
                                                 </td>
                                                 <td class="reader-dashboard__cell reader-dashboard__cell--status">
                                                     @if (item.HasRead)

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-16-5";
+    --css-version: "v2026-08-17-1";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;

--- a/DraftView.Web/wwwroot/css/DraftView.DesktopReader.css
+++ b/DraftView.Web/wwwroot/css/DraftView.DesktopReader.css
@@ -1050,5 +1050,51 @@
     transition: width 0.3s;
 }
 
+/* Continue Reading CTA inside the hero */
+.reader-dashboard__continue-btn {
+    display: inline-block;
+    margin-top: var(--space-5);
+    padding: var(--space-3) var(--space-6);
+    background: var(--color-accent);
+    color: #fff;
+    border-radius: var(--radius);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    text-decoration: none;
+    transition: opacity var(--transition);
+}
+
+.reader-dashboard__continue-btn:hover {
+    opacity: 0.88;
+    text-decoration: none;
+}
+
+/* Comments column */
+.reader-dashboard__head--comments {
+    width: 90px;
+    text-align: center;
+}
+
+.reader-dashboard__cell--comments {
+    text-align: center;
+}
+
+.reader-dashboard__comment-count {
+    display: inline-block;
+    min-width: 24px;
+    padding: 2px var(--space-2);
+    background: var(--color-accent);
+    color: #fff;
+    border-radius: 999px;
+    font-size: var(--text-xs);
+    font-weight: var(--font-bold);
+    text-align: center;
+}
+
+.reader-dashboard__comment-none {
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+}
+
 
 


### PR DESCRIPTION
## Summary

- Replace the auto-redirect behaviour on the Reader Dashboard with a "Continue reading" CTA button shown in the hero, computed from the reader's most-recent read event across all their projects.
- Add a **Comments** column to the chapter table showing the number of root comments (not replies, not soft-deleted) the reader has raised on each chapter, including scene-level and passage-anchor comments.

## What changed

### Application layer (new `IReaderDashboardService`)

- `GetCrossProjectResumeTargetAsync(userId, projectIds)` — finds the most-recently-opened section across all accessible projects and resolves it to a `(ChapterId, SceneId?)` target. Returns null when there is no read history or the section is no longer published.
- `GetReaderChapterCommentCountsAsync(userId, chapterIds)` — fetches the reader's root comments via `ICommentRepository.GetByAuthorIdAsync`, filters out replies and soft-deleted comments, then counts per chapter including all descendant scene sections.
- 15 new unit tests (all GREEN); full suite: 354 Domain + 341 Application + 145 Infrastructure all pass.

### Web layer

- `ReaderController.DesktopDashboard`: auto-redirect block removed; calls `IReaderDashboardService` for resume target and chapter comment counts; maps results to `DesktopDashboardViewModel`.
- `DesktopDashboardViewModel`: new `ContinueReadingUrl` property.
- `DesktopChapterProgressViewModel`: new `ReaderCommentCount` property.
- `DesktopDashboard.cshtml`: "Continue reading" anchor button in hero (conditional on URL); Comments column with badge or `—` in chapter table.

### CSS

- `DraftView.DesktopReader.css`: styles for `.reader-dashboard__continue-btn`, `.reader-dashboard__comment-count`, `.reader-dashboard__comment-none`.
- `DraftView.Core.css`: version bumped to `v2026-08-17-1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNeLikmpYakkmNzhxM93MH)_