### PR TITLE
fix: Reader Dashboard no longer auto-redirects to scene on mobile

### DIFF
--- a/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
@@ -856,6 +856,71 @@ public class ReaderControllerTests
         Assert.Contains("#scene-", redirect.Url);
     }
 
+    [Fact]
+    public async Task Dashboard_Mobile_WithReadHistory_ShowsMobileChaptersNotScene()
+    {
+        var authorId = Guid.NewGuid();
+        var user = User.Create("reader@example.test", "Reader", Role.BetaReader);
+        user.Activate();
+        var sut = CreateSut(user, userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)");
+
+        var project = Project.Create("Test Book", "/Apps/Scrivener/Test", authorId, "project-root");
+        project.ActivateForReaders();
+
+        var chapter = Section.CreateFolder(project.Id, "chapter-uuid", "Chapter 1", null, 1);
+        chapter.MarkAsPublishedContainer();
+
+        var scene = Section.CreateDocument(project.Id, "scene-uuid", "Scene 1", chapter.Id, 1, "<p>Hello</p>", "scene-hash", "Draft");
+        scene.PublishAsPartOfChapter("scene-hash");
+
+        var readEvent = ReadEvent.Create(scene.Id, user.Id);
+        var access = ReaderAccess.Grant(user.Id, authorId, project.Id);
+
+        userRepo.Setup(r => r.GetByEmailAsync(user.Email, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        readerAccessRepo.Setup(r => r.GetByReaderIdAsync(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync([access]);
+        projectRepo.Setup(r => r.GetByIdAsync(project.Id, It.IsAny<CancellationToken>())).ReturnsAsync(project);
+        sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, It.IsAny<CancellationToken>())).ReturnsAsync([chapter, scene]);
+        progressService.Setup(r => r.GetLastReadEventAsync(user.Id, project.Id, It.IsAny<CancellationToken>())).ReturnsAsync(readEvent);
+        progressService.Setup(r => r.HasReadSectionAsync(user.Id, chapter.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var result = await sut.Dashboard();
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Equal("MobileChapters", view.ViewName);
+    }
+
+    [Fact]
+    public async Task Dashboard_Mobile_NoReadHistory_ShowsMobileChapters()
+    {
+        var authorId = Guid.NewGuid();
+        var user = User.Create("reader@example.test", "Reader", Role.BetaReader);
+        user.Activate();
+        var sut = CreateSut(user, userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)");
+
+        var project = Project.Create("Test Book", "/Apps/Scrivener/Test", authorId, "project-root");
+        project.ActivateForReaders();
+
+        var chapter = Section.CreateFolder(project.Id, "chapter-uuid", "Chapter 1", null, 1);
+        chapter.MarkAsPublishedContainer();
+
+        var scene = Section.CreateDocument(project.Id, "scene-uuid", "Scene 1", chapter.Id, 1, "<p>Hello</p>", "scene-hash", "Draft");
+        scene.PublishAsPartOfChapter("scene-hash");
+
+        var access = ReaderAccess.Grant(user.Id, authorId, project.Id);
+
+        userRepo.Setup(r => r.GetByEmailAsync(user.Email, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        readerAccessRepo.Setup(r => r.GetByReaderIdAsync(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync([access]);
+        projectRepo.Setup(r => r.GetByIdAsync(project.Id, It.IsAny<CancellationToken>())).ReturnsAsync(project);
+        sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, It.IsAny<CancellationToken>())).ReturnsAsync([chapter, scene]);
+        progressService.Setup(r => r.GetLastReadEventAsync(user.Id, project.Id, It.IsAny<CancellationToken>())).ReturnsAsync((ReadEvent?)null);
+        progressService.Setup(r => r.HasReadSectionAsync(user.Id, chapter.Id, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var result = await sut.Dashboard();
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Equal("MobileChapters", view.ViewName);
+    }
+
     private ReaderController CreateSut(User user, string userAgent)
     {
         var controller = new ReaderController(

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -443,48 +443,65 @@ public class ReaderController(
                 .Select(a => a.ProjectId)
                 .ToList();
 
-        // Kindle-style resume — redirect to last read position across all projects
-        ReadEvent? resume = null;
-        foreach (var pid in projectIds)
-        {
-            var ev = await ProgressService.GetLastReadEventAsync(user.Id, pid);
-            if (ev is not null && (resume is null || ev.LastOpenedAt > resume.LastOpenedAt))
-                resume = ev;
-        }
-        if (resume is not null)
-        {
-            var resumeSection = await SectionRepo.GetByIdAsync(resume.SectionId);
-            if (resumeSection is not null && resumeSection.IsPublished)
-            {
-                // Scene (Document) â€” mobile reads the scene directly
-                if (resumeSection.NodeType == NodeType.Document)
-                {
-                    return RedirectToAction("Read", new
-                    {
-                        id = resumeSection.Id
-                    });
-                }
-
-                // Chapter (Folder) â€” mobile should go to the scene list, not Read(chapterId)
-                if (resumeSection.NodeType == NodeType.Folder)
-                {
-                    return RedirectToAction("Scenes", new
-                    {
-                        chapterId = resumeSection.Id
-                    });
-                }
-            }
-        }
-
         var projectId = projectIds.FirstOrDefault();
         if (projectId == Guid.Empty)
-            return View("NoActiveProject");
+            return View(“NoActiveProject”);
 
         var project = await ProjectRepo.GetByIdAsync(projectId);
         if (project is null || !project.IsReaderActive || project.IsSoftDeleted)
-            return View("NoActiveProject");
+            return View(“NoActiveProject”);
 
-        return RedirectToAction("Chapters", new { projectId = project.Id });
+        var allSections = await SectionRepo.GetByProjectIdAsync(project.Id);
+
+        var folderChildIds = allSections
+            .Where(s => s.NodeType == NodeType.Folder && s.ParentId.HasValue)
+            .Select(s => s.ParentId!.Value)
+            .ToHashSet();
+
+        var sortOrderById = allSections.ToDictionary(s => s.Id, s => s.SortOrder);
+
+        var publishedChapters = allSections
+            .Where(s => s.NodeType == NodeType.Folder && s.IsPublished && !s.IsSoftDeleted
+                        && !folderChildIds.Contains(s.Id))
+            .OrderBy(s => s.ParentId.HasValue ? sortOrderById.GetValueOrDefault(s.ParentId.Value) : 0)
+            .ThenBy(s => s.SortOrder)
+            .ToList();
+
+        var chapterRows = new List<MobileChapterRowViewModel>();
+        foreach (var chapter in publishedChapters)
+        {
+            var hasRead    = await ProgressService.HasReadSectionAsync(user.Id, chapter.Id);
+            var sceneCount = allSections.Count(s => s.ParentId == chapter.Id
+                                                    && s.NodeType == NodeType.Document
+                                                    && s.IsPublished && !s.IsSoftDeleted);
+            chapterRows.Add(new MobileChapterRowViewModel {
+                Chapter    = chapter,
+                HasRead    = hasRead,
+                SceneCount = sceneCount
+            });
+        }
+
+        Guid? lastReadSceneId   = null;
+        Guid? lastReadChapterId = null;
+
+        var lastReadEvent = await ProgressService.GetLastReadEventAsync(user.Id, project.Id);
+        if (lastReadEvent is not null)
+        {
+            var lastSection = allSections.FirstOrDefault(s => s.Id == lastReadEvent.SectionId);
+            if (lastSection?.NodeType == NodeType.Document)
+            {
+                lastReadSceneId   = lastSection.Id;
+                lastReadChapterId = lastSection.ParentId;
+            }
+        }
+
+        return View(“MobileChapters”, new MobileChaptersViewModel {
+            ProjectName       = project.Name,
+            ProjectId         = project.Id,
+            Chapters          = chapterRows,
+            LastReadSceneId   = lastReadSceneId,
+            LastReadChapterId = lastReadChapterId
+        });
     }
 
     private async Task<IActionResult> DesktopRead(Guid id, Domain.Entities.User user)


### PR DESCRIPTION
## What

`MobileDashboard` was doing a Kindle-style resume redirect: when a reader had any read history, visiting `/Reader/Dashboard` immediately redirected them to the last-read scene, bypassing the dashboard entirely.

Readers now always see the chapter list (`MobileChapters` view) with a **Continue Reading** CTA button at the top when they have a read position — no automatic redirect.

Login already sends readers to `/Reader/Dashboard` (unchanged). The dashboard is now a stable landing page.

## Changes

- **`ReaderController.cs`** — `MobileDashboard` now builds the chapter list inline and renders `MobileChapters` directly (same logic as the `Chapters` action). The Kindle-style redirect block is removed.
- **`ReaderControllerTests.cs`** — two new tests:
  - `Dashboard_Mobile_WithReadHistory_ShowsMobileChaptersNotScene`
  - `Dashboard_Mobile_NoReadHistory_ShowsMobileChapters`

## Out of scope

The profile flag ("Jump to reading position on login: Yes/No") discussed alongside this fix is a follow-on feature, not included here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J41wGKU7w7iVxrVGj9P46A)_