### PR TITLE
refactor: extract domain mutations from AuthorController (Phase 2c) + TASKS.md update

### DIFF
--- a/DraftView.Application.Tests/Services/ProjectManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ProjectManagementServiceTests.cs
@@ -156,6 +156,123 @@ public class ProjectManagementServiceTests
         _syncOrchestrationService.Verify(s => s.StartSyncAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
+    // -----------------------------------------------------------------------
+    // SetActiveProjectAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SetActiveProjectAsync_ProjectNotFound_ThrowsInvalidOperationException()
+    {
+        var projectId = Guid.NewGuid();
+        _projectRepo.Setup(r => r.GetByIdAsync(projectId, default)).ReturnsAsync((Project?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CreateSut().SetActiveProjectAsync(projectId));
+    }
+
+    [Fact]
+    public async Task SetActiveProjectAsync_NoCurrentlyActive_ActivatesTargetAndSaves()
+    {
+        var authorId = Guid.NewGuid();
+        var project = Project.Create("My Book", "/path", authorId, "uuid-1");
+        _projectRepo.Setup(r => r.GetByIdAsync(project.Id, default)).ReturnsAsync(project);
+        _projectRepo.Setup(r => r.GetReaderActiveProjectAsync(default)).ReturnsAsync((Project?)null);
+
+        await CreateSut().SetActiveProjectAsync(project.Id);
+
+        Assert.True(project.IsReaderActive);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task SetActiveProjectAsync_DifferentProjectCurrentlyActive_DeactivatesCurrentAndActivatesTarget()
+    {
+        var authorId = Guid.NewGuid();
+        var current = Project.Create("Current", "/c", authorId, "uuid-c");
+        current.ActivateForReaders();
+        var next = Project.Create("Next", "/n", authorId, "uuid-n");
+
+        _projectRepo.Setup(r => r.GetByIdAsync(next.Id, default)).ReturnsAsync(next);
+        _projectRepo.Setup(r => r.GetReaderActiveProjectAsync(default)).ReturnsAsync(current);
+
+        await CreateSut().SetActiveProjectAsync(next.Id);
+
+        Assert.False(current.IsReaderActive);
+        Assert.True(next.IsReaderActive);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task SetActiveProjectAsync_SameProjectAlreadyActive_JustActivatesAndSaves()
+    {
+        var authorId = Guid.NewGuid();
+        var project = Project.Create("Book", "/path", authorId, "uuid");
+        project.ActivateForReaders();
+
+        _projectRepo.Setup(r => r.GetByIdAsync(project.Id, default)).ReturnsAsync(project);
+        _projectRepo.Setup(r => r.GetReaderActiveProjectAsync(default)).ReturnsAsync(project);
+
+        await CreateSut().SetActiveProjectAsync(project.Id);
+
+        Assert.True(project.IsReaderActive);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    // -----------------------------------------------------------------------
+    // DeactivateProjectAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task DeactivateProjectAsync_ProjectNotFound_ThrowsInvalidOperationException()
+    {
+        var projectId = Guid.NewGuid();
+        _projectRepo.Setup(r => r.GetByIdAsync(projectId, default)).ReturnsAsync((Project?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CreateSut().DeactivateProjectAsync(projectId));
+    }
+
+    [Fact]
+    public async Task DeactivateProjectAsync_ProjectFound_DeactivatesAndSaves()
+    {
+        var authorId = Guid.NewGuid();
+        var project = Project.Create("My Book", "/path", authorId, "uuid-1");
+        project.ActivateForReaders();
+        _projectRepo.Setup(r => r.GetByIdAsync(project.Id, default)).ReturnsAsync(project);
+
+        await CreateSut().DeactivateProjectAsync(project.Id);
+
+        Assert.False(project.IsReaderActive);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    // -----------------------------------------------------------------------
+    // SoftDeleteProjectAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SoftDeleteProjectAsync_ProjectNotFound_ThrowsInvalidOperationException()
+    {
+        var projectId = Guid.NewGuid();
+        _projectRepo.Setup(r => r.GetByIdAsync(projectId, default)).ReturnsAsync((Project?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CreateSut().SoftDeleteProjectAsync(projectId));
+    }
+
+    [Fact]
+    public async Task SoftDeleteProjectAsync_ProjectFound_SoftDeletesAndSaves()
+    {
+        var authorId = Guid.NewGuid();
+        var project = Project.Create("My Book", "/path", authorId, "uuid-1");
+        _projectRepo.Setup(r => r.GetByIdAsync(project.Id, default)).ReturnsAsync(project);
+
+        await CreateSut().SoftDeleteProjectAsync(project.Id);
+
+        Assert.True(project.IsSoftDeleted);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
     [Fact]
     public async Task AddDiscoveredProjectsAsync_FirstProjectDuplicate_SecondSucceeds_NameIsSecondProject()
     {

--- a/DraftView.Application.Tests/Services/VersioningServiceTests.cs
+++ b/DraftView.Application.Tests/Services/VersioningServiceTests.cs
@@ -1041,6 +1041,58 @@ public class VersioningServiceTests
         Assert.Equal(1, added.MinorVersion);
     }
 
+    // -----------------------------------------------------------------------
+    // DeleteVersionAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task DeleteVersionAsync_VersionIsLatest_ThrowsInvariantViolationException()
+    {
+        var projectId = Guid.NewGuid();
+        var section   = MakeDocument(projectId, null);
+        var version1  = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
+        var version2  = SectionVersion.Create(section, Guid.NewGuid(), 2, 1, 1);
+
+        _versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, default))
+            .ReturnsAsync([version1, version2]);
+
+        await Assert.ThrowsAsync<InvariantViolationException>(
+            () => _sut.DeleteVersionAsync(version2.Id, section.Id));
+    }
+
+    [Fact]
+    public async Task DeleteVersionAsync_VersionIsLatest_DoesNotDelete()
+    {
+        var projectId = Guid.NewGuid();
+        var section   = MakeDocument(projectId, null);
+        var version1  = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
+        var version2  = SectionVersion.Create(section, Guid.NewGuid(), 2, 1, 1);
+
+        _versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, default))
+            .ReturnsAsync([version1, version2]);
+
+        try { await _sut.DeleteVersionAsync(version2.Id, section.Id); } catch { }
+
+        _versionRepo.Verify(r => r.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteVersionAsync_VersionIsOlderVersion_DeletesAndSaves()
+    {
+        var projectId = Guid.NewGuid();
+        var section   = MakeDocument(projectId, null);
+        var version1  = SectionVersion.Create(section, Guid.NewGuid(), 1, 1, 0);
+        var version2  = SectionVersion.Create(section, Guid.NewGuid(), 2, 1, 1);
+
+        _versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, default))
+            .ReturnsAsync([version1, version2]);
+
+        await _sut.DeleteVersionAsync(version1.Id, section.Id);
+
+        _versionRepo.Verify(r => r.DeleteAsync(version1.Id, default), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
     // Test helpers
     private static Section MakeChapter(Guid projectId) =>
         Section.CreateFolder(projectId, Guid.NewGuid().ToString(), "Chapter 1", null, 0);

--- a/DraftView.Application/Services/ProjectManagementService.cs
+++ b/DraftView.Application/Services/ProjectManagementService.cs
@@ -72,4 +72,41 @@ public class ProjectManagementService(
             SingleAddedProjectName = addedCount == 1 ? singleAddedProjectName : null
         };
     }
+
+    /// <summary>
+    /// Makes the specified project active for readers, deactivating the current
+    /// active project first if it differs.
+    /// </summary>
+    public async Task SetActiveProjectAsync(Guid projectId, CancellationToken ct = default)
+    {
+        var project = await projectRepo.GetByIdAsync(projectId, ct)
+            ?? throw new InvalidOperationException($"Project {projectId} not found.");
+
+        var currentlyActive = await projectRepo.GetReaderActiveProjectAsync(ct);
+        if (currentlyActive is not null && currentlyActive.Id != project.Id)
+            currentlyActive.DeactivateForReaders();
+
+        project.ActivateForReaders();
+        await unitOfWork.SaveChangesAsync(ct);
+    }
+
+    /// <summary>Deactivates the specified project for readers.</summary>
+    public async Task DeactivateProjectAsync(Guid projectId, CancellationToken ct = default)
+    {
+        var project = await projectRepo.GetByIdAsync(projectId, ct)
+            ?? throw new InvalidOperationException($"Project {projectId} not found.");
+
+        project.DeactivateForReaders();
+        await unitOfWork.SaveChangesAsync(ct);
+    }
+
+    /// <summary>Soft-deletes the specified project.</summary>
+    public async Task SoftDeleteProjectAsync(Guid projectId, CancellationToken ct = default)
+    {
+        var project = await projectRepo.GetByIdAsync(projectId, ct)
+            ?? throw new InvalidOperationException($"Project {projectId} not found.");
+
+        project.SoftDelete();
+        await unitOfWork.SaveChangesAsync(ct);
+    }
 }

--- a/DraftView.Application/Services/VersioningService.cs
+++ b/DraftView.Application/Services/VersioningService.cs
@@ -147,6 +147,23 @@ public class VersioningService(
         return ClearChapterScheduleInternalAsync(chapterId, ct);
     }
 
+    /// <summary>
+    /// Permanently deletes a single historical version.
+    /// Throws <see cref="InvariantViolationException"/> if the version is the current latest.
+    /// </summary>
+    public async Task DeleteVersionAsync(Guid versionId, Guid sectionId, CancellationToken ct = default)
+    {
+        var allVersions = await sectionVersionRepository.GetAllBySectionIdAsync(sectionId, ct);
+        var latest = allVersions.OrderByDescending(v => v.VersionNumber).FirstOrDefault();
+
+        if (latest is not null && latest.Id == versionId)
+            throw new InvariantViolationException("I-VER-DEL-LATEST",
+                "The current version cannot be deleted. Use Revoke instead.");
+
+        await sectionVersionRepository.DeleteAsync(versionId, ct);
+        await unitOfWork.SaveChangesAsync(ct);
+    }
+
     private async Task ScheduleChapterInternalAsync(Guid chapterId, DateTime scheduledAt, CancellationToken ct)
     {
         var chapter = await LoadAndValidateChapterAsync(chapterId, ct);

--- a/DraftView.Domain/Interfaces/Services/IProjectManagementService.cs
+++ b/DraftView.Domain/Interfaces/Services/IProjectManagementService.cs
@@ -22,4 +22,23 @@ public interface IProjectManagementService
     /// </summary>
     Task<AddDiscoveredProjectsResultDto> AddDiscoveredProjectsAsync(
         IReadOnlyList<string> selectedUuids, Guid authorId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Makes <paramref name="projectId"/> the active project for readers,
+    /// atomically deactivating the currently-active project if it differs.
+    /// Throws <see cref="InvalidOperationException"/> if the project does not exist.
+    /// </summary>
+    Task SetActiveProjectAsync(Guid projectId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deactivates the specified project for readers.
+    /// Throws <see cref="InvalidOperationException"/> if the project does not exist.
+    /// </summary>
+    Task DeactivateProjectAsync(Guid projectId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Soft-deletes the specified project so it no longer appears in the author's project list.
+    /// Throws <see cref="InvalidOperationException"/> if the project does not exist.
+    /// </summary>
+    Task SoftDeleteProjectAsync(Guid projectId, CancellationToken ct = default);
 }

--- a/DraftView.Domain/Interfaces/Services/IVersioningService.cs
+++ b/DraftView.Domain/Interfaces/Services/IVersioningService.cs
@@ -68,4 +68,12 @@ public interface IVersioningService
     /// </summary>
     Task ClearScheduleAsync(Guid chapterId, Guid authorId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Permanently deletes a single historical version.
+    /// Throws <see cref="DraftView.Domain.Exceptions.InvariantViolationException"/> if
+    /// <paramref name="versionId"/> is the current (latest) version for <paramref name="sectionId"/> —
+    /// use <see cref="RevokeLatestVersionAsync"/> instead.
+    /// </summary>
+    Task DeleteVersionAsync(Guid versionId, Guid sectionId, CancellationToken ct = default);
 }

--- a/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
@@ -380,55 +380,58 @@ public class AuthorControllerTests
     }
 
     [Fact]
-    public async Task ActivateProject_DeactivatesExistingActiveProject_WhenDifferentProjectIsActivated()
+    public async Task ActivateProject_CallsSetActiveProjectAsync_AndRedirectsToDashboard()
     {
-        var author = User.Create("author@example.test", "Author", Role.Author);
-        var activeProject = Project.Create("Old Project", "/Apps/Scrivener/Old", author.Id, "sync-root-old");
-        var newProject = Project.Create("New Project", "/Apps/Scrivener/New", author.Id, "sync-root-new");
-        activeProject.ActivateForReaders();
+        var projectId = Guid.NewGuid();
         var sut = CreateSut();
         sut.TempData = new TempDataDictionary(sut.HttpContext, Mock.Of<ITempDataProvider>());
 
-        userRepo.Setup(r => r.GetByEmailAsync("author@example.test", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(author);
-        projectRepo.Setup(r => r.GetByIdAsync(newProject.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(newProject);
-        projectRepo.Setup(r => r.GetReaderActiveProjectAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(activeProject);
+        var result = await sut.ActivateProject(projectId);
 
-        var result = await sut.ActivateProject(newProject.Id);
-
+        projectManagementService.Verify(s => s.SetActiveProjectAsync(projectId, It.IsAny<CancellationToken>()), Times.Once);
         var redirect = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal("Dashboard", redirect.ActionName);
-        Assert.False(activeProject.IsReaderActive);
-        Assert.True(newProject.IsReaderActive);
-        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task ActivateProject_DoesNotDeactivate_WhenActivatingAlreadyActiveProject()
+    public async Task ActivateProject_SetsSuccessTempData_WhenServiceSucceeds()
     {
-        var author = User.Create("author@example.test", "Author", Role.Author);
-        var project = Project.Create("Project", "/Apps/Scrivener/Project", author.Id, "sync-root");
-        project.ActivateForReaders();
-        var originalActivatedAt = project.ReaderActivatedAt;
+        var projectId = Guid.NewGuid();
         var sut = CreateSut();
         sut.TempData = new TempDataDictionary(sut.HttpContext, Mock.Of<ITempDataProvider>());
 
-        userRepo.Setup(r => r.GetByEmailAsync("author@example.test", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(author);
-        projectRepo.Setup(r => r.GetByIdAsync(project.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(project);
-        projectRepo.Setup(r => r.GetReaderActiveProjectAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(project);
+        await sut.ActivateProject(projectId);
 
-        var result = await sut.ActivateProject(project.Id);
+        Assert.Equal("Project activated for readers.", sut.TempData["Success"]);
+    }
 
+    [Fact]
+    public async Task ActivateProject_SetsErrorTempData_WhenServiceThrows()
+    {
+        var projectId = Guid.NewGuid();
+        projectManagementService
+            .Setup(s => s.SetActiveProjectAsync(projectId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Project not found."));
+        var sut = CreateSut();
+        sut.TempData = new TempDataDictionary(sut.HttpContext, Mock.Of<ITempDataProvider>());
+
+        await sut.ActivateProject(projectId);
+
+        Assert.Equal("Project not found.", sut.TempData["Error"]);
+    }
+
+    [Fact]
+    public async Task DeactivateProject_CallsDeactivateProjectAsync_AndRedirectsToDashboard()
+    {
+        var projectId = Guid.NewGuid();
+        var sut = CreateSut();
+        sut.TempData = new TempDataDictionary(sut.HttpContext, Mock.Of<ITempDataProvider>());
+
+        var result = await sut.DeactivateProject(projectId);
+
+        projectManagementService.Verify(s => s.DeactivateProjectAsync(projectId, It.IsAny<CancellationToken>()), Times.Once);
         var redirect = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal("Dashboard", redirect.ActionName);
-        Assert.True(project.IsReaderActive);
-        Assert.NotNull(project.ReaderActivatedAt);
-        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -673,62 +676,42 @@ public class AuthorControllerTests
     }
 
     [Fact]
-    public async Task DeleteVersion_WhenDeletingLatestVersion_SetsErrorAndDoesNotDelete()
+    public async Task DeleteVersion_CallsVersioningServiceDeleteVersionAsync()
     {
         var author = User.Create("author@example.test", "Author", Role.Author);
-        var section = Section.CreateDocument(
-            Guid.NewGuid(),
-            Guid.NewGuid().ToString(),
-            "Scene 1",
-            null,
-            0,
-            "<p>content</p>",
-            "hash",
-            null);
-        var version1 = SectionVersion.Create(section, author.Id, 1, 1, 0);
-        var version2 = SectionVersion.Create(section, author.Id, 2, 1, 0);
+        var versionId = Guid.NewGuid();
+        var sectionId = Guid.NewGuid();
         var sut = CreateSut();
         sut.TempData = new TempDataDictionary(sut.HttpContext, Mock.Of<ITempDataProvider>());
 
         userRepo.Setup(r => r.GetByEmailAsync("author@example.test", It.IsAny<CancellationToken>()))
             .ReturnsAsync(author);
-        sectionVersionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([version1, version2]);
 
-        await sut.DeleteVersion(version2.Id, section.Id, Guid.NewGuid());
+        await sut.DeleteVersion(versionId, sectionId, Guid.NewGuid());
 
-        Assert.Equal("The current version cannot be deleted. Use Revoke instead.", sut.TempData["Error"]);
-        sectionVersionRepo.Verify(r => r.DeleteAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        versioningService.Verify(v => v.DeleteVersionAsync(versionId, sectionId, It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal("Version deleted.", sut.TempData["Success"]);
     }
 
     [Fact]
-    public async Task DeleteVersion_WhenDeletingOlderVersion_DeletesAndSaves()
+    public async Task DeleteVersion_WhenServiceThrowsInvariantViolation_SetsErrorMessage()
     {
         var author = User.Create("author@example.test", "Author", Role.Author);
-        var section = Section.CreateDocument(
-            Guid.NewGuid(),
-            Guid.NewGuid().ToString(),
-            "Scene 1",
-            null,
-            0,
-            "<p>content</p>",
-            "hash",
-            null);
-        var version1 = SectionVersion.Create(section, author.Id, 1, 1, 0);
-        var version2 = SectionVersion.Create(section, author.Id, 2, 1, 0);
+        var versionId = Guid.NewGuid();
+        var sectionId = Guid.NewGuid();
         var sut = CreateSut();
         sut.TempData = new TempDataDictionary(sut.HttpContext, Mock.Of<ITempDataProvider>());
 
         userRepo.Setup(r => r.GetByEmailAsync("author@example.test", It.IsAny<CancellationToken>()))
             .ReturnsAsync(author);
-        sectionVersionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([version1, version2]);
+        versioningService
+            .Setup(v => v.DeleteVersionAsync(versionId, sectionId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvariantViolationException(
+                "I-VER-DEL-LATEST", "The current version cannot be deleted. Use Revoke instead."));
 
-        await sut.DeleteVersion(version1.Id, section.Id, Guid.NewGuid());
+        await sut.DeleteVersion(versionId, sectionId, Guid.NewGuid());
 
-        Assert.Equal("Version deleted.", sut.TempData["Success"]);
-        sectionVersionRepo.Verify(r => r.DeleteAsync(version1.Id, It.IsAny<CancellationToken>()), Times.Once);
-        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal("The current version cannot be deleted. Use Revoke instead.", sut.TempData["Error"]);
     }
 
     // -----------------------------------------------------------------------

--- a/DraftView.Web/Controllers/AuthorController.cs
+++ b/DraftView.Web/Controllers/AuthorController.cs
@@ -132,17 +132,15 @@ public class AuthorController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ActivateProject(Guid projectId)
     {
-        var project = await projectRepo.GetByIdAsync(projectId);
-        if (project is null) return NotFound();
-
-        var currentlyActiveProject = await projectRepo.GetReaderActiveProjectAsync();
-        if (currentlyActiveProject is not null && currentlyActiveProject.Id != project.Id)
-            currentlyActiveProject.DeactivateForReaders();
-
-        project.ActivateForReaders();
-        await GetUnitOfWork().SaveChangesAsync();
-
-        TempData["Success"] = $"{project.Name} is now active for readers.";
+        try
+        {
+            await projectManagementService.SetActiveProjectAsync(projectId);
+            TempData["Success"] = "Project activated for readers.";
+        }
+        catch (Exception ex)
+        {
+            TempData["Error"] = ex.Message;
+        }
         return RedirectToAction("Dashboard");
     }
 
@@ -150,13 +148,15 @@ public class AuthorController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeactivateProject(Guid projectId)
     {
-        var project = await projectRepo.GetByIdAsync(projectId);
-        if (project is null) return NotFound();
-
-        project.DeactivateForReaders();
-        await GetUnitOfWork().SaveChangesAsync();
-
-        TempData["Success"] = $"{project.Name} is now inactive for readers.";
+        try
+        {
+            await projectManagementService.DeactivateProjectAsync(projectId);
+            TempData["Success"] = "Project deactivated for readers.";
+        }
+        catch (Exception ex)
+        {
+            TempData["Error"] = ex.Message;
+        }
         return RedirectToAction("Dashboard");
     }
 
@@ -530,17 +530,12 @@ public class AuthorController(
 
         try
         {
-            var allVersions = await sectionVersionRepo.GetAllBySectionIdAsync(sectionId);
-            var latest = allVersions.OrderByDescending(v => v.VersionNumber).FirstOrDefault();
-            if (latest is not null && latest.Id == versionId)
-            {
-                TempData["Error"] = "The current version cannot be deleted. Use Revoke instead.";
-                return Redirect(Url.Action("Publishing", new { projectId }) + "#section-" + sectionId);
-            }
-
-            await sectionVersionRepo.DeleteAsync(versionId);
-            await GetUnitOfWork().SaveChangesAsync();
+            await versioningService.DeleteVersionAsync(versionId, sectionId);
             TempData["Success"] = "Version deleted.";
+        }
+        catch (InvariantViolationException ex)
+        {
+            TempData["Error"] = ex.Message;
         }
         catch (Exception ex)
         {
@@ -849,13 +844,15 @@ public class AuthorController(
         var (author, error) = await RequireCurrentAuthorAsync();
         if (error is not null || author is null) return error ?? Forbid();
 
-        var project = await projectRepo.GetByIdAsync(projectId);
-        if (project is null) return NotFound();
-
-        project.SoftDelete();
-        await GetUnitOfWork().SaveChangesAsync();
-
-        TempData["Success"] = $"{project.Name} removed. You can re-add it from Add Project.";
+        try
+        {
+            await projectManagementService.SoftDeleteProjectAsync(projectId);
+            TempData["Success"] = "Project removed. You can re-add it from Add Project.";
+        }
+        catch (Exception ex)
+        {
+            TempData["Error"] = ex.Message;
+        }
         return RedirectToAction("Dashboard");
     }
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -22,9 +22,8 @@ Last deployed: 2026-08-17 13:59 (commit: d51d201)
 | MT-Sprint Series | 🔴 HIGH PRIORITY — second author interest accelerates timeline; see `MultiTenancy.md` |
 | RD-Sprint Series | 🟡 In progress — RD-Sprint-1 (Continue Reading CTA) merged to main 2026-08-17; see section 3.7 |
 | DR-Sprint Series | ✅ Complete — merged to main 2026-08-17; see section 3.8 |
-| Incremental Refactor | 🟡 In progress — Phase 2a complete, Phase 2b partial; see section 3.6 |
+| Incremental Refactor | 🟡 In progress — Phase 2a and 2b complete, Phase 2c next; see section 3.6 |
 | MU-Sprint Series | 🔵 Pre-implementation — design complete; see section 3.10 |
-| Incremental Refactor (3.6) | 🟡 In progress — Phase 2a complete (PR #31), Phase 2b in progress (PR #37); see section 3.6 |
 | Go-Live Prerequisites | 🔴 Blocking — items below must complete before launch |
 | UAT | 🟡 In progress |
 
@@ -211,18 +210,18 @@ S-Sprint-1 complete — see `HISTORY.md`.
 ### 3.6 Incremental Refactor Roadmap
 See `REFACTORING.md` for full detail. Phase 1 complete — see `HISTORY.md`.
 
-**Status:** 🟡 In progress — Phase 2a complete (PR #31, 2026-08-17), Phase 2b partial (PR #37 merged 2026-08-18 — ISyncOrchestrationService done, ProjectManagementService Task.Run extraction outstanding). Web layer review identified ~530 lines of business logic violations — see `Web-Layer-Business-Logic-Review.md` for full detail.
+**Status:** 🟡 In progress — Phase 2a and 2b complete (PRs #31, #37, #39 merged 2026-08-17/18). Phase 2c next. Web layer review identified ~530 lines of business logic violations — see `Web-Layer-Business-Logic-Review.md` for full detail.
 
-**Current Focus:** Phase 2b — Standardize Background Sync (Web Layer Business Logic Extraction, replaces original Phase 2)
+**Current Focus:** Phase 2c — Extract Domain Mutations
 
 - [x] **Phase 2a — Extract Critical Controller Orchestration** ✅ Complete (merged PR #31)
   - [x] Create `ISectionManagementService.GetSectionsSummaryAsync(projectId)` — extracted from `AuthorController.Sections`
   - [x] Create `IProjectManagementService.AddDiscoveredProjectsAsync(selectedUuids, authorId)` — extracted from `AuthorController.AddProjects`
   - [x] Create `ICommentDisplayService.GetCommentDisplayDataAsync(...)` — extracted from `BaseReaderController.BuildCommentDisplayModelsAsync`
   - [x] Full TDD: failing tests → implementation → zero regressions
-- [ ] **Phase 2b — Standardize Background Sync**
+- [x] **Phase 2b — Standardize Background Sync** ✅ Complete (merged PRs #37, #39)
   - [x] Create `ISyncOrchestrationService.StartSyncAsync(projectId)` — extracted from `AuthorController.Sync`; dead `ISyncService` and `IServiceScopeFactory` constructor params removed from controller
-  - [ ] Remove inline `Task.Run` from `ProjectManagementService.StartBackgroundSync` — use `ISyncOrchestrationService`
+  - [x] Remove inline `Task.Run` from `ProjectManagementService.StartBackgroundSync` — delegates to `ISyncOrchestrationService`; dead `IServiceScopeFactory` and `ILogger` constructor params removed
 - [ ] **Phase 2c — Extract Domain Mutations**
   - [ ] Move project activation/deactivation to `IProjectManagementService`
   - [ ] Move version deletion rules to `IVersioningService`


### PR DESCRIPTION
## Summary

Completes Phase 2c of the Incremental Refactor Roadmap (issue #3-6), plus a TASKS.md documentation update marking Phase 2b complete.

### Phase 2c — Extract Domain Mutations

Moves project activation/deactivation, project soft-delete, and version deletion out of `AuthorController` and into their respective Application services. After this PR, `ActivateProject`, `DeactivateProject`, `DeleteVersion`, and `RemoveProject` contain no domain mutations, direct repository calls, or `IUnitOfWork.SaveChangesAsync` calls of their own.

**New service methods:**

`IProjectManagementService`:
- `SetActiveProjectAsync(Guid projectId)` — atomically deactivates the current active project (if different) and activates the target; throws `InvalidOperationException` if not found
- `DeactivateProjectAsync(Guid projectId)` — deactivates a project for readers
- `SoftDeleteProjectAsync(Guid projectId)` — soft-deletes a project

`IVersioningService`:
- `DeleteVersionAsync(Guid versionId, Guid sectionId)` — permanently deletes a historical version; throws `InvariantViolationException` if the version is the current latest (business rule moved from controller to service)

**Controller changes:** `ActivateProject`, `DeactivateProject`, `DeleteVersion`, `RemoveProject` are now simple try/catch delegations with no domain logic.

**New tests:**
- `ProjectManagementServiceTests` — 8 new tests for `SetActiveProjectAsync`, `DeactivateProjectAsync`, `SoftDeleteProjectAsync`
- `VersioningServiceTests` — 3 new tests for `DeleteVersionAsync`
- `AuthorControllerTests` — old entity-state tests replaced with service-delegation tests

### TASKS.md update

Marks Phase 2b fully complete (PRs #37, #39 merged) and removes a duplicate stale Active Work table row.

## Test plan

- [ ] `dotnet test --filter ProjectManagementServiceTests` — all 15 tests green
- [ ] `dotnet test --filter VersioningServiceTests` — all tests green including 3 new
- [ ] `dotnet test --filter AuthorControllerTests` — all tests green
- [ ] `dotnet test` — full suite green

> **Note (cloud execution):** `dotnet` is not available in this remote session. Local validation required before merge.