### PR TITLE
Record production deployment in TASKS.md after each publish

### DIFF
--- a/publish-draftview.ps1
+++ b/publish-draftview.ps1
@@ -74,4 +74,42 @@ if ($LASTEXITCODE -ne 0) { Write-Host "Restart failed." -ForegroundColor Red; ex
 Write-Host "Verifying service is running..." -ForegroundColor Cyan
 Start-Sleep -Seconds 3
 ssh -i $key $server "sudo systemctl is-active draftview"
+if ($LASTEXITCODE -ne 0) { Write-Host "Service did not start cleanly." -ForegroundColor Red; exit 1 }
+
+# ---------------------------------------------------------------------------
+# Record deployment in TASKS.md and commit to main
+# ---------------------------------------------------------------------------
+Write-Host "Recording deployment in TASKS.md..." -ForegroundColor Cyan
+$repoRoot    = "C:\Users\alast\source\repos\DraftView"
+$tasksPath   = "$repoRoot\TASKS.md"
+$deployDate  = Get-Date -Format "yyyy-MM-dd"
+$commitHash  = git rev-parse --short HEAD
+$deployEntry = "Last deployed: $deployDate (commit: $commitHash)"
+
+$tasks = Get-Content $tasksPath -Raw
+if ($tasks -match 'Last deployed:') {
+    $tasks = $tasks -replace 'Last deployed:[^\r\n]*', $deployEntry
+} else {
+    $replacement = '$1' + "`r`n" + $deployEntry
+    $tasks = $tasks -replace '(Last updated:[^\r\n]*)', $replacement
+}
+
+if ($tasks -notmatch [regex]::Escape($deployEntry)) {
+    Write-Host "WARNING: TASKS.md was not updated — check the script." -ForegroundColor Yellow
+} else {
+    [System.IO.File]::WriteAllText($tasksPath, $tasks)
+    git add TASKS.md
+    git commit -m "chore: record production deployment $deployDate"
+    if ($LASTEXITCODE -eq 0) {
+        git push origin main
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "WARNING: Push failed — commit is local, push manually." -ForegroundColor Yellow
+        } else {
+            Write-Host "Deployment recorded in TASKS.md." -ForegroundColor Green
+        }
+    } else {
+        Write-Host "WARNING: Commit failed." -ForegroundColor Yellow
+    }
+}
+
 Write-Host "Done." -ForegroundColor Green


### PR DESCRIPTION
## Summary

Adds deployment tracking to `publish-draftview.ps1`. After the service verification step confirms the production service is running, the script now:

1. Updates `TASKS.md` with a `Last deployed: YYYY-MM-DD (commit: <hash>)` line near the top (inserted after `Last updated:` on first run; replaced in place on subsequent runs)
2. Commits the change to `main` as `chore: record production deployment <date>`
3. Pushes to `main`

Warnings (non-fatal) are printed if the TASKS.md update or git operations fail, so a commit/push hiccup does not mask a successful deployment.

The service verification block now also exits with code 1 if `systemctl is-active` fails, so the recording step is only reached when the deployment is confirmed healthy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J41wGKU7w7iVxrVGj9P46A)_