### PR TITLE
CHANGE-011: Themed reset-password page, display name, fix double-submit

### DIFF
--- a/DraftView.Web/Controllers/AccountController.cs
+++ b/DraftView.Web/Controllers/AccountController.cs
@@ -304,7 +304,19 @@ public class AccountController(
         if (resetToken is null || !resetToken.IsValid())
             return RedirectToAction("ResetPasswordInvalid");
 
-        return View(new ResetPasswordViewModel { Token = token });
+        var user = await GetUserByIdAsync(resetToken.UserId);
+        if (user is not null)
+        {
+            var prefs = await prefsRepo.GetByUserIdAsync(user.Id);
+            if (prefs is not null)
+                ViewData["OverrideTheme"] = prefs.DisplayTheme.ToString();
+        }
+
+        return View(new ResetPasswordViewModel
+        {
+            Token = token,
+            DisplayName = user?.DisplayName ?? string.Empty
+        });
     }
 
     [HttpPost]

--- a/DraftView.Web/Models/AccountViewModels.cs
+++ b/DraftView.Web/Models/AccountViewModels.cs
@@ -129,6 +129,7 @@ public class ChangePasswordViewModel
 public class ResetPasswordViewModel
 {
     public string Token { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
 
     [System.ComponentModel.DataAnnotations.Required(ErrorMessage = "Please choose a password.")]
     [System.ComponentModel.DataAnnotations.StringLength(100, MinimumLength = 8,

--- a/DraftView.Web/Views/Account/ForgotPassword.cshtml
+++ b/DraftView.Web/Views/Account/ForgotPassword.cshtml
@@ -8,7 +8,8 @@
     </div>
     <div class="card">
         <div class="card__body">
-            <form asp-action="ForgotPassword" method="post">
+            <form asp-action="ForgotPassword" method="post"
+                  onsubmit="this.querySelector('[type=submit]').disabled=true;">
                 @Html.AntiForgeryToken()
                 <div asp-validation-summary="All" class="alert alert--error"
                      style="margin-bottom:var(--space-5);"></div>

--- a/DraftView.Web/Views/Account/ResetPassword.cshtml
+++ b/DraftView.Web/Views/Account/ResetPassword.cshtml
@@ -1,12 +1,34 @@
 @model ResetPasswordViewModel
 @{ ViewData["Title"] = "Choose a new password"; }
-<div class="login-wrap">
-    <div class="login-header">
-        <h1>Choose a new password</h1>
+
+<div class="site-hero">
+    <div class="site-hero__content">
+        <img src="~/images/DraftView.Logo.web.png"
+             alt="DraftView"
+             style="height:64px; width:auto; display:block; margin:0 auto var(--space-4);" />
+        <div class="site-hero__title">DraftView</div>
+        <div class="site-hero__subtitle">
+            @if (!string.IsNullOrEmpty(Model.DisplayName))
+            {
+                @($"Setting a new password for {Model.DisplayName}")
+            }
+            else
+            {
+                @("Beta reading, beautifully done")
+            }
+        </div>
     </div>
+</div>
+
+<div style="max-width:420px; margin:var(--space-10) auto var(--space-16);">
     <div class="card">
         <div class="card__body">
-            <form asp-action="ResetPassword" method="post">
+            <h2 style="font-size:var(--text-xl); font-weight:var(--font-bold);
+                       margin-bottom:var(--space-6); text-align:center;">
+                Choose a new password
+            </h2>
+            <form asp-action="ResetPassword" method="post"
+                  onsubmit="this.querySelector('[type=submit]').disabled=true;">
                 @Html.AntiForgeryToken()
                 <input type="hidden" asp-for="Token" />
                 <div asp-validation-summary="All" class="alert alert--error"

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -48,6 +48,10 @@ All css files are included here to ensure consistent styling across the site.
             proseFontSize = prefs.ProseFontSize.ToString();
         }
     }
+    else if (ViewData["OverrideTheme"] is string overrideTheme && !string.IsNullOrEmpty(overrideTheme))
+    {
+        theme = overrideTheme;
+    }
 
     var themeCss = theme switch {
         "Dark"              => "/css/DraftView.Dark.css",
@@ -76,16 +80,16 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-17-2" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-17-2" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-17-2" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-17-2" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-17-2" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-17-2" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-17-2" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-17-2" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-17-2" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-17-2" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-17-3" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -93,7 +97,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-17-2" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-17-3" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-17-2";
+    --css-version: "v2026-08-17-3";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
## Summary

- **Reset password page** now renders in the user's chosen theme — the atmosphere hero image, colour palette, and typography all match their profile preferences, resolved from the reset token before they log in
- **Display name in hero subtitle** — "Setting a new password for Alastair" confirms the right account without exposing the stored email address
- **Double-submit fix** — both ForgotPassword and ResetPassword forms disable the submit button on first click, preventing duplicate reset emails

## How it works

The `ResetPassword` GET action resolves `userId` from the token, looks up `UserPreferences`, and sets `ViewData["OverrideTheme"]`. The layout checks this when the user is unauthenticated and uses it instead of defaulting to Light. No new infrastructure — just wiring existing theme and prefs lookups into the unauthenticated flow.

## Test plan

- [ ] Request a password reset → confirm only one email arrives
- [ ] Open the reset link → page shows in the correct theme for that user
- [ ] Hero subtitle shows "Setting a new password for [display name]"
- [ ] Complete the reset → redirects to confirmation, then sign-in works
- [ ] Click Reset password twice quickly → button disables, only one request sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)