### PR TITLE
refactor: Phase 2a completion + Phase 2b ISyncOrchestrationService (3.6 Incremental Refactor)

### DIFF
--- a/DraftView.Application.Tests/Services/CommentDisplayServiceTests.cs
+++ b/DraftView.Application.Tests/Services/CommentDisplayServiceTests.cs
@@ -8,6 +8,13 @@ using DraftView.Domain.Interfaces.Services;
 
 namespace DraftView.Application.Tests.Services;
 
+/// <summary>
+/// Tests for CommentDisplayService.GetCommentDisplayDataAsync.
+/// Covers: soft-delete filtering, author display name resolution, unknown-author fallback,
+/// parent/child HasChildren and CanDelete logic, passage anchor resolution and override
+/// permission, and passage anchor lookup failures being swallowed.
+/// Excludes: EF Core persistence, UI rendering.
+/// </summary>
 public class CommentDisplayServiceTests
 {
     private readonly Mock<IUserRepository>         _userRepo            = new();

--- a/DraftView.Application.Tests/Services/ProjectManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ProjectManagementServiceTests.cs
@@ -10,6 +10,13 @@ using DraftView.Domain.Interfaces.Services;
 
 namespace DraftView.Application.Tests.Services;
 
+/// <summary>
+/// Tests for ProjectManagementService.AddDiscoveredProjectsAsync.
+/// Covers: empty selection, new project creation, soft-deleted project restoration,
+/// already-added and undiscovered UUIDs being ignored, DuplicateProjectException swallowing,
+/// and AddedCount / SingleAddedProjectName result semantics.
+/// Excludes: background sync execution (fire-and-forget), EF Core persistence.
+/// </summary>
 public class ProjectManagementServiceTests
 {
     private readonly Mock<IProjectDiscoveryService> _discoveryService = new();

--- a/DraftView.Application.Tests/Services/SectionManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/SectionManagementServiceTests.cs
@@ -8,6 +8,12 @@ using DraftView.Domain.Interfaces.Services;
 
 namespace DraftView.Application.Tests.Services;
 
+/// <summary>
+/// Tests for SectionManagementService.GetSectionsSummaryAsync.
+/// Covers: depth-first ordering, publishability flagging, change classification
+/// for published chapters with edited documents, and null return for unknown projects.
+/// Excludes: EF Core persistence (unit tests only), UI rendering.
+/// </summary>
 public class SectionManagementServiceTests
 {
     private readonly Mock<IProjectRepository>              _projectRepo               = new();

--- a/DraftView.Application.Tests/Services/SyncOrchestrationServiceTests.cs
+++ b/DraftView.Application.Tests/Services/SyncOrchestrationServiceTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using DraftView.Application.Services;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Tests.Services;
+
+/// <summary>
+/// Tests for SyncOrchestrationService.StartSyncAsync.
+/// Covers: project not found (no-op), project found (MarkSyncing called and
+/// SaveChangesAsync called), and verifying the method does not throw on missing projects.
+/// Excludes: background Task.Run execution (fire-and-forget, not awaitable in unit tests),
+/// EF Core persistence, ISyncService parse behaviour.
+/// </summary>
+public class SyncOrchestrationServiceTests
+{
+    private readonly Mock<IProjectRepository>   _projectRepo  = new();
+    private readonly Mock<IUnitOfWork>          _unitOfWork   = new();
+    private readonly Mock<IServiceScopeFactory> _scopeFactory = new();
+
+    private SyncOrchestrationService CreateSut() => new(
+        _projectRepo.Object,
+        _unitOfWork.Object,
+        _scopeFactory.Object,
+        NullLogger<SyncOrchestrationService>.Instance);
+
+    [Fact]
+    public async Task StartSyncAsync_ProjectNotFound_DoesNotSaveChanges()
+    {
+        var projectId = Guid.NewGuid();
+        _projectRepo.Setup(r => r.GetByIdAsync(projectId, default)).ReturnsAsync((Project?)null);
+
+        await CreateSut().StartSyncAsync(projectId);
+
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartSyncAsync_ProjectFound_MarksProjectAsSyncingAndSaves()
+    {
+        var authorId  = Guid.NewGuid();
+        var project   = Project.Create("Book", "/path", authorId, "sync-root");
+        var projectId = project.Id;
+
+        _projectRepo.Setup(r => r.GetByIdAsync(projectId, default)).ReturnsAsync(project);
+
+        await CreateSut().StartSyncAsync(projectId);
+
+        Assert.Equal(SyncStatus.Syncing, project.SyncStatus);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartSyncAsync_ProjectNotFound_DoesNotThrow()
+    {
+        var projectId = Guid.NewGuid();
+        _projectRepo.Setup(r => r.GetByIdAsync(projectId, default)).ReturnsAsync((Project?)null);
+
+        var exception = await Record.ExceptionAsync(() => CreateSut().StartSyncAsync(projectId));
+
+        Assert.Null(exception);
+    }
+}

--- a/DraftView.Application/Services/CommentDisplayService.cs
+++ b/DraftView.Application/Services/CommentDisplayService.cs
@@ -5,10 +5,21 @@ using DraftView.Domain.Interfaces.Services;
 
 namespace DraftView.Application.Services;
 
+/// <summary>
+/// Resolves all display data required to render a list of comments in the
+/// reader view: author names, passage anchor state, and per-user permissions.
+/// Filters soft-deleted comments before any resolution.
+/// </summary>
 public class CommentDisplayService(
     IUserRepository userRepository,
     IPassageAnchorService passageAnchorService) : ICommentDisplayService
 {
+    /// <summary>
+    /// Filters soft-deleted comments, resolves author display names for
+    /// each visible comment and any passage-anchor audit users, and
+    /// determines edit/delete/override permissions for the current user.
+    /// Passage anchor lookups that throw are treated as missing (null anchor).
+    /// </summary>
     public async Task<IReadOnlyList<CommentDisplayDto>> GetCommentDisplayDataAsync(
         IReadOnlyList<Comment> comments,
         Guid currentUserId,

--- a/DraftView.Application/Services/ProjectManagementService.cs
+++ b/DraftView.Application/Services/ProjectManagementService.cs
@@ -8,6 +8,11 @@ using DraftView.Domain.Interfaces.Services;
 
 namespace DraftView.Application.Services;
 
+/// <summary>
+/// Orchestrates adding discovered Scrivener/Dropbox projects for an author:
+/// restoring soft-deleted projects or creating new ones, then kicking off
+/// background synchronisation for each newly added project.
+/// </summary>
 public class ProjectManagementService(
     IProjectDiscoveryService discoveryService,
     IProjectRepository projectRepo,
@@ -15,6 +20,12 @@ public class ProjectManagementService(
     IServiceScopeFactory scopeFactory,
     ILogger<ProjectManagementService> logger) : IProjectManagementService
 {
+    /// <summary>
+    /// Matches the selected UUIDs against the author's discovered projects,
+    /// restores any that were previously soft-deleted, or creates new Project
+    /// entities. Saves to the database, then enqueues a background sync for
+    /// each project that was added.
+    /// </summary>
     public async Task<AddDiscoveredProjectsResultDto> AddDiscoveredProjectsAsync(
         IReadOnlyList<string> selectedUuids, Guid authorId, CancellationToken ct = default)
     {
@@ -79,6 +90,11 @@ public class ProjectManagementService(
         };
     }
 
+    /// <summary>
+    /// Fires a background Task.Run that parses the project via ISyncService
+    /// in an isolated DI scope. On failure, attempts to record the error
+    /// on the project's SyncStatus.
+    /// </summary>
     private void StartBackgroundSync(Guid projectId)
     {
         _ = Task.Run(async () =>

--- a/DraftView.Application/Services/SectionManagementService.cs
+++ b/DraftView.Application/Services/SectionManagementService.cs
@@ -5,6 +5,11 @@ using DraftView.Domain.Interfaces.Services;
 
 namespace DraftView.Application.Services;
 
+/// <summary>
+/// Builds the aggregated sections summary for the author's Sections page,
+/// encapsulating depth-first tree ordering, publishability evaluation, and
+/// change classification across all project chapters.
+/// </summary>
 public class SectionManagementService(
     IProjectRepository projectRepo,
     ISectionRepository sectionRepo,
@@ -13,6 +18,12 @@ public class SectionManagementService(
     IHtmlDiffService htmlDiffService,
     IChangeClassificationService changeClassificationService) : ISectionManagementService
 {
+    /// <summary>
+    /// Loads the project and its full section tree, evaluates publishability
+    /// for every folder, and computes change classifications for published
+    /// chapters that have unpublished document edits. Returns null when the
+    /// project does not exist.
+    /// </summary>
     public async Task<SectionsSummaryDto?> GetSectionsSummaryAsync(
         Guid projectId, CancellationToken ct = default)
     {
@@ -87,6 +98,10 @@ public class SectionManagementService(
         };
     }
 
+    /// <summary>
+    /// Returns all sections in depth-first order, each paired with its
+    /// indentation depth. Children are sorted by SortOrder within their parent.
+    /// </summary>
     private static IReadOnlyList<SectionTreeRow> SortDepthFirst(
         IReadOnlyList<Section> sections)
     {

--- a/DraftView.Application/Services/SyncOrchestrationService.cs
+++ b/DraftView.Application/Services/SyncOrchestrationService.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Services;
+
+/// <summary>
+/// Implements the sync kick-off workflow: persists the syncing status for a
+/// project, then fires a scoped background Task that invokes ISyncService.
+/// The background task handles its own error recording if the parse fails.
+/// </summary>
+public class SyncOrchestrationService(
+    IProjectRepository projectRepo,
+    IUnitOfWork unitOfWork,
+    IServiceScopeFactory scopeFactory,
+    ILogger<SyncOrchestrationService> logger) : ISyncOrchestrationService
+{
+    /// <summary>
+    /// Fetches the project, marks it as syncing, saves the change, then
+    /// enqueues a background Task.Run to parse the project. Returns once
+    /// the status is persisted; the background parse runs asynchronously.
+    /// Does nothing if the project is not found.
+    /// </summary>
+    public async Task StartSyncAsync(Guid projectId, CancellationToken ct = default)
+    {
+        var project = await projectRepo.GetByIdAsync(projectId, ct);
+        if (project is not null)
+        {
+            project.MarkSyncing();
+            await unitOfWork.SaveChangesAsync(ct);
+        }
+
+        FireBackgroundSync(projectId);
+    }
+
+    /// <summary>
+    /// Fires a fire-and-forget Task.Run that parses the project in an isolated
+    /// DI scope. On failure, records the error on the project's SyncStatus.
+    /// </summary>
+    private void FireBackgroundSync(Guid projectId)
+    {
+        _ = Task.Run(async () =>
+        {
+            using var scope       = scopeFactory.CreateScope();
+            var bgSyncService     = scope.ServiceProvider.GetRequiredService<ISyncService>();
+            var bgProjectRepo     = scope.ServiceProvider.GetRequiredService<IProjectRepository>();
+            var bgUnitOfWork      = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            try
+            {
+                await bgSyncService.ParseProjectAsync(projectId);
+                logger.LogInformation("Background sync completed for project {ProjectId}", projectId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Background sync failed for project {ProjectId}: {Message}",
+                    projectId, ex.Message);
+                try
+                {
+                    var failedProject = await bgProjectRepo.GetByIdAsync(projectId);
+                    if (failedProject is not null && failedProject.SyncStatus == SyncStatus.Syncing)
+                    {
+                        failedProject.UpdateSyncStatus(SyncStatus.Error, DateTime.UtcNow,
+                            ex.Message.Length > 200 ? ex.Message[..200] : ex.Message);
+                        await bgUnitOfWork.SaveChangesAsync();
+                    }
+                }
+                catch (Exception innerEx)
+                {
+                    logger.LogError(innerEx,
+                        "Failed to update sync error status for {ProjectId}", projectId);
+                }
+            }
+        });
+    }
+}

--- a/DraftView.Domain/Interfaces/Services/ISyncOrchestrationService.cs
+++ b/DraftView.Domain/Interfaces/Services/ISyncOrchestrationService.cs
@@ -1,0 +1,18 @@
+namespace DraftView.Domain.Interfaces.Services;
+
+/// <summary>
+/// Orchestrates the two-step project sync kick-off: marking the project as
+/// syncing in the database, then firing a background parse. Callers do not
+/// await the background work — the method returns once the sync status is
+/// persisted and the background task has been enqueued.
+/// </summary>
+public interface ISyncOrchestrationService
+{
+    /// <summary>
+    /// Marks <paramref name="projectId"/> as syncing, persists the status,
+    /// then fires a background parse via <see cref="ISyncService"/>. Returns
+    /// immediately; the background work continues after the caller's request
+    /// has completed.
+    /// </summary>
+    Task StartSyncAsync(Guid projectId, CancellationToken ct = default);
+}

--- a/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
@@ -24,12 +24,11 @@ public class AuthorControllerTests
     private readonly Mock<IPublicationService> publicationService = new();
     private readonly Mock<IUserService> userService = new();
     private readonly Mock<IDashboardService> dashboardService = new();
-    private readonly Mock<ISyncService> syncService = new();
     private readonly Mock<IUserRepository> userRepo = new();
     private readonly Mock<IProjectDiscoveryService> discoveryService = new();
     private readonly Mock<IInvitationRepository> invitationRepo = new();
-    private readonly Mock<IServiceScopeFactory> scopeFactory = new();
     private readonly Mock<ISyncProgressTracker> progressTracker = new();
+    private readonly Mock<ISyncOrchestrationService> syncOrchestrationService = new();
     private readonly Mock<IReaderAccessRepository> readerAccessRepo = new();
     private readonly Mock<ISectionVersionRepository> sectionVersionRepo = new();
     private readonly Mock<IVersioningService> versioningService = new();
@@ -70,12 +69,11 @@ public class AuthorControllerTests
             publicationService.Object,
             userService.Object,
             dashboardService.Object,
-            syncService.Object,
             userRepo.Object,
             discoveryService.Object,
             invitationRepo.Object,
-            scopeFactory.Object,
             progressTracker.Object,
+            syncOrchestrationService.Object,
             readerAccessRepo.Object,
             versioningService.Object,
             htmlDiffService.Object,

--- a/DraftView.Web/Controllers/AuthorController.cs
+++ b/DraftView.Web/Controllers/AuthorController.cs
@@ -24,12 +24,11 @@ public class AuthorController(
     IPublicationService publicationService,
     IUserService userService,
     IDashboardService dashboardService,
-    ISyncService syncService,
     IUserRepository userRepo,
     IProjectDiscoveryService discoveryService,
     IInvitationRepository invitationRepo,
-    IServiceScopeFactory scopeFactory,
     ISyncProgressTracker progressTracker,
+    ISyncOrchestrationService syncOrchestrationService,
     IReaderAccessRepository readerAccessRepo,
     IVersioningService versioningService,
     IHtmlDiffService htmlDiffService,
@@ -103,45 +102,7 @@ public class AuthorController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Sync(Guid projectId)
     {
-        var project = await projectRepo.GetByIdAsync(projectId);
-        if (project is not null)
-        {
-            project.MarkSyncing();
-            await GetUnitOfWork().SaveChangesAsync();
-        }
-
-        _ = Task.Run(async () =>
-        {
-            using var scope   = scopeFactory.CreateScope();
-            var bgSyncService = scope.ServiceProvider.GetRequiredService<ISyncService>();
-            var bgProjectRepo = scope.ServiceProvider.GetRequiredService<IProjectRepository>();
-            var bgUnitOfWork  = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-            try
-            {
-                await bgSyncService.ParseProjectAsync(projectId);
-                logger.LogInformation("Background sync completed for project {ProjectId}", projectId);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Background sync failed for project {ProjectId}: {Message}",
-                    projectId, ex.Message);
-                try
-                {
-                    var failedProject = await bgProjectRepo.GetByIdAsync(projectId);
-                    if (failedProject is not null && failedProject.SyncStatus == SyncStatus.Syncing)
-                    {
-                        failedProject.UpdateSyncStatus(SyncStatus.Error, DateTime.UtcNow,
-                            ex.Message.Length > 200 ? ex.Message[..200] : ex.Message);
-                        await bgUnitOfWork.SaveChangesAsync();
-                    }
-                }
-                catch (Exception innerEx)
-                {
-                    logger.LogError(innerEx, "Failed to update sync error status for {ProjectId}", projectId);
-                }
-            }
-        });
-
+        await syncOrchestrationService.StartSyncAsync(projectId);
         return RedirectToAction("Dashboard");
     }
 

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -113,6 +113,7 @@ namespace DraftView.Web.Extensions
             services.AddScoped<ISectionManagementService, SectionManagementService>();
             services.AddScoped<IProjectManagementService, ProjectManagementService>();
             services.AddScoped<ICommentDisplayService, CommentDisplayService>();
+            services.AddScoped<ISyncOrchestrationService, SyncOrchestrationService>();
 
             return services;
         }

--- a/TASKS.md
+++ b/TASKS.md
@@ -213,14 +213,14 @@ See `REFACTORING.md` for full detail. Phase 1 complete — see `HISTORY.md`.
 
 **Current Focus:** Web Layer Business Logic Extraction (replaces original Phase 2)
 
-- [ ] **Phase 2a — Extract Critical Controller Orchestration** (🔴 BLOCKING)
-  - [ ] Create `ISectionManagementService.GetSectionsSummaryAsync(projectId)` — extract `AuthorController.Sections` (lines 289-356)
-  - [ ] Create `IProjectManagementService.AddDiscoveredProjectsAsync(selectedUuids, authorId)` — extract `AuthorController.AddProjects` (lines 985-1077)
-  - [ ] Create `ICommentDisplayService.GetCommentDisplayDataAsync(...)` — extract `BaseReaderController.BuildCommentDisplayModelsAsync` (lines 263-355)
-  - [ ] Full TDD: failing tests → implementation → zero regressions
+- [x] **Phase 2a — Extract Critical Controller Orchestration** ✅ Complete (merged PR #31)
+  - [x] Create `ISectionManagementService.GetSectionsSummaryAsync(projectId)` — extracted from `AuthorController.Sections`
+  - [x] Create `IProjectManagementService.AddDiscoveredProjectsAsync(selectedUuids, authorId)` — extracted from `AuthorController.AddProjects`
+  - [x] Create `ICommentDisplayService.GetCommentDisplayDataAsync(...)` — extracted from `BaseReaderController.BuildCommentDisplayModelsAsync`
+  - [x] Full TDD: failing tests → implementation → zero regressions
 - [ ] **Phase 2b — Standardize Background Sync**
-  - [ ] Create `ISyncOrchestrationService.StartSyncAsync(projectId, authorId)`
-  - [ ] Remove inline `Task.Run` blocks from `AuthorController.Sync` and `AddProjects`
+  - [x] Create `ISyncOrchestrationService.StartSyncAsync(projectId)` — extracted from `AuthorController.Sync`; dead `ISyncService` and `IServiceScopeFactory` constructor params removed from controller
+  - [ ] Remove inline `Task.Run` from `ProjectManagementService.StartBackgroundSync` — use `ISyncOrchestrationService`
 - [ ] **Phase 2c — Extract Domain Mutations**
   - [ ] Move project activation/deactivation to `IProjectManagementService`
   - [ ] Move version deletion rules to `IVersioningService`

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,5 @@
 ﻿# DraftView — Task List
-Last updated: 2026-08-17
+Last updated: 2026-08-18
 Last deployed: 2026-08-17 13:59 (commit: d51d201)
 
 ---
@@ -23,6 +23,7 @@ Last deployed: 2026-08-17 13:59 (commit: d51d201)
 | RD-Sprint Series | 🟡 In progress — RD-Sprint-1 (Continue Reading CTA) merged to main 2026-08-17; see section 3.7 |
 | DR-Sprint Series | ✅ Complete — merged to main 2026-08-17; see section 3.8 |
 | MU-Sprint Series | 🔵 Pre-implementation — design complete; see section 3.10 |
+| Incremental Refactor (3.6) | 🟡 In progress — Phase 2a complete (PR #31), Phase 2b in progress (PR #37); see section 3.6 |
 | Go-Live Prerequisites | 🔴 Blocking — items below must complete before launch |
 | UAT | 🟡 In progress |
 
@@ -209,9 +210,9 @@ S-Sprint-1 complete — see `HISTORY.md`.
 ### 3.6 Incremental Refactor Roadmap
 See `REFACTORING.md` for full detail. Phase 1 complete — see `HISTORY.md`.
 
-**Status:** 🔴 HIGH PRIORITY — Web layer review (2026-08-17) identified ~530 lines of business logic violations. See `Web-Layer-Business-Logic-Review.md` and GitHub issue for full detail.
+**Status:** 🟡 In progress — Phase 2a complete (PR #31, 2026-08-17), Phase 2b in progress (PR #37, 2026-08-18). Web layer review identified ~530 lines of business logic violations — see `Web-Layer-Business-Logic-Review.md` for full detail.
 
-**Current Focus:** Web Layer Business Logic Extraction (replaces original Phase 2)
+**Current Focus:** Phase 2b — Standardize Background Sync (Web Layer Business Logic Extraction, replaces original Phase 2)
 
 - [x] **Phase 2a — Extract Critical Controller Orchestration** ✅ Complete (merged PR #31)
   - [x] Create `ISectionManagementService.GetSectionsSummaryAsync(projectId)` — extracted from `AuthorController.Sections`


### PR DESCRIPTION
## Summary

Two-commit refactor advancing section 3.6 of the Incremental Refactor Roadmap.

### Commit 1 — Phase 2a: XML doc comments on extracted service classes

All three Phase 2a service implementations and their test classes were missing the required XML doc comments (Refactoring.md §9.1, §9.2, §9.3):

- `SectionManagementService` — class summary + `GetSectionsSummaryAsync` + `SortDepthFirst`
- `ProjectManagementService` — class summary + `AddDiscoveredProjectsAsync` + `StartBackgroundSync`
- `CommentDisplayService` — class summary + `GetCommentDisplayDataAsync`
- `SectionManagementServiceTests`, `ProjectManagementServiceTests`, `CommentDisplayServiceTests` — test class XML summaries stating in-scope and out-of-scope coverage

### Commit 2 — Phase 2b: Extract `ISyncOrchestrationService`

**Problem:** `AuthorController.Sync` contained 44 lines of business logic: a direct repository call, a domain mutation (`project.MarkSyncing()`), a `UnitOfWork.SaveChangesAsync()`, and a `Task.Run` block with full error-handling and scope management. Two constructor parameters (`ISyncService`, `IServiceScopeFactory`) were injected but the `Task.Run` was the only call site — making `ISyncService` dead code.

**Changes:**
- New `ISyncOrchestrationService` interface (`DraftView.Domain/Interfaces/Services/`)
- New `SyncOrchestrationService` implementation (`DraftView.Application/Services/`) — encapsulates mark-as-syncing, save, and the fire-and-forget background parse
- New `SyncOrchestrationServiceTests` — covers project-not-found (no save), project-found (MarkSyncing + SaveChangesAsync), and no-throw on missing project
- `AuthorController.Sync` reduced from 44 lines to 3 — delegates entirely to `syncOrchestrationService.StartSyncAsync(projectId)`
- Removed dead `ISyncService` and `IServiceScopeFactory` constructor parameters from `AuthorController`
- `AuthorControllerTests` updated: removed `syncService` and `scopeFactory` mocks, added `ISyncOrchestrationService` mock
- `ServiceCollectionExtensions` registers `ISyncOrchestrationService → SyncOrchestrationService`
- `TASKS.md` updated: Phase 2a checked off, Phase 2b ISyncOrchestrationService item checked off

## Architecture compliance

- No layer boundaries crossed — interface in Domain, implementation in Application, registration in Web
- Refactor commits are behaviour-preserving: no observable change to Sync endpoint behaviour
- Dead code removed (unused `ISyncService` injection)
- TDD: `SyncOrchestrationServiceTests` written alongside implementation

## Notes for local validation

`dotnet` is not available in this cloud execution environment. The unit tests in `SyncOrchestrationServiceTests` cover the non-fire-and-forget paths. Full test suite validation (`dotnet test`) should be run locally before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_018cmg5HSAwjvPtE1uXVg2bH)_