### PR TITLE
CHANGE-014: Semantic versioning Version ##.## — Polish/Revision/Rewrite

### DIFF
--- a/DraftView.Application.Tests/Services/CommentServiceTests.cs
+++ b/DraftView.Application.Tests/Services/CommentServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using DraftView.Domain.Contracts;
+using DraftView.Domain.Contracts;
 using Moq;
 using DraftView.Application.Services;
 using DraftView.Domain.Entities;
@@ -396,7 +396,7 @@ public class CommentServiceTests
         reader.Activate();
         var sut = CreateSut();
 
-        var version = SectionVersion.Create(section, Guid.NewGuid(), 1);
+        var version = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
         var versionRepo = new Mock<ISectionVersionRepository>();
         versionRepo.Setup(r => r.GetLatestAsync(section.Id, default))
             .ReturnsAsync(version);

--- a/DraftView.Application.Tests/Services/HumanOverrideServiceTests.cs
+++ b/DraftView.Application.Tests/Services/HumanOverrideServiceTests.cs
@@ -42,7 +42,7 @@ public class HumanOverrideServiceTests
         var owner = MakeUser("owner@example.test", "Owner", Role.BetaReader);
         var project = Project.Create("Project", "/tmp/project", author.Id, "root");
         var section = MakePublishedSection(project.Id);
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = CreateAnchor(section, version, author.Id);
         var comment = Comment.CreateRoot(
             section.Id,
@@ -66,7 +66,7 @@ public class HumanOverrideServiceTests
         var otherUser = MakeUser("reader@example.test", "Reader", Role.BetaReader);
         var project = Project.Create("Project", "/tmp/project", author.Id, "root");
         var section = MakePublishedSection(project.Id);
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = CreateAnchor(section, version, otherUser.Id);
         var comment = Comment.CreateRoot(
             section.Id,
@@ -90,7 +90,7 @@ public class HumanOverrideServiceTests
         var otherUser = MakeUser("reader@example.test", "Reader", Role.BetaReader);
         var project = Project.Create("Project", "/tmp/project", author.Id, "root");
         var section = MakePublishedSection(project.Id);
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = CreateAnchor(section, version, author.Id);
         var comment = Comment.CreateRoot(
             section.Id,
@@ -115,7 +115,7 @@ public class HumanOverrideServiceTests
         var support = MakeUser("support@example.test", "Support", Role.SystemSupport);
         var project = Project.Create("Project", "/tmp/project", author.Id, "root");
         var section = MakePublishedSection(project.Id);
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = CreateAnchor(section, version, author.Id);
         var sut = CreateSut();
 
@@ -133,7 +133,7 @@ public class HumanOverrideServiceTests
         var owner = MakeUser("owner@example.test", "Owner", Role.BetaReader);
         var project = Project.Create("Project", "/tmp/project", author.Id, "root");
         var section = MakePublishedSection(project.Id);
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = CreateAnchor(section, version, owner.Id);
         anchor.UpdateCurrentMatch(CreateMatch(version.Id));
         var comment = Comment.CreateRoot(
@@ -167,7 +167,7 @@ public class HumanOverrideServiceTests
         var owner = MakeUser("owner@example.test", "Owner", Role.BetaReader);
         var project = Project.Create("Project", "/tmp/project", author.Id, "root");
         var section = MakePublishedSection(project.Id);
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = CreateAnchor(section, version, owner.Id);
         var comment = Comment.CreateRoot(
             section.Id,

--- a/DraftView.Application.Tests/Services/ImportServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ImportServiceTests.cs
@@ -34,7 +34,7 @@ public class ImportServiceTests
     {
         var section = Section.CreateDocumentForUpload(Guid.NewGuid(), "Scene 1", null, 1);
         section.UpdateContent("<p>Published</p>", "hash");
-        return SectionVersion.Create(section, Guid.NewGuid(), 1);
+        return SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
     }
 
     /// <summary>Import should write converted HTML into the section.</summary>

--- a/DraftView.Application.Tests/Services/PassageAnchorServiceTests.cs
+++ b/DraftView.Application.Tests/Services/PassageAnchorServiceTests.cs
@@ -41,7 +41,7 @@ public class PassageAnchorServiceTests
     {
         var reader = MakeReader();
         var section = MakePublishedSection();
-        var version = SectionVersion.Create(section, Guid.NewGuid(), 1);
+        var version = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
         var request = CreateRequest(section.Id, version.Id, "Alpha beta");
         var sut = CreateSut();
 
@@ -72,7 +72,7 @@ public class PassageAnchorServiceTests
     {
         var reader = MakeReader();
         var section = MakePublishedSection();
-        var version = SectionVersion.Create(section, Guid.NewGuid(), 1);
+        var version = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
         var request = CreateRequest(section.Id, version.Id, "Wrong text");
         var sut = CreateSut();
 
@@ -91,7 +91,7 @@ public class PassageAnchorServiceTests
     {
         var reader = MakeReader();
         var section = MakePublishedSection();
-        var version = SectionVersion.Create(section, Guid.NewGuid(), 1);
+        var version = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
         var request = CreateRequest(section.Id, version.Id, "Alpha beta");
         var sut = CreateSut();
 
@@ -122,7 +122,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, Guid.NewGuid(), 1);
+        var version = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
         var request = CreateRequest(section.Id, version.Id, "Alpha beta");
         var sut = CreateSut();
 
@@ -143,7 +143,7 @@ public class PassageAnchorServiceTests
     {
         var reader = MakeReader();
         var section = MakePublishedSection();
-        var version = SectionVersion.Create(section, Guid.NewGuid(), 1);
+        var version = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
         var request = CreateRequest(section.Id, version.Id, "Alpha beta");
         var sut = CreateSut();
 
@@ -162,7 +162,7 @@ public class PassageAnchorServiceTests
     {
         var reader = MakeReader();
         var section = MakePublishedSection();
-        var version = SectionVersion.Create(section, Guid.NewGuid(), 1);
+        var version = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
         var request = CreateRequest(section.Id, version.Id, "Alpha beta");
         var sut = CreateSut();
 
@@ -182,7 +182,7 @@ public class PassageAnchorServiceTests
     {
         var reader = MakeReader();
         var section = MakePublishedSection();
-        var version = SectionVersion.Create(section, Guid.NewGuid(), 1);
+        var version = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
         var snapshot = PassageAnchorSnapshot.Create(
             "Alpha beta",
             "Alpha beta",
@@ -229,7 +229,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -276,7 +276,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -318,7 +318,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -365,7 +365,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -407,7 +407,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -454,7 +454,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -496,7 +496,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -542,7 +542,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -587,7 +587,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -632,7 +632,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -676,7 +676,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,
@@ -730,7 +730,7 @@ public class PassageAnchorServiceTests
             "section-hash",
             "Draft");
         section.PublishAsPartOfChapter("section-hash");
-        var version = SectionVersion.Create(section, author.Id, 1);
+        var version = SectionVersion.Create(section, author.Id, 1, 1, 0);
         var anchor = PassageAnchor.Create(
             section.Id,
             version.Id,

--- a/DraftView.Application.Tests/Services/SectionDiffServiceTests.cs
+++ b/DraftView.Application.Tests/Services/SectionDiffServiceTests.cs
@@ -203,6 +203,6 @@ public class SectionDiffServiceTests
     {
         var authorId = Guid.NewGuid();
         section.UpdateContent(htmlContent, "hash-" + versionNumber);
-        return SectionVersion.Create(section, authorId, versionNumber);
+        return SectionVersion.Create(section, authorId, versionNumber, 1, 0);
     }
 }

--- a/DraftView.Application.Tests/Services/VersioningServiceTests.cs
+++ b/DraftView.Application.Tests/Services/VersioningServiceTests.cs
@@ -453,7 +453,7 @@ public class VersioningServiceTests
         var chapter = MakeChapter(projectId);
         var doc = MakeDocument(projectId, chapter.Id);
         doc.MarkContentChanged();
-        var previousVersion = SectionVersion.Create(doc, authorId, 1);
+        var previousVersion = SectionVersion.Create(doc, authorId, 1, 1, 0);
 
         _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default))
             .ReturnsAsync(chapter);
@@ -510,7 +510,7 @@ public class VersioningServiceTests
         var chapter = MakeChapter(projectId);
         var doc = MakeDocument(projectId, chapter.Id);
         doc.MarkContentChanged();
-        var previousVersion = SectionVersion.Create(doc, authorId, 1);
+        var previousVersion = SectionVersion.Create(doc, authorId, 1, 1, 0);
 
         _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default))
             .ReturnsAsync(chapter);
@@ -610,7 +610,7 @@ public class VersioningServiceTests
     {
         var authorId = Guid.NewGuid();
         var section = MakeDocument(Guid.NewGuid(), null);
-        var previousVersion = SectionVersion.Create(section, authorId, 1);
+        var previousVersion = SectionVersion.Create(section, authorId, 1, 1, 0);
         SectionVersion? addedVersion = null;
 
         _sectionRepo.Setup(r => r.GetByIdAsync(section.Id, default))
@@ -637,7 +637,7 @@ public class VersioningServiceTests
     {
         var authorId = Guid.NewGuid();
         var section = MakeDocument(Guid.NewGuid(), null);
-        var previousVersion = SectionVersion.Create(section, authorId, 1);
+        var previousVersion = SectionVersion.Create(section, authorId, 1, 1, 0);
 
         _sectionRepo.Setup(r => r.GetByIdAsync(section.Id, default))
             .ReturnsAsync(section);
@@ -661,8 +661,8 @@ public class VersioningServiceTests
     {
         var authorId = Guid.NewGuid();
         var section = MakeDocument(Guid.NewGuid(), null);
-        var version1 = SectionVersion.Create(section, authorId, 1);
-        var version2 = SectionVersion.Create(section, authorId, 2);
+        var version1 = SectionVersion.Create(section, authorId, 1, 1, 0);
+        var version2 = SectionVersion.Create(section, authorId, 2, 1, 0);
 
         _sectionRepo.Setup(r => r.GetByIdAsync(section.Id, default))
             .ReturnsAsync(section);
@@ -696,7 +696,7 @@ public class VersioningServiceTests
     {
         var authorId = Guid.NewGuid();
         var section = MakeDocument(Guid.NewGuid(), null);
-        var version = SectionVersion.Create(section, authorId, 1);
+        var version = SectionVersion.Create(section, authorId, 1, 1, 0);
 
         _sectionRepo.Setup(r => r.GetByIdAsync(section.Id, default))
             .ReturnsAsync(section);
@@ -906,6 +906,141 @@ public class VersioningServiceTests
             () => _sut.ClearScheduleAsync(section.Id, Guid.NewGuid(), default));
     }
 
+    // ---------------------------------------------------------------------------
+    // Semantic versioning — MajorVersion / MinorVersion
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RepublishChapterAsync_FirstPublish_SetsMajor1Minor0()
+    {
+        var projectId = Guid.NewGuid();
+        var chapter = MakeChapter(projectId);
+        var doc = MakeDocument(projectId, chapter.Id);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapter.Id, default)).ReturnsAsync([doc]);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(0);
+        _versionRepo.Setup(r => r.GetAllBySectionIdAsync(doc.Id, default)).ReturnsAsync([]);
+
+        SectionVersion? added = null;
+        _versionRepo.Setup(r => r.AddAsync(It.IsAny<SectionVersion>(), default))
+            .Callback<SectionVersion, CancellationToken>((v, _) => added = v);
+
+        await _sut.RepublishChapterAsync(chapter.Id, Guid.NewGuid(), default);
+
+        Assert.NotNull(added);
+        Assert.Equal(1, added!.MajorVersion);
+        Assert.Equal(0, added.MinorVersion);
+    }
+
+    [Fact]
+    public async Task RepublishChapterAsync_SameStatus_IncrementsMinorVersion()
+    {
+        var projectId = Guid.NewGuid();
+        var chapter = MakeChapter(projectId);
+        var doc = MakeDocumentWithStatus(projectId, chapter.Id, "First Draft");
+        doc.MarkContentChanged();
+        var prev = SectionVersion.Create(
+            MakeDocumentWithStatus(projectId, chapter.Id, "First Draft"),
+            Guid.NewGuid(), 1, 1, 2);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapter.Id, default)).ReturnsAsync([doc]);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(1);
+        _versionRepo.Setup(r => r.GetAllBySectionIdAsync(doc.Id, default)).ReturnsAsync([prev]);
+
+        SectionVersion? added = null;
+        _versionRepo.Setup(r => r.AddAsync(It.IsAny<SectionVersion>(), default))
+            .Callback<SectionVersion, CancellationToken>((v, _) => added = v);
+
+        await _sut.RepublishChapterAsync(chapter.Id, Guid.NewGuid(), default);
+
+        Assert.NotNull(added);
+        Assert.Equal(1, added!.MajorVersion);
+        Assert.Equal(3, added.MinorVersion);
+    }
+
+    [Fact]
+    public async Task RepublishChapterAsync_StatusChanges_IncrementsMajorVersionResetsMinor()
+    {
+        var projectId = Guid.NewGuid();
+        var chapter = MakeChapter(projectId);
+        var doc = MakeDocumentWithStatus(projectId, chapter.Id, "Revised Draft");
+        doc.MarkContentChanged();
+        var prev = SectionVersion.Create(
+            MakeDocumentWithStatus(projectId, chapter.Id, "First Draft"),
+            Guid.NewGuid(), 1, 1, 3);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapter.Id, default)).ReturnsAsync([doc]);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(1);
+        _versionRepo.Setup(r => r.GetAllBySectionIdAsync(doc.Id, default)).ReturnsAsync([prev]);
+
+        SectionVersion? added = null;
+        _versionRepo.Setup(r => r.AddAsync(It.IsAny<SectionVersion>(), default))
+            .Callback<SectionVersion, CancellationToken>((v, _) => added = v);
+
+        await _sut.RepublishChapterAsync(chapter.Id, Guid.NewGuid(), default);
+
+        Assert.NotNull(added);
+        Assert.Equal(2, added!.MajorVersion);
+        Assert.Equal(0, added.MinorVersion);
+    }
+
+    [Fact]
+    public async Task RepublishChapterAsync_StatusReversal_AlsoTriggersMajorBump()
+    {
+        var projectId = Guid.NewGuid();
+        var chapter = MakeChapter(projectId);
+        var doc = MakeDocumentWithStatus(projectId, chapter.Id, "First Draft");
+        doc.MarkContentChanged();
+        var prev = SectionVersion.Create(
+            MakeDocumentWithStatus(projectId, chapter.Id, "Revised Draft"),
+            Guid.NewGuid(), 2, 2, 1);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapter.Id, default)).ReturnsAsync([doc]);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(2);
+        _versionRepo.Setup(r => r.GetAllBySectionIdAsync(doc.Id, default)).ReturnsAsync([prev]);
+
+        SectionVersion? added = null;
+        _versionRepo.Setup(r => r.AddAsync(It.IsAny<SectionVersion>(), default))
+            .Callback<SectionVersion, CancellationToken>((v, _) => added = v);
+
+        await _sut.RepublishChapterAsync(chapter.Id, Guid.NewGuid(), default);
+
+        Assert.NotNull(added);
+        Assert.Equal(3, added!.MajorVersion);
+        Assert.Equal(0, added.MinorVersion);
+    }
+
+    [Fact]
+    public async Task RepublishChapterAsync_PreviousVersionHasNoStoredStatus_AlwaysMinorBump()
+    {
+        var projectId = Guid.NewGuid();
+        var chapter = MakeChapter(projectId);
+        var doc = MakeDocumentWithStatus(projectId, chapter.Id, "First Draft");
+        doc.MarkContentChanged();
+        var prev = SectionVersion.Create(
+            MakeDocument(projectId, chapter.Id), // ScrivenerStatus = null (pre-feature)
+            Guid.NewGuid(), 1, 1, 0);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapter.Id, default)).ReturnsAsync([doc]);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(1);
+        _versionRepo.Setup(r => r.GetAllBySectionIdAsync(doc.Id, default)).ReturnsAsync([prev]);
+
+        SectionVersion? added = null;
+        _versionRepo.Setup(r => r.AddAsync(It.IsAny<SectionVersion>(), default))
+            .Callback<SectionVersion, CancellationToken>((v, _) => added = v);
+
+        await _sut.RepublishChapterAsync(chapter.Id, Guid.NewGuid(), default);
+
+        Assert.NotNull(added);
+        Assert.Equal(1, added!.MajorVersion); // No major bump — no stored status to compare
+        Assert.Equal(1, added.MinorVersion);
+    }
+
     // Test helpers
     private static Section MakeChapter(Guid projectId) =>
         Section.CreateFolder(projectId, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
@@ -913,6 +1048,10 @@ public class VersioningServiceTests
     private static Section MakeDocument(Guid projectId, Guid? chapterId) =>
         Section.CreateDocument(projectId, Guid.NewGuid().ToString(),
             "Scene 1", chapterId, 0, "<p>content</p>", "hash", null);
+
+    private static Section MakeDocumentWithStatus(Guid projectId, Guid? chapterId, string status) =>
+        Section.CreateDocument(projectId, Guid.NewGuid().ToString(),
+            "Scene 1", chapterId, 0, "<p>content</p>", "hash", status);
 
     private static Section MakeManualDocument(Guid projectId, Guid chapterId)
     {

--- a/DraftView.Application/Services/VersioningService.cs
+++ b/DraftView.Application/Services/VersioningService.cs
@@ -162,7 +162,9 @@ public class VersioningService(
     }
 
     /// <summary>
-    /// Creates, classifies, summarizes, and persists a new version for one document.
+    /// Creates, classifies, and persists a new version for one document.
+    /// Computes the semantic major/minor version by comparing the document's
+    /// current ScrivenerStatus against the previous version's stored status.
     /// </summary>
     private async Task CreateVersionForDocumentAsync(
         Section document,
@@ -174,20 +176,42 @@ public class VersioningService(
         await AssertWithinRetentionLimitAsync(document.Id, subscriptionTier, ct);
 
         var currentMaxVersion = maxVersion ?? await sectionVersionRepository.GetMaxVersionNumberAsync(document.Id, ct);
-        var nextVersion = currentMaxVersion + 1;
-        var version = SectionVersion.Create(document, authorId, nextVersion);
+        var nextVersionNumber = currentMaxVersion + 1;
 
         var allVersions = await sectionVersionRepository.GetAllBySectionIdAsync(document.Id, ct);
         var previousVersion = allVersions
-            .Where(v => v.VersionNumber < version.VersionNumber)
             .OrderByDescending(v => v.VersionNumber)
             .FirstOrDefault();
+
+        var (major, minor) = ComputeSemanticVersion(previousVersion, document.ScrivenerStatus);
+        var version = SectionVersion.Create(document, authorId, nextVersionNumber, major, minor);
 
         if (previousVersion is not null)
             TryApplyClassification(version, previousVersion);
 
         await sectionVersionRepository.AddAsync(version, ct);
         document.PublishAsPartOfChapter(document.ContentHash ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Determines the semantic major/minor version for a new publish based on
+    /// whether the Scrivener status changed since the previous version.
+    /// A status change (in either direction) increments the major version and resets minor.
+    /// If the previous version has no stored status (pre-feature data), always minor-bumps.
+    /// </summary>
+    private static (int major, int minor) ComputeSemanticVersion(
+        SectionVersion? previousVersion, string? currentStatus)
+    {
+        if (previousVersion is null)
+            return (1, 0);
+
+        if (string.IsNullOrEmpty(previousVersion.ScrivenerStatus))
+            return (previousVersion.MajorVersion, previousVersion.MinorVersion + 1);
+
+        var statusChanged = previousVersion.ScrivenerStatus != (currentStatus ?? string.Empty);
+        return statusChanged
+            ? (previousVersion.MajorVersion + 1, 0)
+            : (previousVersion.MajorVersion, previousVersion.MinorVersion + 1);
     }
 
     private async Task AssertWithinRetentionLimitAsync(Guid sectionId, SubscriptionTier tier, CancellationToken ct)

--- a/DraftView.Domain.Tests/Entities/SectionVersionTests.cs
+++ b/DraftView.Domain.Tests/Entities/SectionVersionTests.cs
@@ -6,8 +6,9 @@ namespace DraftView.Domain.Tests.Entities;
 
 /// <summary>
 /// Tests for SectionVersion entity covering factory method Create,
-/// property initialization, and invariant validations.
-/// Covers change classification and AI summary one-time assignment invariants.
+/// property initialization, invariant validations, and semantic versioning.
+/// Covers change classification, semantic version label, and ScrivenerStatus capture.
+/// Excludes: reader content resolution and UI integration.
 /// </summary>
 public class SectionVersionTests
 {
@@ -16,30 +17,22 @@ public class SectionVersionTests
     private const string TestHtmlContent = "<p>Test content</p>";
     private const string TestContentHash = "abc123";
 
-    private static Section CreateValidDocumentSection()
+    private static Section CreateValidDocumentSection(string? scrivenerStatus = null)
     {
         return Section.CreateDocument(
-            ValidProjectId,
-            "test-uuid",
-            "Test Document",
-            null,
-            1,
-            TestHtmlContent,
-            TestContentHash,
-            null);
+            ValidProjectId, "test-uuid", "Test Document",
+            null, 1, TestHtmlContent, TestContentHash, scrivenerStatus);
     }
 
     // ---------------------------------------------------------------------------
-    // Create - Success cases
+    // Create — Success cases
     // ---------------------------------------------------------------------------
 
     [Fact]
     public void Create_WithDocumentSection_ReturnsVersion()
     {
         var section = CreateValidDocumentSection();
-
-        var version = SectionVersion.Create(section, ValidAuthorId, 1);
-
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
         Assert.NotEqual(Guid.Empty, version.Id);
         Assert.Equal(section.Id, version.SectionId);
     }
@@ -48,9 +41,7 @@ public class SectionVersionTests
     public void Create_WithDocumentSection_SnapshotsHtmlContent()
     {
         var section = CreateValidDocumentSection();
-
-        var version = SectionVersion.Create(section, ValidAuthorId, 1);
-
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
         Assert.Equal(TestHtmlContent, version.HtmlContent);
     }
 
@@ -58,9 +49,7 @@ public class SectionVersionTests
     public void Create_WithDocumentSection_SnapshotsContentHash()
     {
         var section = CreateValidDocumentSection();
-
-        var version = SectionVersion.Create(section, ValidAuthorId, 1);
-
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
         Assert.Equal(TestContentHash, version.ContentHash);
     }
 
@@ -68,9 +57,7 @@ public class SectionVersionTests
     public void Create_WithDocumentSection_SetsVersionNumber()
     {
         var section = CreateValidDocumentSection();
-
-        var version = SectionVersion.Create(section, ValidAuthorId, 42);
-
+        var version = SectionVersion.Create(section, ValidAuthorId, 42, 1, 0);
         Assert.Equal(42, version.VersionNumber);
     }
 
@@ -78,9 +65,7 @@ public class SectionVersionTests
     public void Create_WithDocumentSection_SetsAuthorId()
     {
         var section = CreateValidDocumentSection();
-
-        var version = SectionVersion.Create(section, ValidAuthorId, 1);
-
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
         Assert.Equal(ValidAuthorId, version.AuthorId);
     }
 
@@ -89,9 +74,7 @@ public class SectionVersionTests
     {
         var section = CreateValidDocumentSection();
         var before = DateTime.UtcNow;
-
-        var version = SectionVersion.Create(section, ValidAuthorId, 1);
-
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
         Assert.True(version.CreatedAt >= before);
         Assert.True(version.CreatedAt <= DateTime.UtcNow.AddSeconds(1));
     }
@@ -100,9 +83,7 @@ public class SectionVersionTests
     public void Create_WithDocumentSection_ChangeClassificationIsNull()
     {
         var section = CreateValidDocumentSection();
-
-        var version = SectionVersion.Create(section, ValidAuthorId, 1);
-
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
         Assert.Null(version.ChangeClassification);
     }
 
@@ -110,24 +91,20 @@ public class SectionVersionTests
     public void Create_HasNullChangeClassification()
     {
         var section = CreateValidDocumentSection();
-
-        var version = SectionVersion.Create(section, ValidAuthorId, 1);
-
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
         Assert.Null(version.ChangeClassification);
     }
 
     // ---------------------------------------------------------------------------
-    // Create - Invariant violations
+    // Create — Invariant violations
     // ---------------------------------------------------------------------------
 
     [Fact]
     public void Create_WithFolderSection_ThrowsInvariantViolation()
     {
         var section = Section.CreateFolder(ValidProjectId, "folder-uuid", "Test Folder", null, 1);
-
         var ex = Assert.Throws<InvariantViolationException>(
-            () => SectionVersion.Create(section, ValidAuthorId, 1));
-
+            () => SectionVersion.Create(section, ValidAuthorId, 1, 1, 0));
         Assert.Equal("I-VER-FOLDER", ex.InvariantCode);
     }
 
@@ -136,10 +113,8 @@ public class SectionVersionTests
     {
         var section = CreateValidDocumentSection();
         section.SoftDelete();
-
         var ex = Assert.Throws<InvariantViolationException>(
-            () => SectionVersion.Create(section, ValidAuthorId, 1));
-
+            () => SectionVersion.Create(section, ValidAuthorId, 1, 1, 0));
         Assert.Equal("I-VER-DELETED", ex.InvariantCode);
     }
 
@@ -147,18 +122,9 @@ public class SectionVersionTests
     public void Create_WithNullHtmlContent_ThrowsInvariantViolation()
     {
         var section = Section.CreateDocument(
-            ValidProjectId,
-            "test-uuid",
-            "Test Document",
-            null,
-            1,
-            null,
-            TestContentHash,
-            null);
-
+            ValidProjectId, "test-uuid", "Test Document", null, 1, null, TestContentHash, null);
         var ex = Assert.Throws<InvariantViolationException>(
-            () => SectionVersion.Create(section, ValidAuthorId, 1));
-
+            () => SectionVersion.Create(section, ValidAuthorId, 1, 1, 0));
         Assert.Equal("I-VER-CONTENT", ex.InvariantCode);
     }
 
@@ -166,18 +132,9 @@ public class SectionVersionTests
     public void Create_WithEmptyHtmlContent_ThrowsInvariantViolation()
     {
         var section = Section.CreateDocument(
-            ValidProjectId,
-            "test-uuid",
-            "Test Document",
-            null,
-            1,
-            "",
-            TestContentHash,
-            null);
-
+            ValidProjectId, "test-uuid", "Test Document", null, 1, "", TestContentHash, null);
         var ex = Assert.Throws<InvariantViolationException>(
-            () => SectionVersion.Create(section, ValidAuthorId, 1));
-
+            () => SectionVersion.Create(section, ValidAuthorId, 1, 1, 0));
         Assert.Equal("I-VER-CONTENT", ex.InvariantCode);
     }
 
@@ -185,10 +142,8 @@ public class SectionVersionTests
     public void Create_WithEmptyGuidAuthorId_ThrowsInvariantViolation()
     {
         var section = CreateValidDocumentSection();
-
         var ex = Assert.Throws<InvariantViolationException>(
-            () => SectionVersion.Create(section, Guid.Empty, 1));
-
+            () => SectionVersion.Create(section, Guid.Empty, 1, 1, 0));
         Assert.Equal("I-VER-AUTHOR", ex.InvariantCode);
     }
 
@@ -196,10 +151,8 @@ public class SectionVersionTests
     public void Create_WithVersionNumberZero_ThrowsInvariantViolation()
     {
         var section = CreateValidDocumentSection();
-
         var ex = Assert.Throws<InvariantViolationException>(
-            () => SectionVersion.Create(section, ValidAuthorId, 0));
-
+            () => SectionVersion.Create(section, ValidAuthorId, 0, 1, 0));
         Assert.Equal("I-VER-NUMBER", ex.InvariantCode);
     }
 
@@ -207,21 +160,21 @@ public class SectionVersionTests
     public void Create_WithVersionNumberNegative_ThrowsInvariantViolation()
     {
         var section = CreateValidDocumentSection();
-
         var ex = Assert.Throws<InvariantViolationException>(
-            () => SectionVersion.Create(section, ValidAuthorId, -1));
-
+            () => SectionVersion.Create(section, ValidAuthorId, -1, 1, 0));
         Assert.Equal("I-VER-NUMBER", ex.InvariantCode);
     }
+
+    // ---------------------------------------------------------------------------
+    // SetChangeClassification
+    // ---------------------------------------------------------------------------
 
     [Fact]
     public void SetChangeClassification_SetsClassification()
     {
         var section = CreateValidDocumentSection();
-        var version = SectionVersion.Create(section, ValidAuthorId, 1);
-
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
         version.SetChangeClassification(ChangeClassification.Revision);
-
         Assert.Equal(ChangeClassification.Revision, version.ChangeClassification);
     }
 
@@ -229,13 +182,83 @@ public class SectionVersionTests
     public void SetChangeClassification_WhenAlreadySet_ThrowsInvariantViolation()
     {
         var section = CreateValidDocumentSection();
-        var version = SectionVersion.Create(section, ValidAuthorId, 1);
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
         version.SetChangeClassification(ChangeClassification.Polish);
-
-        var ex = Assert.Throws<InvariantViolationException>(() =>
-            version.SetChangeClassification(ChangeClassification.Rewrite));
-
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => version.SetChangeClassification(ChangeClassification.Rewrite));
         Assert.Equal("I-VER-CLASS", ex.InvariantCode);
     }
 
+    // ---------------------------------------------------------------------------
+    // Semantic versioning — MajorVersion, MinorVersion, ScrivenerStatus
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Create_FirstPublish_SetsMajor1Minor0()
+    {
+        var section = CreateValidDocumentSection();
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
+        Assert.Equal(1, version.MajorVersion);
+        Assert.Equal(0, version.MinorVersion);
+    }
+
+    [Fact]
+    public void Create_CapturesScrivenerStatusFromSection()
+    {
+        var section = CreateValidDocumentSection("Revised Draft");
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
+        Assert.Equal("Revised Draft", version.ScrivenerStatus);
+    }
+
+    [Fact]
+    public void Create_NullScrivenerStatus_StoredAsNull()
+    {
+        var section = CreateValidDocumentSection(); // ScrivenerStatus = null
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
+        Assert.Null(version.ScrivenerStatus);
+    }
+
+    [Fact]
+    public void VersionLabel_WithClassification_FormatsCorrectly()
+    {
+        var section = CreateValidDocumentSection();
+        var version = SectionVersion.Create(section, ValidAuthorId, 4, 1, 3);
+        version.SetChangeClassification(ChangeClassification.Polish);
+        Assert.Equal("Version 1.03 — Polish", version.VersionLabel);
+    }
+
+    [Fact]
+    public void VersionLabel_WithRewrite_FormatsCorrectly()
+    {
+        var section = CreateValidDocumentSection();
+        var version = SectionVersion.Create(section, ValidAuthorId, 3, 2, 0);
+        version.SetChangeClassification(ChangeClassification.Rewrite);
+        Assert.Equal("Version 2.00 — Rewrite", version.VersionLabel);
+    }
+
+    [Fact]
+    public void VersionLabel_WithoutClassification_OmitsLabel()
+    {
+        var section = CreateValidDocumentSection();
+        var version = SectionVersion.Create(section, ValidAuthorId, 1, 1, 0);
+        Assert.Equal("Version 1.00", version.VersionLabel);
+    }
+
+    [Fact]
+    public void Create_WithMajorVersionZero_ThrowsInvariantViolation()
+    {
+        var section = CreateValidDocumentSection();
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => SectionVersion.Create(section, ValidAuthorId, 1, 0, 0));
+        Assert.Equal("I-VER-MAJOR", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void Create_WithNegativeMinorVersion_ThrowsInvariantViolation()
+    {
+        var section = CreateValidDocumentSection();
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => SectionVersion.Create(section, ValidAuthorId, 1, 1, -1));
+        Assert.Equal("I-VER-MINOR", ex.InvariantCode);
+    }
 }

--- a/DraftView.Domain/Entities/SectionVersion.cs
+++ b/DraftView.Domain/Entities/SectionVersion.cs
@@ -14,10 +14,28 @@ public sealed class SectionVersion
     public Guid SectionId { get; private set; }
     public Guid AuthorId { get; private set; }
     public int VersionNumber { get; private set; }
+    public int MajorVersion { get; private set; }
+    public int MinorVersion { get; private set; }
+
+    /// <summary>
+    /// Scrivener status label captured at publish time (e.g. "First Draft", "Revised Draft").
+    /// Null for manual-upload sections or pre-feature backfilled records.
+    /// Used by VersioningService to detect status changes and determine major vs minor bumps.
+    /// </summary>
+    public string? ScrivenerStatus { get; private set; }
+
     public string HtmlContent { get; private set; } = default!;
     public string ContentHash { get; private set; } = default!;
     public ChangeClassification? ChangeClassification { get; private set; }
     public DateTime CreatedAt { get; private set; }
+
+    /// <summary>
+    /// Human-readable version label shown to readers, e.g. "Version 1.03 — Polish".
+    /// Omits the classification label when none has been set (first publish).
+    /// </summary>
+    public string VersionLabel => ChangeClassification.HasValue
+        ? $"Version {MajorVersion}.{MinorVersion:D2} — {ChangeClassification}"
+        : $"Version {MajorVersion}.{MinorVersion:D2}";
 
     private SectionVersion() { }
 
@@ -27,10 +45,13 @@ public sealed class SectionVersion
     /// </summary>
     /// <param name="section">The Section to snapshot. Must be a Document with non-empty HtmlContent.</param>
     /// <param name="authorId">The ID of the author creating this version.</param>
-    /// <param name="nextVersionNumber">The version number to assign (1-based, must be MAX + 1).</param>
+    /// <param name="versionNumber">Sequential version number (1-based) for ordering and ReadEvent comparison.</param>
+    /// <param name="majorVersion">Semantic major version — increments when ScrivenerStatus changes.</param>
+    /// <param name="minorVersion">Semantic minor version — increments when status is unchanged.</param>
     /// <returns>A new SectionVersion entity.</returns>
     /// <exception cref="InvariantViolationException">Thrown when invariants are violated.</exception>
-    public static SectionVersion Create(Section section, Guid authorId, int nextVersionNumber)
+    public static SectionVersion Create(
+        Section section, Guid authorId, int versionNumber, int majorVersion, int minorVersion)
     {
         if (section.NodeType != NodeType.Document)
             throw new InvariantViolationException("I-VER-FOLDER",
@@ -48,16 +69,27 @@ public sealed class SectionVersion
             throw new InvariantViolationException("I-VER-AUTHOR",
                 "AuthorId must not be empty.");
 
-        if (nextVersionNumber < 1)
+        if (versionNumber < 1)
             throw new InvariantViolationException("I-VER-NUMBER",
                 "Version number must be 1 or greater.");
+
+        if (majorVersion < 1)
+            throw new InvariantViolationException("I-VER-MAJOR",
+                "Major version must be 1 or greater.");
+
+        if (minorVersion < 0)
+            throw new InvariantViolationException("I-VER-MINOR",
+                "Minor version must be 0 or greater.");
 
         return new SectionVersion
         {
             Id = Guid.NewGuid(),
             SectionId = section.Id,
             AuthorId = authorId,
-            VersionNumber = nextVersionNumber,
+            VersionNumber = versionNumber,
+            MajorVersion = majorVersion,
+            MinorVersion = minorVersion,
+            ScrivenerStatus = section.ScrivenerStatus,
             HtmlContent = section.HtmlContent,
             ContentHash = section.ContentHash ?? string.Empty,
             ChangeClassification = null,

--- a/DraftView.Infrastructure.Tests/Persistence/SectionVersionRepositoryTests.cs
+++ b/DraftView.Infrastructure.Tests/Persistence/SectionVersionRepositoryTests.cs
@@ -25,10 +25,10 @@ public class SectionVersionRepositoryTests
         var section = MakeSection();
         var otherSection = MakeSection();
 
-        db.SectionVersions.Add(SectionVersion.Create(section, AuthorId, 1));
-        db.SectionVersions.Add(SectionVersion.Create(section, AuthorId, 2));
-        db.SectionVersions.Add(SectionVersion.Create(section, AuthorId, 3));
-        db.SectionVersions.Add(SectionVersion.Create(otherSection, AuthorId, 1));
+        db.SectionVersions.Add(SectionVersion.Create(section, AuthorId, 1, 1, 0));
+        db.SectionVersions.Add(SectionVersion.Create(section, AuthorId, 2, 1, 0));
+        db.SectionVersions.Add(SectionVersion.Create(section, AuthorId, 3, 1, 0));
+        db.SectionVersions.Add(SectionVersion.Create(otherSection, AuthorId, 1, 1, 0));
         await db.SaveChangesAsync();
 
         var sut = new SectionVersionRepository(db);

--- a/DraftView.Infrastructure/Persistence/Configurations/SectionVersionConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/SectionVersionConfiguration.cs
@@ -15,6 +15,17 @@ public class SectionVersionConfiguration : IEntityTypeConfiguration<SectionVersi
         builder.Property(v => v.VersionNumber)
             .IsRequired();
 
+        builder.Property(v => v.MajorVersion)
+            .IsRequired();
+
+        builder.Property(v => v.MinorVersion)
+            .IsRequired();
+
+        builder.Property(v => v.ScrivenerStatus)
+            .HasMaxLength(100);
+
+        builder.Ignore(v => v.VersionLabel);
+
         builder.Property(v => v.HtmlContent)
             .IsRequired();
 

--- a/DraftView.Infrastructure/Persistence/Migrations/20260817111250_AddSemanticVersioningToSectionVersion.Designer.cs
+++ b/DraftView.Infrastructure/Persistence/Migrations/20260817111250_AddSemanticVersioningToSectionVersion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DraftView.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DraftView.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DraftViewDbContext))]
-    partial class DraftViewDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260817111250_AddSemanticVersioningToSectionVersion")]
+    partial class AddSemanticVersioningToSectionVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DraftView.Infrastructure/Persistence/Migrations/20260817111250_AddSemanticVersioningToSectionVersion.cs
+++ b/DraftView.Infrastructure/Persistence/Migrations/20260817111250_AddSemanticVersioningToSectionVersion.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DraftView.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSemanticVersioningToSectionVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MajorVersion",
+                table: "SectionVersions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MinorVersion",
+                table: "SectionVersions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ScrivenerStatus",
+                table: "SectionVersions",
+                type: "text",
+                nullable: true);
+
+            // Backfill: treat all pre-existing versions as 1.00, 1.01, 1.02 ... per section.
+            // MajorVersion stays 1; MinorVersion = VersionNumber - 1.
+            migrationBuilder.Sql(
+                """
+                UPDATE "SectionVersions"
+                SET "MajorVersion" = 1,
+                    "MinorVersion" = "VersionNumber" - 1;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MajorVersion",
+                table: "SectionVersions");
+
+            migrationBuilder.DropColumn(
+                name: "MinorVersion",
+                table: "SectionVersions");
+
+            migrationBuilder.DropColumn(
+                name: "ScrivenerStatus",
+                table: "SectionVersions");
+        }
+    }
+}

--- a/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
@@ -306,7 +306,7 @@ public class AuthorControllerTests
             "<p>Original prose</p>",
             "hash-original",
             null);
-        var latestVersion = SectionVersion.Create(previousSceneSnapshot, author.Id, 1);
+        var latestVersion = SectionVersion.Create(previousSceneSnapshot, author.Id, 1, 1, 0);
 
         var sut = CreateSut();
 
@@ -393,9 +393,9 @@ public class AuthorControllerTests
             "hash",
             null);
 
-        var version1 = SectionVersion.Create(document, author.Id, 1);
-        var version2 = SectionVersion.Create(document, author.Id, 2);
-        var version3 = SectionVersion.Create(document, author.Id, 3);
+        var version1 = SectionVersion.Create(document, author.Id, 1, 1, 0);
+        var version2 = SectionVersion.Create(document, author.Id, 2, 1, 0);
+        var version3 = SectionVersion.Create(document, author.Id, 3, 1, 0);
 
         var sut = CreateSut();
 
@@ -730,8 +730,8 @@ public class AuthorControllerTests
             "<p>content</p>",
             "hash",
             null);
-        var version1 = SectionVersion.Create(section, author.Id, 1);
-        var version2 = SectionVersion.Create(section, author.Id, 2);
+        var version1 = SectionVersion.Create(section, author.Id, 1, 1, 0);
+        var version2 = SectionVersion.Create(section, author.Id, 2, 1, 0);
         var sut = CreateSut();
         sut.TempData = new TempDataDictionary(sut.HttpContext, Mock.Of<ITempDataProvider>());
 
@@ -759,8 +759,8 @@ public class AuthorControllerTests
             "<p>content</p>",
             "hash",
             null);
-        var version1 = SectionVersion.Create(section, author.Id, 1);
-        var version2 = SectionVersion.Create(section, author.Id, 2);
+        var version1 = SectionVersion.Create(section, author.Id, 1, 1, 0);
+        var version2 = SectionVersion.Create(section, author.Id, 2, 1, 0);
         var sut = CreateSut();
         sut.TempData = new TempDataDictionary(sut.HttpContext, Mock.Of<ITempDataProvider>());
 

--- a/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
@@ -136,8 +136,7 @@ public class ReaderControllerTests
         scene.PublishAsPartOfChapter("scene-hash");
         var latestVersion = SectionVersion.Create(
             Section.CreateDocument(project.Id, "scene-published", "Scene 1", chapter.Id, 1, "<p>Hello</p>", "scene-hash", "Published"),
-            Guid.NewGuid(),
-            2);
+            Guid.NewGuid(), 2, 1, 0);
 
         var anchorId = Guid.NewGuid();
         var anchoredComment = Comment.CreateRoot(
@@ -388,7 +387,7 @@ public class ReaderControllerTests
         scene.PublishAsPartOfChapter("scene-hash");
 
         var publishedSection = Section.CreateDocument(project.Id, "scene-published", "Scene 1", chapter.Id, 1, "<p>Published text</p>", "published-hash", "Published");
-        var latestVersion = SectionVersion.Create(publishedSection, Guid.NewGuid(), 1);
+        var latestVersion = SectionVersion.Create(publishedSection, Guid.NewGuid(), 1, 1, 0);
 
         var sut = CreateSut(user, userAgent: "Mozilla/5.0");
 
@@ -432,7 +431,7 @@ public class ReaderControllerTests
         scene.PublishAsPartOfChapter("scene-hash");
 
         var publishedSection = Section.CreateDocument(project.Id, "scene-published", "Scene 1", chapter.Id, 1, "<p>Published text</p>", "published-hash", "Published");
-        var latestVersion = SectionVersion.Create(publishedSection, Guid.NewGuid(), 3);
+        var latestVersion = SectionVersion.Create(publishedSection, Guid.NewGuid(), 3, 1, 0);
         var readEvent = ReadEvent.Create(scene.Id, user.Id);
         readEvent.UpdateLastReadVersion(1);
 
@@ -478,8 +477,7 @@ public class ReaderControllerTests
         scene.PublishAsPartOfChapter("scene-hash");
         var latestVersion = SectionVersion.Create(
             Section.CreateDocument(project.Id, "scene-published", "Scene 1", chapter.Id, 1, "<p>Hello</p>", "published-hash", "Published"),
-            Guid.NewGuid(),
-            2);
+            Guid.NewGuid(), 2, 1, 0);
 
         var sut = CreateSut(user, userAgent: "Mozilla/5.0");
 
@@ -534,8 +532,7 @@ public class ReaderControllerTests
         scene.PublishAsPartOfChapter("scene-hash");
         var latestVersion = SectionVersion.Create(
             Section.CreateDocument(project.Id, "scene-published", "Scene 1", chapter.Id, 1, "<p>Hello</p>", "published-hash", "Published"),
-            Guid.NewGuid(),
-            2);
+            Guid.NewGuid(), 2, 1, 0);
 
         var sut = CreateSut(user, userAgent: "Mozilla/5.0");
 
@@ -590,8 +587,7 @@ public class ReaderControllerTests
         scene.PublishAsPartOfChapter("scene-hash");
         var latestVersion = SectionVersion.Create(
             Section.CreateDocument(project.Id, "scene-published", "Scene 1", chapter.Id, 1, "<p>Hello</p>", "published-hash", "Published"),
-            Guid.NewGuid(),
-            2);
+            Guid.NewGuid(), 2, 1, 0);
 
         var sut = CreateSut(user, userAgent: "Mozilla/5.0 (iPhone)");
 
@@ -940,7 +936,7 @@ public class ReaderReadRenderingRegressionTests : IClassFixture<ReaderReadRender
 
         var html = await response.Content.ReadAsStringAsync();
 
-        Assert.Matches(new Regex("href=\"#scene-[^\"]+\"[^>]*>\\s*Scene 1\\s*\\(v2\\)\\s*</a>", RegexOptions.IgnoreCase), html);
+        Assert.Matches(new Regex("href=\"#scene-[^\"]+\"[^>]*>\\s*Scene 1\\s*\\(Version 1\\.00\\)\\s*</a>", RegexOptions.IgnoreCase), html);
     }
 
     [Fact]
@@ -1119,7 +1115,7 @@ public class ReaderReadRenderingRegressionTests : IClassFixture<ReaderReadRender
             scene.PublishAsPartOfChapter("scene-hash");
 
             var publishedScene = Section.CreateDocument(project.Id, "scene-uuid-version", "Scene 1", chapter.Id, 1, "<p>Hello</p>", "scene-hash", "Published");
-            latestVersion = SectionVersion.Create(publishedScene, ReaderId, 2);
+            latestVersion = SectionVersion.Create(publishedScene, ReaderId, 2, 1, 0);
 
             var anchoredCommentAnchorId = Guid.Parse("33333333-3333-3333-3333-333333333333");
             anchoredComment = Comment.CreateRoot(

--- a/DraftView.Web/Controllers/AuthorController.cs
+++ b/DraftView.Web/Controllers/AuthorController.cs
@@ -1312,6 +1312,7 @@ public class AuthorController(
                 {
                     VersionId = v.Id,
                     VersionNumber = v.VersionNumber,
+                    VersionLabel = v.VersionLabel,
                     CreatedAt = v.CreatedAt,
                     Classification = v.ChangeClassification,
                     CanDelete = v.VersionNumber != latestVersionNumber
@@ -1323,6 +1324,7 @@ public class AuthorController(
         {
             Document = document,
             CurrentVersionNumber = latestVersion?.VersionNumber,
+            CurrentVersionLabel = latestVersion?.VersionLabel,
             HasChanges = document.ContentChangedSincePublish,
             Classification = TryClassifyDocumentChanges(document, latestVersion),
             CanRevoke = allVersions.Count > 1,

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -580,7 +580,7 @@ public class ReaderController(
 
         await ProgressService.RecordOpenAsync(id, user.Id);
 
-        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner) =
+        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner) =
             await ResolveSceneContentAndDiffAsync(scene, user.Id);
 
         var allSections = await SectionRepo.GetByProjectIdAsync(project.Id);
@@ -609,6 +609,7 @@ public class ReaderController(
             ResumeRestoreConfidenceScore = resumeRestoreTarget?.ConfidenceScore,
             ResumeRestoreMatchMethod = resumeRestoreTarget?.MatchMethod,
             CurrentVersionNumber     = currentVersionNumber,
+            VersionLabel             = versionLabel,
             DiffParagraphs           = diffParagraphs,
             UpdatedSinceLastRead     = updatedSinceLastRead,
             ShowUpdateBanner         = showUpdateBanner
@@ -628,7 +629,7 @@ public class ReaderController(
     {
         await ProgressService.RecordOpenAsync(scene.Id, user.Id, ct);
 
-        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner) =
+        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner) =
             await ResolveSceneContentAndDiffAsync(scene, user.Id, ct);
 
         var comments = await CommentService.GetThreadsForSectionAsync(scene.Id, user.Id, ct);
@@ -650,16 +651,17 @@ public class ReaderController(
             DiffParagraphs = diffParagraphs,
             UpdatedSinceLastRead = updatedSinceLastRead,
             ShowUpdateBanner = showUpdateBanner,
-            CurrentVersionNumber = currentVersionNumber
+            CurrentVersionNumber = currentVersionNumber,
+            VersionLabel = versionLabel
         };
     }
 
     /// <summary>
     /// Resolves scene content from the latest version (or fallback to working content),
     /// computes diff if reader has a prior read version, and updates reader progress.
-    /// Returns: (resolvedHtml, currentVersionNumber, diffParagraphs, updatedSinceLastRead, showUpdateBanner)
+    /// Returns: (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner)
     /// </summary>
-    private async Task<(string? resolvedHtml, Guid? currentSectionVersionId, int? currentVersionNumber, string resumeCaptureText, ResumeRestoreTargetDto? resumeRestoreTarget, IReadOnlyList<ParagraphDiffResult> diffParagraphs, bool updatedSinceLastRead, bool showUpdateBanner)>
+    private async Task<(string? resolvedHtml, Guid? currentSectionVersionId, int? currentVersionNumber, string? versionLabel, string resumeCaptureText, ResumeRestoreTargetDto? resumeRestoreTarget, IReadOnlyList<ParagraphDiffResult> diffParagraphs, bool updatedSinceLastRead, bool showUpdateBanner)>
         ResolveSceneContentAndDiffAsync(
             Section scene,
             Guid userId,
@@ -669,6 +671,7 @@ public class ReaderController(
         var resolvedHtml = latestVersion?.HtmlContent ?? scene.HtmlContent;
         var currentSectionVersionId = latestVersion?.Id;
         var currentVersionNumber = latestVersion?.VersionNumber;
+        var versionLabel = latestVersion?.VersionLabel;
         var resumeCaptureText = CanonicalizeForCapture(resolvedHtml);
         var resumeRestoreTarget = await ProgressService.GetResumeRestoreTargetAsync(
             scene.Id,
@@ -701,7 +704,7 @@ public class ReaderController(
             ? diffResult.Paragraphs
             : Array.Empty<ParagraphDiffResult>();
 
-        return (resolvedHtml, currentSectionVersionId, currentVersionNumber, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner);
+        return (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner);
     }
 
     /// <summary>

--- a/DraftView.Web/Models/AuthorViewModels.cs
+++ b/DraftView.Web/Models/AuthorViewModels.cs
@@ -122,6 +122,7 @@ public class PublishingDocumentViewModel
 {
     public Section Document { get; init; } = default!;
     public int? CurrentVersionNumber { get; init; }
+    public string? CurrentVersionLabel { get; init; }
     public bool HasChanges { get; init; }
     public ChangeClassification? Classification { get; init; }
     public bool CanRevoke { get; init; }
@@ -150,6 +151,7 @@ public class VersionHistoryItem
 {
     public Guid VersionId { get; init; }
     public int VersionNumber { get; init; }
+    public string? VersionLabel { get; init; }
     public DateTime CreatedAt { get; init; }
     public ChangeClassification? Classification { get; init; }
     public bool CanDelete { get; init; }

--- a/DraftView.Web/Models/MobileReaderViewModels.cs
+++ b/DraftView.Web/Models/MobileReaderViewModels.cs
@@ -107,6 +107,7 @@ public class MobileReadViewModel
     /// Null if no version exists yet (pre-versioning section).
     /// </summary>
     public int? CurrentVersionNumber { get; set; }
+    public string? VersionLabel { get; set; }
 
     /// <summary>
     /// Paragraph-level diff results for this scene. Empty when no changes.

--- a/DraftView.Web/Models/ReaderViewModels.cs
+++ b/DraftView.Web/Models/ReaderViewModels.cs
@@ -93,6 +93,7 @@ public class SceneWithComments
     /// The current version number. Used in the banner label.
     /// </summary>
     public int? CurrentVersionNumber { get; set; }
+    public string? VersionLabel { get; set; }
 
 }
 

--- a/DraftView.Web/Views/Author/Publishing.cshtml
+++ b/DraftView.Web/Views/Author/Publishing.cshtml
@@ -140,7 +140,7 @@ else
 
                             @if (doc.CurrentVersionNumber.HasValue)
                             {
-                                <span class="publishing-doc__version">@($"v{doc.CurrentVersionNumber.Value}")</span>
+                                <span class="publishing-doc__version">@(doc.CurrentVersionLabel ?? $"v{doc.CurrentVersionNumber.Value}")</span>
                             }
 
                             @if (doc.Classification.HasValue)
@@ -183,7 +183,7 @@ else
                                         @foreach (var v in doc.VersionHistory)
                                         {
                                             <li class="version-history__item">
-                                                <span class="version-history__number">v@v.VersionNumber</span>
+                                                <span class="version-history__number">@(v.VersionLabel ?? $"v{v.VersionNumber}")</span>
                                                 <span class="version-history__date">@v.CreatedAt.ToString("d MMM yyyy")</span>
                                                 @if (v.Classification.HasValue)
                                                 {
@@ -194,7 +194,7 @@ else
                                                 @if (v.CanDelete)
                                                 {
                                                     <form asp-action="DeleteVersion" method="post" style="display:inline"
-                                                          onsubmit="return confirm('Permanently delete version @v.VersionNumber? This cannot be undone.');">
+                                                          onsubmit="return confirm('Permanently delete version @(v.VersionLabel ?? v.VersionNumber.ToString())? This cannot be undone.');">
                                                         @Html.AntiForgeryToken()
                                                         <input type="hidden" name="versionId" value="@v.VersionId" />
                                                         <input type="hidden" name="sectionId" value="@doc.Document.Id" />

--- a/DraftView.Web/Views/Reader/DesktopRead.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopRead.cshtml
@@ -41,7 +41,7 @@
             <div class="reader__contents-label">This chapter</div>
             @foreach (var item in Model.Scenes)
             {
-                <a href="#scene-@item.Scene.Id" class="reader__contents-link">@item.Scene.Title@(item.CurrentVersionNumber.HasValue ? $" (v{item.CurrentVersionNumber.Value})" : string.Empty)</a>
+                <a href="#scene-@item.Scene.Id" class="reader__contents-link">@item.Scene.Title@(item.VersionLabel != null ? $" ({item.VersionLabel})" : string.Empty)</a>
             }
             <a href="#chapter-comments"
                    class="reader__contents-link reader__contents-link--muted">
@@ -126,7 +126,7 @@
                 <div class="chapter-sidebar__label">This chapter</div>
                 @foreach (var item in Model.Scenes)
                 {
-                    <a href="#scene-@item.Scene.Id" class="chapter-sidebar__link">@item.Scene.Title@(item.CurrentVersionNumber.HasValue ? $" (v{item.CurrentVersionNumber.Value})" : string.Empty)</a>
+                    <a href="#scene-@item.Scene.Id" class="chapter-sidebar__link">@item.Scene.Title@(item.VersionLabel != null ? $" ({item.VersionLabel})" : string.Empty)</a>
                 }
 
                 <a href="#chapter-comments"
@@ -250,7 +250,7 @@
                             <div class="update-banner" data-section-id="@item.Scene.Id" data-version="@item.CurrentVersionNumber">
                                 <div class="update-banner__content">
                                     <span class="update-banner__version">
-                                        Updated — version @item.CurrentVersionNumber
+                                        @(item.VersionLabel ?? $"Version {item.CurrentVersionNumber}")
                                     </span>
                                 </div>
                                 <button type="button" class="update-banner__dismiss" aria-label="Dismiss update notice">

--- a/DraftView.Web/Views/Reader/MobileRead.cshtml
+++ b/DraftView.Web/Views/Reader/MobileRead.cshtml
@@ -25,7 +25,7 @@
 
         <a asp-action="Scenes" asp-route-chapterId="@Model.Chapter.Id"
            class="mobile-read__nav-up">
-            &#8593; Scenes@(Model.CurrentVersionNumber.HasValue ? $" · v{Model.CurrentVersionNumber.Value}" : string.Empty)
+            &#8593; Scenes@(Model.VersionLabel != null ? $" · {Model.VersionLabel}" : string.Empty)
         </a>
 
         @if (Model.HasNext)
@@ -56,7 +56,7 @@
         <div class="update-banner" data-section-id="@Model.Scene.Id" data-version="@Model.CurrentVersionNumber">
             <div class="update-banner__content">
                 <span class="update-banner__version">
-                    Updated — version @Model.CurrentVersionNumber
+                    @(Model.VersionLabel ?? $"Version {Model.CurrentVersionNumber}")
                 </span>
             </div>
             <button type="button" class="update-banner__dismiss" aria-label="Dismiss update notice">

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,16 +80,16 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-17-4" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-17-4" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-17-4" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-17-4" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-17-4" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-17-4" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-17-4" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-17-4" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-17-4" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-17-4" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-17-5" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-17-5" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-17-5" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-17-5" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-17-5" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-17-5" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-17-5" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-17-5" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-17-5" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-17-5" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -97,7 +97,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-17-4" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-17-5" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-17-4";
+    --css-version: "v2026-08-17-5";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
## Summary

Replaces raw sequential version numbers with a semantic `Version ##.##` scheme throughout the app.

**Rules:**
- First publish → `1.00`
- Same Scrivener status → minor bump: `1.00 → 1.01 → 1.02`
- Status changes (either direction) → major bump, minor resets: `1.02 → 2.00`
- Full display label: `"Version 1.03 — Polish"` (combines semantic version + diff classification)
- No AI involved — classification is rule-based from content diff

**What changed:**
- `SectionVersion` entity: adds `MajorVersion`, `MinorVersion`, `ScrivenerStatus` (captured at publish time), `VersionLabel` computed property
- `VersioningService`: `ComputeSemanticVersion()` compares previous version's stored status against current section status to decide major vs minor
- EF migration: adds 3 columns, backfills existing rows as `1.(VersionNumber-1)`, pre-feature rows (null status) always produce minor bumps
- Views: update banner, Publishing page version history, scene nav sidebar all show `VersionLabel`

## Test plan

- [ ] Publish a scene for the first time → version shows `Version 1.00`
- [ ] Edit and republish with same Scrivener status → `Version 1.01`
- [ ] Change Scrivener status (e.g. First Draft → Revised Draft), sync, republish → `Version 2.00`
- [ ] Change status back (Revised Draft → First Draft), republish → `Version 3.00`
- [ ] Reader opens scene — update banner shows `Version 1.03 — Polish` (or appropriate classification)
- [ ] Publishing page version history shows semantic labels
- [ ] Scene nav sidebar shows `(Version 1.03)` next to scene title

🤖 Generated with [Claude Code](https://claude.com/claude-code)