### PR TITLE
refactor: delegate ProjectManagementService background sync to ISyncOrchestrationService (Phase 2b complete)

### DIFF
--- a/DraftView.Application.Tests/Services/ProjectManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ProjectManagementServiceTests.cs
@@ -1,9 +1,6 @@
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using DraftView.Application.Services;
 using DraftView.Domain.Entities;
-using DraftView.Domain.Enumerations;
 using DraftView.Domain.Exceptions;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
@@ -15,34 +12,20 @@ namespace DraftView.Application.Tests.Services;
 /// Covers: empty selection, new project creation, soft-deleted project restoration,
 /// already-added and undiscovered UUIDs being ignored, DuplicateProjectException swallowing,
 /// and AddedCount / SingleAddedProjectName result semantics.
-/// Excludes: background sync execution (fire-and-forget), EF Core persistence.
+/// Excludes: background sync execution (fire-and-forget via ISyncOrchestrationService), EF Core persistence.
 /// </summary>
 public class ProjectManagementServiceTests
 {
-    private readonly Mock<IProjectDiscoveryService> _discoveryService = new();
-    private readonly Mock<IProjectRepository>        _projectRepo     = new();
-    private readonly Mock<IUnitOfWork>               _unitOfWork      = new();
-    private readonly Mock<IServiceScopeFactory>      _scopeFactory    = new();
-    private readonly Mock<ISyncService>              _syncService     = new();
+    private readonly Mock<IProjectDiscoveryService>    _discoveryService        = new();
+    private readonly Mock<IProjectRepository>          _projectRepo             = new();
+    private readonly Mock<IUnitOfWork>                 _unitOfWork              = new();
+    private readonly Mock<ISyncOrchestrationService>   _syncOrchestrationService = new();
 
     private ProjectManagementService CreateSut() => new(
         _discoveryService.Object,
         _projectRepo.Object,
         _unitOfWork.Object,
-        _scopeFactory.Object,
-        NullLogger<ProjectManagementService>.Instance);
-
-    private void SetUpBackgroundScope()
-    {
-        var serviceProvider = new Mock<IServiceProvider>();
-        serviceProvider.Setup(p => p.GetService(typeof(ISyncService))).Returns(_syncService.Object);
-        serviceProvider.Setup(p => p.GetService(typeof(IProjectRepository))).Returns(_projectRepo.Object);
-        serviceProvider.Setup(p => p.GetService(typeof(IUnitOfWork))).Returns(_unitOfWork.Object);
-
-        var scope = new Mock<IServiceScope>();
-        scope.Setup(s => s.ServiceProvider).Returns(serviceProvider.Object);
-        _scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
-    }
+        _syncOrchestrationService.Object);
 
     [Fact]
     public async Task AddDiscoveredProjectsAsync_NoSelection_ReturnsZeroAdded()
@@ -51,6 +34,7 @@ public class ProjectManagementServiceTests
 
         Assert.Equal(0, result.AddedCount);
         _projectRepo.Verify(r => r.AddAsync(It.IsAny<Project>(), default), Times.Never);
+        _syncOrchestrationService.Verify(s => s.StartSyncAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -66,16 +50,14 @@ public class ProjectManagementServiceTests
             .ReturnsAsync(new List<DiscoveredProject> { discovered });
         _projectRepo.Setup(r => r.GetSoftDeletedBySyncRootIdAsync("uuid-1", default))
             .ReturnsAsync((Project?)null);
-        _projectRepo.Setup(r => r.GetAllAsync(default))
-            .ReturnsAsync(new List<Project> { Project.Create("My Book", "/path", authorId, "uuid-1") });
-        SetUpBackgroundScope();
 
         var result = await CreateSut().AddDiscoveredProjectsAsync(["uuid-1"], authorId);
 
         Assert.Equal(1, result.AddedCount);
         Assert.Equal("My Book", result.SingleAddedProjectName);
         _projectRepo.Verify(r => r.AddAsync(It.Is<Project>(p => p.SyncRootId == "uuid-1"), default), Times.Once);
-        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.AtLeastOnce);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        _syncOrchestrationService.Verify(s => s.StartSyncAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -92,15 +74,13 @@ public class ProjectManagementServiceTests
             .ReturnsAsync(new List<DiscoveredProject> { discovered });
         _projectRepo.Setup(r => r.GetSoftDeletedBySyncRootIdAsync("uuid-2", default))
             .ReturnsAsync(softDeleted);
-        _projectRepo.Setup(r => r.GetAllAsync(default))
-            .ReturnsAsync(new List<Project> { softDeleted });
-        SetUpBackgroundScope();
 
         var result = await CreateSut().AddDiscoveredProjectsAsync(["uuid-2"], authorId);
 
         Assert.Equal(1, result.AddedCount);
         Assert.Equal("Restored Book", softDeleted.Name);
         _projectRepo.Verify(r => r.AddAsync(It.IsAny<Project>(), default), Times.Never);
+        _syncOrchestrationService.Verify(s => s.StartSyncAsync(softDeleted.Id, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -119,6 +99,7 @@ public class ProjectManagementServiceTests
 
         Assert.Equal(0, result.AddedCount);
         _projectRepo.Verify(r => r.AddAsync(It.IsAny<Project>(), default), Times.Never);
+        _syncOrchestrationService.Verify(s => s.StartSyncAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -131,6 +112,7 @@ public class ProjectManagementServiceTests
         var result = await CreateSut().AddDiscoveredProjectsAsync(["missing-uuid"], authorId);
 
         Assert.Equal(0, result.AddedCount);
+        _syncOrchestrationService.Verify(s => s.StartSyncAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -148,12 +130,11 @@ public class ProjectManagementServiceTests
             .ReturnsAsync((Project?)null);
         _projectRepo.Setup(r => r.AddAsync(It.IsAny<Project>(), default))
             .ThrowsAsync(new DuplicateProjectException("uuid-4"));
-        _projectRepo.Setup(r => r.GetAllAsync(default))
-            .ReturnsAsync(new List<Project>());
 
         var result = await CreateSut().AddDiscoveredProjectsAsync(["uuid-4"], authorId);
 
         Assert.Equal(0, result.AddedCount);
+        _syncOrchestrationService.Verify(s => s.StartSyncAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -167,18 +148,12 @@ public class ProjectManagementServiceTests
             .ReturnsAsync(new List<DiscoveredProject> { d1, d2 });
         _projectRepo.Setup(r => r.GetSoftDeletedBySyncRootIdAsync(It.IsAny<string>(), default))
             .ReturnsAsync((Project?)null);
-        _projectRepo.Setup(r => r.GetAllAsync(default))
-            .ReturnsAsync(new List<Project>
-            {
-                Project.Create("Book A", "/a", authorId, "uuid-a"),
-                Project.Create("Book B", "/b", authorId, "uuid-b")
-            });
-        SetUpBackgroundScope();
 
         var result = await CreateSut().AddDiscoveredProjectsAsync(["uuid-a", "uuid-b"], authorId);
 
         Assert.Equal(2, result.AddedCount);
         Assert.Null(result.SingleAddedProjectName);
+        _syncOrchestrationService.Verify(s => s.StartSyncAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]
@@ -195,12 +170,11 @@ public class ProjectManagementServiceTests
         _projectRepo.SetupSequence(r => r.AddAsync(It.IsAny<Project>(), default))
             .ThrowsAsync(new DuplicateProjectException("uuid-dup"))
             .Returns(Task.CompletedTask);
-        _projectRepo.Setup(r => r.GetAllAsync(default))
-            .ReturnsAsync(new List<Project> { Project.Create("Good Book", "/b", authorId, "uuid-good") });
 
         var result = await CreateSut().AddDiscoveredProjectsAsync(["uuid-dup", "uuid-good"], authorId);
 
         Assert.Equal(1, result.AddedCount);
         Assert.Equal("Good Book", result.SingleAddedProjectName);
+        _syncOrchestrationService.Verify(s => s.StartSyncAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/DraftView.Application/Services/ProjectManagementService.cs
+++ b/DraftView.Application/Services/ProjectManagementService.cs
@@ -1,7 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using DraftView.Domain.Entities;
-using DraftView.Domain.Enumerations;
 using DraftView.Domain.Exceptions;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
@@ -17,8 +14,7 @@ public class ProjectManagementService(
     IProjectDiscoveryService discoveryService,
     IProjectRepository projectRepo,
     IUnitOfWork unitOfWork,
-    IServiceScopeFactory scopeFactory,
-    ILogger<ProjectManagementService> logger) : IProjectManagementService
+    ISyncOrchestrationService syncOrchestrationService) : IProjectManagementService
 {
     /// <summary>
     /// Matches the selected UUIDs against the author's discovered projects,
@@ -39,6 +35,8 @@ public class ProjectManagementService(
 
         var addedCount = 0;
         string? singleAddedProjectName = null;
+        var addedProjectIds = new List<Guid>();
+
         foreach (var d in toAdd)
         {
             try
@@ -47,6 +45,7 @@ public class ProjectManagementService(
                 if (softDeleted is not null)
                 {
                     softDeleted.Restore(d.Name);
+                    addedProjectIds.Add(softDeleted.Id);
                     addedCount++;
                     singleAddedProjectName = d.Name;
                 }
@@ -54,6 +53,7 @@ public class ProjectManagementService(
                 {
                     var project = Project.Create(d.Name, d.DropboxPath, authorId, d.SyncRootId);
                     await projectRepo.AddAsync(project, ct);
+                    addedProjectIds.Add(project.Id);
                     addedCount++;
                     singleAddedProjectName = d.Name;
                 }
@@ -63,70 +63,13 @@ public class ProjectManagementService(
 
         await unitOfWork.SaveChangesAsync(ct);
 
-        var syncRootIdsToSync = toAdd.Select(d => d.SyncRootId).ToHashSet();
-        var projectsToSync    = new List<Guid>();
-
-        if (syncRootIdsToSync.Count > 0)
-        {
-            var allProjects = await projectRepo.GetAllAsync(ct);
-            foreach (var project in allProjects.Where(p =>
-                         p.SyncRootId is not null && syncRootIdsToSync.Contains(p.SyncRootId)))
-            {
-                project.MarkSyncing();
-                projectsToSync.Add(project.Id);
-            }
-        }
-
-        if (projectsToSync.Count > 0)
-            await unitOfWork.SaveChangesAsync(ct);
-
-        foreach (var projectId in projectsToSync)
-            StartBackgroundSync(projectId);
+        foreach (var projectId in addedProjectIds)
+            await syncOrchestrationService.StartSyncAsync(projectId, ct);
 
         return new AddDiscoveredProjectsResultDto
         {
             AddedCount = addedCount,
             SingleAddedProjectName = addedCount == 1 ? singleAddedProjectName : null
         };
-    }
-
-    /// <summary>
-    /// Fires a background Task.Run that parses the project via ISyncService
-    /// in an isolated DI scope. On failure, attempts to record the error
-    /// on the project's SyncStatus.
-    /// </summary>
-    private void StartBackgroundSync(Guid projectId)
-    {
-        _ = Task.Run(async () =>
-        {
-            using var scope   = scopeFactory.CreateScope();
-            var bgSyncService = scope.ServiceProvider.GetRequiredService<ISyncService>();
-            var bgProjectRepo = scope.ServiceProvider.GetRequiredService<IProjectRepository>();
-            var bgUnitOfWork  = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-            try
-            {
-                await bgSyncService.ParseProjectAsync(projectId);
-                logger.LogInformation("Background sync completed for project {ProjectId}", projectId);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Background sync failed for project {ProjectId}: {Message}",
-                    projectId, ex.Message);
-                try
-                {
-                    var failedProject = await bgProjectRepo.GetByIdAsync(projectId);
-                    if (failedProject is not null && failedProject.SyncStatus == SyncStatus.Syncing)
-                    {
-                        failedProject.UpdateSyncStatus(SyncStatus.Error, DateTime.UtcNow,
-                            ex.Message.Length > 200 ? ex.Message[..200] : ex.Message);
-                        await bgUnitOfWork.SaveChangesAsync();
-                    }
-                }
-                catch (Exception innerEx)
-                {
-                    logger.LogError(innerEx, "Failed to update sync error status for {ProjectId}", projectId);
-                }
-            }
-        });
     }
 }


### PR DESCRIPTION
## Summary

Completes Phase 2b of the Incremental Refactor Roadmap (issue #3-6).

- **`ProjectManagementService`** — removes the inline `Task.Run` / manual DI-scope creation from `StartBackgroundSync` and replaces the entire block with `await syncOrchestrationService.StartSyncAsync(projectId, ct)` for each added project.
- **Dead code removed** — `IServiceScopeFactory` and `ILogger<ProjectManagementService>` are no longer injected (both were only used by `StartBackgroundSync`). The `StartBackgroundSync` private method is deleted entirely.
- **`AddDiscoveredProjectsAsync` simplified** — project IDs are now tracked during the add loop, eliminating the redundant `GetAllAsync` + manual `MarkSyncing` block that followed `SaveChangesAsync`.
- **`ProjectManagementServiceTests`** — updated to the new constructor; `SetUpBackgroundScope` helper and `ISyncService`/`IServiceScopeFactory` mocks removed; tests now assert directly on `ISyncOrchestrationService.StartSyncAsync` call counts.

## Test plan

- [ ] `dotnet test --filter ProjectManagementServiceTests` — all 7 tests green
- [ ] `dotnet test --filter SyncOrchestrationServiceTests` — all 3 tests remain green
- [ ] `dotnet test` — full suite green, no regressions

> **Note (cloud execution):** `dotnet` is not available in this remote session. Local validation required before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_018cmg5HSAwjvPtE1uXVg2bH)_