### PR TITLE
CHANGE-012: Fix reader dashboard hero image

### DIFF
--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,16 +80,16 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-17-3" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-17-3" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-17-3" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-17-3" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-17-3" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-17-3" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-17-3" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-17-3" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-17-3" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-17-3" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-17-4" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -97,7 +97,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-17-3" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-17-4" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-17-3";
+    --css-version: "v2026-08-17-4";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;

--- a/DraftView.Web/wwwroot/css/DraftView.DesktopReader.css
+++ b/DraftView.Web/wwwroot/css/DraftView.DesktopReader.css
@@ -850,6 +850,7 @@
 .reader-dashboard__hero {
     min-height: 200px;
     margin-bottom: var(--space-8);
+    background-image: url('/images/DraftViewReaderDash.Hero.png');
 }
 
 .reader-dashboard__empty-body {


### PR DESCRIPTION
## Summary

- `.reader-dashboard__hero` was inheriting `--atmosphere-image` from `.site-hero`, showing the general theme landscape instead of the purpose-built reader dashboard image
- Now explicitly sets `background-image: url('/images/DraftViewReaderDash.Hero.png')`, using the dedicated image added for this page

🤖 Generated with [Claude Code](https://claude.com/claude-code)