### PR TITLE
refactor: extract helper orchestration from AuthorController (Phase 2d)

### DIFF
--- a/DraftView.Application.Tests/Services/ContentNavigationServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ContentNavigationServiceTests.cs
@@ -1,0 +1,180 @@
+using Moq;
+using DraftView.Application.Services;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+using Microsoft.Extensions.Configuration;
+
+namespace DraftView.Application.Tests.Services;
+
+/// <summary>
+/// Tests for ContentNavigationService.BuildPublishingChapterDataAsync.
+/// Covers: empty project, published leaf chapter detection, document inclusion,
+/// version history at retention limit, classification tolerance, soft-deleted exclusion.
+/// Excludes: EF Core persistence, controller mapping, subscription-tier enforcement.
+/// </summary>
+public class ContentNavigationServiceTests
+{
+    private readonly Mock<ISectionRepository>          _sectionRepo          = new();
+    private readonly Mock<ISectionVersionRepository>   _sectionVersionRepo   = new();
+    private readonly Mock<IHtmlDiffService>            _htmlDiffService      = new();
+    private readonly Mock<IChangeClassificationService> _classificationService = new();
+    private readonly Mock<IConfiguration>              _configuration        = new();
+
+    private ContentNavigationService CreateSut() => new(
+        _sectionRepo.Object,
+        _sectionVersionRepo.Object,
+        _htmlDiffService.Object,
+        _classificationService.Object,
+        _configuration.Object);
+
+    private void SetupNoVersions(Guid documentId)
+    {
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(documentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SectionVersion?)null);
+    }
+
+    [Fact]
+    public async Task BuildPublishingChapterDataAsync_NoSections_ReturnsEmpty()
+    {
+        var projectId = Guid.NewGuid();
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task BuildPublishingChapterDataAsync_UnpublishedChapter_ReturnsEmpty()
+    {
+        var projectId = Guid.NewGuid();
+        var chapter = Section.CreateFolder(projectId, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
+
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([chapter]);
+
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task BuildPublishingChapterDataAsync_PublishedChapterWithDocument_ReturnsOneChapter()
+    {
+        var authorId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var chapter = Section.CreateFolder(projectId, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
+        chapter.MarkAsPublishedContainer();
+        var document = Section.CreateDocument(projectId, Guid.NewGuid().ToString(), "Scene 1",
+            chapter.Id, 0, "<p>text</p>", "hash", null);
+
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([chapter, document]);
+        SetupNoVersions(document.Id);
+
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+
+        var chapterData = Assert.Single(result);
+        Assert.Equal(chapter.Id, chapterData.Chapter.Id);
+        Assert.Single(chapterData.Documents);
+        Assert.Equal(document.Id, chapterData.Documents[0].Document.Id);
+    }
+
+    [Fact]
+    public async Task BuildPublishingChapterDataAsync_SoftDeletedDocument_IsExcluded()
+    {
+        var projectId = Guid.NewGuid();
+        var chapter = Section.CreateFolder(projectId, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
+        chapter.MarkAsPublishedContainer();
+        var document = Section.CreateDocument(projectId, Guid.NewGuid().ToString(), "Scene 1",
+            chapter.Id, 0, "<p>text</p>", "hash", null);
+        document.SoftDelete();
+
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([chapter, document]);
+
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+
+        var chapterData = Assert.Single(result);
+        Assert.Empty(chapterData.Documents);
+    }
+
+    [Fact]
+    public async Task BuildPublishingChapterDataAsync_AtRetentionLimit_ShowsVersionHistory()
+    {
+        var authorId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var chapter = Section.CreateFolder(projectId, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
+        chapter.MarkAsPublishedContainer();
+        var document = Section.CreateDocument(projectId, Guid.NewGuid().ToString(), "Scene 1",
+            chapter.Id, 0, "<p>text</p>", "hash", null);
+
+        var v1 = SectionVersion.Create(document, authorId, 1, 1, 0);
+        var v2 = SectionVersion.Create(document, authorId, 2, 1, 1);
+        var v3 = SectionVersion.Create(document, authorId, 3, 1, 2);
+
+        _configuration.Setup(c => c["DraftView:SubscriptionTier"]).Returns("Free");
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([chapter, document]);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(document.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(v3);
+        _sectionVersionRepo.Setup(r => r.GetAllBySectionIdAsync(document.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([v1, v2, v3]);
+
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+
+        var docData = Assert.Single(result[0].Documents);
+        Assert.True(docData.ShowVersionHistory);
+        Assert.Equal(3, docData.VersionHistory.Count);
+        Assert.False(docData.VersionHistory.First(v => v.VersionNumber == 3).CanDelete);
+        Assert.True(docData.VersionHistory.First(v => v.VersionNumber == 2).CanDelete);
+    }
+
+    [Fact]
+    public async Task BuildPublishingChapterDataAsync_ClassificationException_DoesNotPropagate()
+    {
+        var authorId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var chapter = Section.CreateFolder(projectId, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
+        chapter.MarkAsPublishedContainer();
+        var document = Section.CreateDocument(projectId, Guid.NewGuid().ToString(), "Scene 1",
+            chapter.Id, 0, "<p>new</p>", "hash", null);
+
+        var latestVersion = SectionVersion.Create(document, authorId, 1, 1, 0);
+
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([chapter, document]);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(document.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+        _sectionVersionRepo.Setup(r => r.GetAllBySectionIdAsync(document.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([latestVersion]);
+        _htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new InvalidOperationException("diff failure"));
+
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+
+        var docData = Assert.Single(result[0].Documents);
+        Assert.Null(docData.Classification);
+    }
+
+    [Fact]
+    public async Task BuildPublishingChapterDataAsync_ManualProject_ShowsDocumentControls()
+    {
+        var projectId = Guid.NewGuid();
+        var chapter = Section.CreateFolder(projectId, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
+        chapter.MarkAsPublishedContainer();
+        var document = Section.CreateDocument(projectId, Guid.NewGuid().ToString(), "Scene 1",
+            chapter.Id, 0, "<p>text</p>", "hash", null);
+
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([chapter, document]);
+        SetupNoVersions(document.Id);
+
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Manual);
+
+        Assert.True(result[0].ShowDocumentControls);
+    }
+}

--- a/DraftView.Application.Tests/Services/ReaderManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderManagementServiceTests.cs
@@ -1,0 +1,122 @@
+using Moq;
+using DraftView.Application.Services;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+
+namespace DraftView.Application.Tests.Services;
+
+/// <summary>
+/// Tests for ReaderManagementService.GetReaderSummaryAsync.
+/// Covers: soft-deleted exclusion, status derivation (Active/Invited/Inactive),
+/// display name defaulting, alphabetical ordering.
+/// Excludes: EF Core persistence, invitation issuance, reader deactivation.
+/// </summary>
+public class ReaderManagementServiceTests
+{
+    private readonly Mock<IUserRepository>       _userRepo       = new();
+    private readonly Mock<IInvitationRepository> _invitationRepo = new();
+
+    private ReaderManagementService CreateSut() => new(
+        _userRepo.Object,
+        _invitationRepo.Object);
+
+    private void SetupNoPendingInvitations(Guid userId)
+    {
+        _invitationRepo.Setup(r => r.GetPendingByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+    }
+
+    [Fact]
+    public async Task GetReaderSummaryAsync_SoftDeletedReader_IsExcluded()
+    {
+        var reader = User.Create("reader@example.test", "Alice", Role.BetaReader);
+        reader.SoftDelete();
+
+        _userRepo.Setup(r => r.GetAllBetaReadersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([reader]);
+
+        var result = await CreateSut().GetReaderSummaryAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetReaderSummaryAsync_ActiveReader_GetsActiveStatus()
+    {
+        var reader = User.Create("reader@example.test", "Alice", Role.BetaReader);
+        reader.Activate();
+
+        _userRepo.Setup(r => r.GetAllBetaReadersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([reader]);
+        SetupNoPendingInvitations(reader.Id);
+
+        var result = await CreateSut().GetReaderSummaryAsync();
+
+        Assert.Equal(ReaderStatus.Active, Assert.Single(result).Status);
+    }
+
+    [Fact]
+    public async Task GetReaderSummaryAsync_InactiveReaderWithPendingInvitation_GetsInvitedStatus()
+    {
+        var reader = User.Create("reader@example.test", "Alice", Role.BetaReader);
+        var invitation = Invitation.CreateAlwaysOpen(reader.Id);
+
+        _userRepo.Setup(r => r.GetAllBetaReadersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([reader]);
+        _invitationRepo.Setup(r => r.GetPendingByUserIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([invitation]);
+
+        var result = await CreateSut().GetReaderSummaryAsync();
+
+        Assert.Equal(ReaderStatus.Invited, Assert.Single(result).Status);
+        Assert.True(result[0].HasPendingInvitation);
+    }
+
+    [Fact]
+    public async Task GetReaderSummaryAsync_InactiveReaderWithNoPendingInvitation_GetsInactiveStatus()
+    {
+        var reader = User.Create("reader@example.test", "Alice", Role.BetaReader);
+
+        _userRepo.Setup(r => r.GetAllBetaReadersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([reader]);
+        SetupNoPendingInvitations(reader.Id);
+
+        var result = await CreateSut().GetReaderSummaryAsync();
+
+        Assert.Equal(ReaderStatus.Inactive, Assert.Single(result).Status);
+        Assert.False(result[0].HasPendingInvitation);
+    }
+
+    [Fact]
+    public async Task GetReaderSummaryAsync_BlankDisplayName_DefaultsToPendingReader()
+    {
+        var reader = User.Create("reader@example.test", string.Empty, Role.BetaReader);
+
+        _userRepo.Setup(r => r.GetAllBetaReadersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([reader]);
+        SetupNoPendingInvitations(reader.Id);
+
+        var result = await CreateSut().GetReaderSummaryAsync();
+
+        Assert.Equal("Pending reader", result[0].DisplayName);
+    }
+
+    [Fact]
+    public async Task GetReaderSummaryAsync_MultipleReaders_OrderedByDisplayName()
+    {
+        var charlie = User.Create("c@example.test", "Charlie", Role.BetaReader);
+        var alice   = User.Create("a@example.test", "Alice",   Role.BetaReader);
+        var bob     = User.Create("b@example.test", "Bob",     Role.BetaReader);
+
+        _userRepo.Setup(r => r.GetAllBetaReadersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([charlie, alice, bob]);
+        SetupNoPendingInvitations(charlie.Id);
+        SetupNoPendingInvitations(alice.Id);
+        SetupNoPendingInvitations(bob.Id);
+
+        var result = await CreateSut().GetReaderSummaryAsync();
+
+        Assert.Equal(["Alice", "Bob", "Charlie"], result.Select(r => r.DisplayName));
+    }
+}

--- a/DraftView.Application/Services/ContentNavigationService.cs
+++ b/DraftView.Application/Services/ContentNavigationService.cs
@@ -1,0 +1,196 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+using DraftView.Domain.Policies;
+using Microsoft.Extensions.Configuration;
+
+namespace DraftView.Application.Services;
+
+/// <summary>
+/// Builds the chapter and document data for the Publishing page by loading sections,
+/// traversing the tree depth-first, and enriching each document with version history
+/// and advisory change-classification metadata.
+/// </summary>
+public class ContentNavigationService(
+    ISectionRepository sectionRepository,
+    ISectionVersionRepository sectionVersionRepository,
+    IHtmlDiffService htmlDiffService,
+    IChangeClassificationService changeClassificationService,
+    IConfiguration configuration) : IContentNavigationService
+{
+    /// <summary>
+    /// Loads all sections for the project, identifies published leaf chapters, and returns
+    /// their documents with version and classification data. Returns an empty list when no
+    /// published leaf chapters exist.
+    /// </summary>
+    public async Task<IReadOnlyList<PublishingChapterData>> BuildPublishingChapterDataAsync(
+        Guid projectId, ProjectType projectType, CancellationToken ct = default)
+    {
+        var sections = await sectionRepository.GetByProjectIdAsync(projectId, ct);
+        var sorted = SortDepthFirst(sections);
+
+        var chapters = new List<PublishingChapterData>();
+        foreach (var chapter in GetPublishedLeafChapters(sorted))
+            chapters.Add(await BuildChapterDataAsync(chapter, sorted, projectType, ct));
+
+        return chapters;
+    }
+
+    /// <summary>
+    /// Builds document data for each direct Document child of the chapter, then aggregates
+    /// has-changes and highest classification across all documents in the chapter.
+    /// </summary>
+    private async Task<PublishingChapterData> BuildChapterDataAsync(
+        Section chapter,
+        IReadOnlyList<(Section Section, int Depth)> sorted,
+        ProjectType projectType,
+        CancellationToken ct)
+    {
+        var documents = GetPublishedDocumentsForChapter(chapter.Id, sorted);
+        var docData = new List<PublishingDocumentData>();
+        foreach (var doc in documents)
+            docData.Add(await BuildDocumentDataAsync(doc, ct));
+
+        var chapterHasChanges = documents.Any(d => d.ContentChangedSincePublish);
+        var chapterClassification = docData
+            .Where(d => d.Classification.HasValue)
+            .Select(d => d.Classification)
+            .Max();
+
+        return new PublishingChapterData(
+            Chapter: chapter,
+            HasChanges: chapterHasChanges,
+            Classification: chapterClassification,
+            CanRevoke: docData.Any(d => d.CanRevoke),
+            ShowDocumentControls: documents.Count > 1 || projectType == ProjectType.Manual,
+            Documents: docData);
+    }
+
+    /// <summary>
+    /// Retrieves the latest and all versions for a document section, computes retention
+    /// state, and assembles version history when the retention limit is reached.
+    /// </summary>
+    private async Task<PublishingDocumentData> BuildDocumentDataAsync(Section document, CancellationToken ct)
+    {
+        var latestVersion = await sectionVersionRepository.GetLatestAsync(document.Id, ct);
+        var allVersions = latestVersion is not null
+            ? await sectionVersionRepository.GetAllBySectionIdAsync(document.Id, ct)
+            : [];
+
+        var tier = GetSubscriptionTier();
+        var limit = VersionRetentionPolicy.GetLimit(tier);
+        var atLimit = VersionRetentionPolicy.IsAtLimit(allVersions.Count, tier);
+        var latestVersionNumber = allVersions.Any() ? allVersions.Max(v => v.VersionNumber) : 0;
+
+        var versionHistory = atLimit
+            ? allVersions
+                .OrderByDescending(v => v.VersionNumber)
+                .Select(v => new VersionHistoryData(
+                    VersionId: v.Id,
+                    VersionNumber: v.VersionNumber,
+                    VersionLabel: v.VersionLabel,
+                    CreatedAt: v.CreatedAt,
+                    Classification: v.ChangeClassification,
+                    CanDelete: v.VersionNumber != latestVersionNumber))
+                .ToList()
+            : (IReadOnlyList<VersionHistoryData>)[];
+
+        return new PublishingDocumentData(
+            Document: document,
+            CurrentVersionNumber: latestVersion?.VersionNumber,
+            CurrentVersionLabel: latestVersion?.VersionLabel,
+            HasChanges: document.ContentChangedSincePublish,
+            Classification: TryClassifyDocumentChanges(document, latestVersion),
+            CanRevoke: allVersions.Count > 1,
+            VersionHistory: versionHistory,
+            ShowVersionHistory: atLimit,
+            RetentionLimit: limit);
+    }
+
+    private SubscriptionTier GetSubscriptionTier()
+    {
+        var raw = configuration["DraftView:SubscriptionTier"];
+        return Enum.TryParse<SubscriptionTier>(raw, ignoreCase: true, out var tier)
+            ? tier
+            : SubscriptionTier.Free;
+    }
+
+    private ChangeClassification? TryClassifyDocumentChanges(Section document, SectionVersion? latestVersion)
+    {
+        if (latestVersion is null || !document.ContentChangedSincePublish)
+            return null;
+
+        try
+        {
+            var diff = htmlDiffService.Compute(latestVersion.HtmlContent, document.HtmlContent ?? string.Empty);
+            return changeClassificationService.Classify(diff);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static IReadOnlyList<Section> GetPublishedLeafChapters(
+        IReadOnlyList<(Section Section, int Depth)> sorted)
+    {
+        var folderChildIds = sorted
+            .Where(x => x.Section.NodeType == NodeType.Folder && x.Section.ParentId.HasValue)
+            .Select(x => x.Section.ParentId!.Value)
+            .ToHashSet();
+
+        return sorted
+            .Select(x => x.Section)
+            .Where(s => s.NodeType == NodeType.Folder &&
+                        s.IsPublished &&
+                        !folderChildIds.Contains(s.Id))
+            .ToList();
+    }
+
+    private static IReadOnlyList<Section> GetPublishedDocumentsForChapter(
+        Guid chapterId,
+        IReadOnlyList<(Section Section, int Depth)> sorted) =>
+        sorted
+            .Select(x => x.Section)
+            .Where(s => s.ParentId == chapterId &&
+                        s.NodeType == NodeType.Document &&
+                        !s.IsSoftDeleted)
+            .ToList();
+
+    /// <summary>
+    /// Returns all sections in depth-first order, each paired with its indentation depth.
+    /// Children are sorted by SortOrder within their parent.
+    /// </summary>
+    private static IReadOnlyList<(Section Section, int Depth)> SortDepthFirst(
+        IReadOnlyList<Section> sections)
+    {
+        var root   = Guid.Empty;
+        var lookup = new Dictionary<Guid, List<Section>>();
+
+        foreach (var s in sections)
+        {
+            var key = s.ParentId ?? root;
+            if (!lookup.ContainsKey(key)) lookup[key] = [];
+            lookup[key].Add(s);
+        }
+
+        foreach (var key in lookup.Keys.ToList())
+            lookup[key] = [.. lookup[key].OrderBy(s => s.SortOrder)];
+
+        var result = new List<(Section, int)>();
+
+        void Walk(Guid parentId, int depth)
+        {
+            if (!lookup.TryGetValue(parentId, out var children)) return;
+            foreach (var child in children)
+            {
+                result.Add((child, depth));
+                Walk(child.Id, depth + 1);
+            }
+        }
+
+        Walk(root, 0);
+        return result;
+    }
+}

--- a/DraftView.Application/Services/ReaderManagementService.cs
+++ b/DraftView.Application/Services/ReaderManagementService.cs
@@ -1,0 +1,46 @@
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Services;
+
+/// <summary>
+/// Builds the aggregated reader summary for the author's Readers management page,
+/// resolving each reader's derived status from invitation and activation state.
+/// </summary>
+public class ReaderManagementService(
+    IUserRepository userRepository,
+    IInvitationRepository invitationRepository) : IReaderManagementService
+{
+    /// <summary>
+    /// Returns all non-soft-deleted beta readers with their derived lifecycle status,
+    /// ordered alphabetically by display name. Readers without a display name are
+    /// shown as "Pending reader".
+    /// </summary>
+    public async Task<IReadOnlyList<ReaderSummaryRow>> GetReaderSummaryAsync(CancellationToken ct = default)
+    {
+        var readers = await userRepository.GetAllBetaReadersAsync(ct);
+        var rows = new List<ReaderSummaryRow>();
+
+        foreach (var r in readers.Where(r => !r.IsSoftDeleted))
+        {
+            var pending = await invitationRepository.GetPendingByUserIdAsync(r.Id, ct);
+            var hasPending = pending.Count > 0;
+
+            var status = r.IsActive
+                ? ReaderStatus.Active
+                : hasPending
+                    ? ReaderStatus.Invited
+                    : ReaderStatus.Inactive;
+
+            rows.Add(new ReaderSummaryRow(
+                Id: r.Id,
+                DisplayName: string.IsNullOrWhiteSpace(r.DisplayName) ? "Pending reader" : r.DisplayName,
+                Status: status,
+                ActivatedAt: r.ActivatedAt,
+                HasPendingInvitation: hasPending));
+        }
+
+        return [.. rows.OrderBy(r => r.DisplayName)];
+    }
+}

--- a/DraftView.Domain/Enumerations/ReaderStatus.cs
+++ b/DraftView.Domain/Enumerations/ReaderStatus.cs
@@ -1,0 +1,4 @@
+namespace DraftView.Domain.Enumerations;
+
+/// <summary>Lifecycle status of a beta reader relative to their invitation and activation state.</summary>
+public enum ReaderStatus { Invited, Active, Inactive }

--- a/DraftView.Domain/Interfaces/Services/IContentNavigationService.cs
+++ b/DraftView.Domain/Interfaces/Services/IContentNavigationService.cs
@@ -1,0 +1,48 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+
+namespace DraftView.Domain.Interfaces.Services;
+
+/// <summary>One entry in a document's version history, shown when the retention limit is reached.</summary>
+public sealed record VersionHistoryData(
+    Guid VersionId,
+    int VersionNumber,
+    string? VersionLabel,
+    DateTime CreatedAt,
+    ChangeClassification? Classification,
+    bool CanDelete);
+
+/// <summary>Data for a single document section on the Publishing page.</summary>
+public sealed record PublishingDocumentData(
+    Section Document,
+    int? CurrentVersionNumber,
+    string? CurrentVersionLabel,
+    bool HasChanges,
+    ChangeClassification? Classification,
+    bool CanRevoke,
+    IReadOnlyList<VersionHistoryData> VersionHistory,
+    bool ShowVersionHistory,
+    int RetentionLimit);
+
+/// <summary>Data for a published leaf chapter and its document sections on the Publishing page.</summary>
+public sealed record PublishingChapterData(
+    Section Chapter,
+    bool HasChanges,
+    ChangeClassification? Classification,
+    bool CanRevoke,
+    bool ShowDocumentControls,
+    IReadOnlyList<PublishingDocumentData> Documents);
+
+/// <summary>
+/// Builds the chapter and document data required to render the Publishing page.
+/// Encapsulates depth-first tree traversal, version history retrieval, and change classification.
+/// </summary>
+public interface IContentNavigationService
+{
+    /// <summary>
+    /// Returns the ordered list of published leaf chapters and their document sections
+    /// for the given project, enriched with version and classification metadata.
+    /// </summary>
+    Task<IReadOnlyList<PublishingChapterData>> BuildPublishingChapterDataAsync(
+        Guid projectId, ProjectType projectType, CancellationToken ct = default);
+}

--- a/DraftView.Domain/Interfaces/Services/IReaderManagementService.cs
+++ b/DraftView.Domain/Interfaces/Services/IReaderManagementService.cs
@@ -1,0 +1,23 @@
+using DraftView.Domain.Enumerations;
+
+namespace DraftView.Domain.Interfaces.Services;
+
+/// <summary>Aggregated row for a single beta reader on the Readers management page.</summary>
+public sealed record ReaderSummaryRow(
+    Guid Id,
+    string DisplayName,
+    ReaderStatus Status,
+    DateTime? ActivatedAt,
+    bool HasPendingInvitation);
+
+/// <summary>
+/// Provides a summary of all beta readers for the author's Readers management page.
+/// </summary>
+public interface IReaderManagementService
+{
+    /// <summary>
+    /// Returns all non-soft-deleted beta readers with their derived status and pending
+    /// invitation state, ordered by display name.
+    /// </summary>
+    Task<IReadOnlyList<ReaderSummaryRow>> GetReaderSummaryAsync(CancellationToken ct = default);
+}

--- a/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
@@ -8,7 +8,6 @@ using DraftView.Web.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Identity;
@@ -30,14 +29,10 @@ public class AuthorControllerTests
     private readonly Mock<ISyncProgressTracker> progressTracker = new();
     private readonly Mock<ISyncOrchestrationService> syncOrchestrationService = new();
     private readonly Mock<IReaderAccessRepository> readerAccessRepo = new();
-    private readonly Mock<ISectionVersionRepository> sectionVersionRepo = new();
     private readonly Mock<IVersioningService> versioningService = new();
-    private readonly Mock<IHtmlDiffService> htmlDiffService = new();
-    private readonly Mock<IChangeClassificationService> changeClassificationService = new();
     private readonly Mock<IImportService> importService = new();
     private readonly Mock<ISectionTreeService> sectionTreeService = new();
     private readonly Mock<IUnitOfWork> unitOfWork = new();
-    private readonly Mock<IConfiguration> configuration = new();
     private readonly Mock<ILogger<AuthorController>> logger = new();
     private readonly Mock<IAccessRequestService> accessRequestService = new();
     private readonly Mock<IAccessRequestRepository> accessRequestRepo = new();
@@ -46,6 +41,8 @@ public class AuthorControllerTests
     private readonly Mock<SignInManager<IdentityUser>> signInManager;
     private readonly Mock<ISectionManagementService> sectionManagementService = new();
     private readonly Mock<IProjectManagementService> projectManagementService = new();
+    private readonly Mock<IContentNavigationService> contentNavigationService = new();
+    private readonly Mock<IReaderManagementService> readerManagementService = new();
 
     public AuthorControllerTests()
     {
@@ -65,7 +62,6 @@ public class AuthorControllerTests
         var controller = new AuthorController(
             projectRepo.Object,
             sectionRepo.Object,
-            sectionVersionRepo.Object,
             publicationService.Object,
             userService.Object,
             dashboardService.Object,
@@ -76,11 +72,8 @@ public class AuthorControllerTests
             syncOrchestrationService.Object,
             readerAccessRepo.Object,
             versioningService.Object,
-            htmlDiffService.Object,
-            changeClassificationService.Object,
             importService.Object,
             sectionTreeService.Object,
-            configuration.Object,
             logger.Object,
             accessRequestService.Object,
             accessRequestRepo.Object,
@@ -88,7 +81,9 @@ public class AuthorControllerTests
             userManager.Object,
             signInManager.Object,
             sectionManagementService.Object,
-            projectManagementService.Object);
+            projectManagementService.Object,
+            contentNavigationService.Object,
+            readerManagementService.Object);
 
         controller.ControllerContext = new ControllerContext
         {
@@ -107,7 +102,6 @@ public class AuthorControllerTests
         urlHelper.Setup(u => u.IsLocalUrl(It.IsAny<string?>())).Returns(false);
         controller.Url = urlHelper.Object;
         controller.TempData = new Mock<ITempDataDictionary>().Object;
-        configuration.Setup(c => c["DraftView:SubscriptionTier"]).Returns((string?)null);
 
         return controller;
     }
@@ -240,25 +234,34 @@ public class AuthorControllerTests
     }
 
     // ---------------------------------------------------------------------------
-    // RepublishChapter
+    // Publishing
     // ---------------------------------------------------------------------------
 
     [Fact]
-    public async Task Publishing_WhenProjectExists_ReturnsPublishingPageViewModel()
+    public async Task Publishing_WhenProjectExists_DelegatesToContentNavigationService()
     {
         var author = User.Create("author@example.test", "Author", Role.Author);
         var project = Project.Create("Project One", "/Apps/Scrivener/ProjectOne", author.Id, "sync-root");
         var chapter = Section.CreateFolder(project.Id, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
-        chapter.MarkAsPublishedContainer();
         var document = Section.CreateDocument(
-            project.Id,
-            Guid.NewGuid().ToString(),
-            "Scene 1",
-            chapter.Id,
-            0,
-            "<p>content</p>",
-            "hash",
-            null);
+            project.Id, Guid.NewGuid().ToString(), "Scene 1", chapter.Id, 0, "<p>content</p>", "hash", null);
+
+        var chapterData = new PublishingChapterData(
+            Chapter: chapter,
+            HasChanges: false,
+            Classification: null,
+            CanRevoke: false,
+            ShowDocumentControls: false,
+            Documents: [new PublishingDocumentData(
+                Document: document,
+                CurrentVersionNumber: null,
+                CurrentVersionLabel: null,
+                HasChanges: false,
+                Classification: null,
+                CanRevoke: false,
+                VersionHistory: [],
+                ShowVersionHistory: false,
+                RetentionLimit: 3)]);
 
         var sut = CreateSut();
 
@@ -266,10 +269,9 @@ public class AuthorControllerTests
             .ReturnsAsync(author);
         projectRepo.Setup(r => r.GetByIdAsync(project.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(project);
-        sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([chapter, document]);
-        sectionVersionRepo.Setup(r => r.GetLatestAsync(document.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SectionVersion?)null);
+        contentNavigationService
+            .Setup(s => s.BuildPublishingChapterDataAsync(project.Id, project.ProjectType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([chapterData]);
 
         var result = await sut.Publishing(project.Id);
 
@@ -332,39 +334,46 @@ public class AuthorControllerTests
     }
 
     [Fact]
-    public async Task Publishing_WhenAtRetentionLimit_ShowsVersionHistoryWithCurrentNotDeletable()
+    public async Task Publishing_MapsVersionHistoryFromServiceData()
     {
         var author = User.Create("author@example.test", "Author", Role.Author);
         var project = Project.Create("Project One", "/Apps/Scrivener/ProjectOne", author.Id, "sync-root");
         var chapter = Section.CreateFolder(project.Id, Guid.NewGuid().ToString(), "Chapter 1", null, 0);
-        chapter.MarkAsPublishedContainer();
         var document = Section.CreateDocument(
-            project.Id,
-            Guid.NewGuid().ToString(),
-            "Scene 1",
-            chapter.Id,
-            0,
-            "<p>content</p>",
-            "hash",
-            null);
+            project.Id, Guid.NewGuid().ToString(), "Scene 1", chapter.Id, 0, "<p>content</p>", "hash", null);
 
-        var version1 = SectionVersion.Create(document, author.Id, 1, 1, 0);
-        var version2 = SectionVersion.Create(document, author.Id, 2, 1, 0);
-        var version3 = SectionVersion.Create(document, author.Id, 3, 1, 0);
+        var v1 = new VersionHistoryData(Guid.NewGuid(), 1, null, DateTime.UtcNow, null, true);
+        var v2 = new VersionHistoryData(Guid.NewGuid(), 2, null, DateTime.UtcNow, null, true);
+        var v3 = new VersionHistoryData(Guid.NewGuid(), 3, null, DateTime.UtcNow, null, false);
+
+        var docData = new PublishingDocumentData(
+            Document: document,
+            CurrentVersionNumber: 3,
+            CurrentVersionLabel: null,
+            HasChanges: false,
+            Classification: null,
+            CanRevoke: true,
+            VersionHistory: [v1, v2, v3],
+            ShowVersionHistory: true,
+            RetentionLimit: 3);
+
+        var chapterData = new PublishingChapterData(
+            Chapter: chapter,
+            HasChanges: false,
+            Classification: null,
+            CanRevoke: true,
+            ShowDocumentControls: false,
+            Documents: [docData]);
 
         var sut = CreateSut();
 
-        configuration.Setup(c => c["DraftView:SubscriptionTier"]).Returns("Free");
         userRepo.Setup(r => r.GetByEmailAsync("author@example.test", It.IsAny<CancellationToken>()))
             .ReturnsAsync(author);
         projectRepo.Setup(r => r.GetByIdAsync(project.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(project);
-        sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([chapter, document]);
-        sectionVersionRepo.Setup(r => r.GetLatestAsync(document.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(version3);
-        sectionVersionRepo.Setup(r => r.GetAllBySectionIdAsync(document.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([version1, version2, version3]);
+        contentNavigationService
+            .Setup(s => s.BuildPublishingChapterDataAsync(project.Id, project.ProjectType, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([chapterData]);
 
         var result = await sut.Publishing(project.Id);
 
@@ -712,6 +721,34 @@ public class AuthorControllerTests
         await sut.DeleteVersion(versionId, sectionId, Guid.NewGuid());
 
         Assert.Equal("The current version cannot be deleted. Use Revoke instead.", sut.TempData["Error"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Readers
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task Readers_DelegatesToReaderManagementService_AndMapsRows()
+    {
+        var readerId = Guid.NewGuid();
+        var row = new ReaderSummaryRow(
+            Id: readerId,
+            DisplayName: "Alice",
+            Status: ReaderStatus.Active,
+            ActivatedAt: null,
+            HasPendingInvitation: false);
+
+        readerManagementService.Setup(s => s.GetReaderSummaryAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([row]);
+
+        var sut = CreateSut();
+        var result = await sut.Readers();
+
+        var view = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<List<ReaderRowViewModel>>(view.Model);
+        Assert.Single(model);
+        Assert.Equal("Alice", model[0].DisplayName);
+        Assert.Equal(ReaderStatus.Active, model[0].Status);
     }
 
     // -----------------------------------------------------------------------

--- a/DraftView.Web/Controllers/AuthorController.cs
+++ b/DraftView.Web/Controllers/AuthorController.cs
@@ -6,9 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using DraftView.Domain.Entities;
 using DraftView.Domain.Interfaces.Services;
-using DraftView.Domain.Policies;
 using DraftView.Web.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Authentication;
 using System.Security.Claims;
@@ -20,7 +18,6 @@ namespace DraftView.Web.Controllers;
 public class AuthorController(
     IProjectRepository projectRepo,
     ISectionRepository sectionRepo,
-    ISectionVersionRepository sectionVersionRepo,
     IPublicationService publicationService,
     IUserService userService,
     IDashboardService dashboardService,
@@ -31,11 +28,8 @@ public class AuthorController(
     ISyncOrchestrationService syncOrchestrationService,
     IReaderAccessRepository readerAccessRepo,
     IVersioningService versioningService,
-    IHtmlDiffService htmlDiffService,
-    IChangeClassificationService changeClassificationService,
     IImportService importService,
     ISectionTreeService sectionTreeService,
-    IConfiguration configuration,
     ILogger<AuthorController> logger,
     IAccessRequestService accessRequestService,
     IAccessRequestRepository accessRequestRepo,
@@ -43,7 +37,9 @@ public class AuthorController(
     UserManager<IdentityUser> userManager,
     SignInManager<IdentityUser> signInManager,
     ISectionManagementService sectionManagementService,
-    IProjectManagementService projectManagementService) : BaseController(userRepo)
+    IProjectManagementService projectManagementService,
+    IContentNavigationService contentNavigationService,
+    IReaderManagementService readerManagementService) : BaseController(userRepo)
 {
     // ---------------------------------------------------------------------------
     // Dashboard
@@ -346,9 +342,7 @@ public class AuthorController(
         var project = await projectRepo.GetByIdAsync(projectId);
         if (project is null) return NotFound();
 
-        var sections = await sectionRepo.GetByProjectIdAsync(projectId);
-        var sorted = SortDepthFirst(sections);
-        var chapters = await BuildPublishingChapterViewModelsAsync(sorted, project.ProjectType);
+        var chapterData = await contentNavigationService.BuildPublishingChapterDataAsync(projectId, project.ProjectType);
         var pendingCount = project.IsOpen
             ? await accessRequestRepo.GetPendingCountByProjectIdAsync(projectId)
             : 0;
@@ -356,7 +350,7 @@ public class AuthorController(
         return View(new PublishingPageViewModel
         {
             Project = project,
-            Chapters = chapters,
+            Chapters = chapterData.Select(MapChapterData).ToList(),
             PendingRequestCount = pendingCount
         });
     }
@@ -630,32 +624,16 @@ public class AuthorController(
     // ---------------------------------------------------------------------------
     public async Task<IActionResult> Readers()
     {
-        var readers = await userRepo.GetAllBetaReadersAsync();
-
-        var rows = new List<ReaderRowViewModel>();
-        foreach (var r in readers.Where(r => !r.IsSoftDeleted))
+        var rows = await readerManagementService.GetReaderSummaryAsync();
+        return View(rows.Select(r => new ReaderRowViewModel
         {
-            var pending = await invitationRepo.GetPendingByUserIdAsync(r.Id);
-            var hasPending = pending.Count > 0;
-
-            var status = r.IsActive
-                ? ReaderStatus.Active
-                : hasPending
-                    ? ReaderStatus.Invited
-                    : ReaderStatus.Inactive;
-
-            rows.Add(new ReaderRowViewModel
-            {
-                Id                   = r.Id,
-                DisplayName          = string.IsNullOrWhiteSpace(r.DisplayName) ? "Pending reader" : r.DisplayName,
-                Email                = string.Empty,
-                Status               = status,
-                ActivatedAt          = r.ActivatedAt,
-                HasPendingInvitation = hasPending
-            });
-        }
-
-        return View(rows.OrderBy(r => r.DisplayName).ToList());
+            Id                   = r.Id,
+            DisplayName          = r.DisplayName,
+            Email                = string.Empty,
+            Status               = r.Status,
+            ActivatedAt          = r.ActivatedAt,
+            HasPendingInvitation = r.HasPendingInvitation
+        }).ToList());
     }
 
     [HttpGet]
@@ -1051,176 +1029,36 @@ public class AuthorController(
     private IReadEventRepository GetReadEventRepo() =>
         HttpContext.RequestServices.GetRequiredService<IReadEventRepository>();
 
-    private async Task<IReadOnlyList<PublishingChapterViewModel>> BuildPublishingChapterViewModelsAsync(
-        IReadOnlyList<(Section Section, int Depth)> sorted,
-        ProjectType projectType)
-    {
-        var chapters = new List<PublishingChapterViewModel>();
-        foreach (var chapter in GetPublishedLeafChapters(sorted))
+    private static PublishingChapterViewModel MapChapterData(PublishingChapterData d) =>
+        new()
         {
-            var chapterViewModel = await BuildPublishingChapterViewModelAsync(
-                chapter,
-                sorted,
-                projectType);
-
-            chapters.Add(chapterViewModel);
-        }
-
-        return chapters;
-    }
-
-    private async Task<PublishingChapterViewModel> BuildPublishingChapterViewModelAsync(
-        Section chapter,
-        IReadOnlyList<(Section Section, int Depth)> sorted,
-        ProjectType projectType)
-    {
-        var documents = GetPublishedDocumentsForChapter(chapter.Id, sorted);
-        var docViewModels = new List<PublishingDocumentViewModel>();
-        foreach (var doc in documents)
-            docViewModels.Add(await BuildPublishingDocumentViewModelAsync(doc));
-
-        var chapterHasChanges = documents.Any(d => d.ContentChangedSincePublish);
-        var chapterClassification = docViewModels
-            .Where(d => d.Classification.HasValue)
-            .Select(d => d.Classification)
-            .Max();
-
-        return new PublishingChapterViewModel
-        {
-            Chapter = chapter,
-            HasChanges = chapterHasChanges,
-            Classification = chapterClassification,
-            CanRevoke = docViewModels.Any(d => d.CanRevoke),
-            ShowDocumentControls = documents.Count > 1 || projectType == ProjectType.Manual,
-            Documents = docViewModels
+            Chapter              = d.Chapter,
+            HasChanges           = d.HasChanges,
+            Classification       = d.Classification,
+            CanRevoke            = d.CanRevoke,
+            ShowDocumentControls = d.ShowDocumentControls,
+            Documents            = d.Documents.Select(MapDocumentData).ToList()
         };
-    }
 
-    private async Task<PublishingDocumentViewModel> BuildPublishingDocumentViewModelAsync(Section document)
-    {
-        var latestVersion = await sectionVersionRepo.GetLatestAsync(document.Id);
-        var allVersions = latestVersion is not null
-            ? await sectionVersionRepo.GetAllBySectionIdAsync(document.Id)
-            : [];
-
-        var tier = GetSubscriptionTier();
-        var limit = VersionRetentionPolicy.GetLimit(tier);
-        var versionCount = allVersions.Count;
-        var atLimit = VersionRetentionPolicy.IsAtLimit(versionCount, tier);
-        var latestVersionNumber = allVersions.Any()
-            ? allVersions.Max(v => v.VersionNumber)
-            : 0;
-
-        var versionHistory = atLimit
-            ? allVersions
-                .OrderByDescending(v => v.VersionNumber)
-                .Select(v => new VersionHistoryItem
-                {
-                    VersionId = v.Id,
-                    VersionNumber = v.VersionNumber,
-                    VersionLabel = v.VersionLabel,
-                    CreatedAt = v.CreatedAt,
-                    Classification = v.ChangeClassification,
-                    CanDelete = v.VersionNumber != latestVersionNumber
-                })
-                .ToList()
-            : [];
-
-        return new PublishingDocumentViewModel
+    private static PublishingDocumentViewModel MapDocumentData(PublishingDocumentData d) =>
+        new()
         {
-            Document = document,
-            CurrentVersionNumber = latestVersion?.VersionNumber,
-            CurrentVersionLabel = latestVersion?.VersionLabel,
-            HasChanges = document.ContentChangedSincePublish,
-            Classification = TryClassifyDocumentChanges(document, latestVersion),
-            CanRevoke = allVersions.Count > 1,
-            VersionHistory = versionHistory,
-            ShowVersionHistory = atLimit,
-            RetentionLimit = limit
-        };
-    }
-
-    private SubscriptionTier GetSubscriptionTier()
-    {
-        var raw = configuration["DraftView:SubscriptionTier"];
-        return Enum.TryParse<SubscriptionTier>(raw, ignoreCase: true, out var tier)
-            ? tier
-            : SubscriptionTier.Free;
-    }
-
-    private ChangeClassification? TryClassifyDocumentChanges(Section document, SectionVersion? latestVersion)
-    {
-        if (latestVersion is null || !document.ContentChangedSincePublish)
-            return null;
-
-        try
-        {
-            var diff = htmlDiffService.Compute(
-                latestVersion.HtmlContent,
-                document.HtmlContent ?? string.Empty);
-
-            return changeClassificationService.Classify(diff);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static IReadOnlyList<Section> GetPublishedLeafChapters(IReadOnlyList<(Section Section, int Depth)> sorted)
-    {
-        var folderChildIds = sorted
-            .Where(x => x.Section.NodeType == NodeType.Folder && x.Section.ParentId.HasValue)
-            .Select(x => x.Section.ParentId!.Value)
-            .ToHashSet();
-
-        return sorted
-            .Select(x => x.Section)
-            .Where(s => s.NodeType == NodeType.Folder &&
-                        s.IsPublished &&
-                        !folderChildIds.Contains(s.Id))
-            .ToList();
-    }
-
-    private static IReadOnlyList<Section> GetPublishedDocumentsForChapter(
-        Guid chapterId,
-        IReadOnlyList<(Section Section, int Depth)> sorted) =>
-        sorted
-            .Select(x => x.Section)
-            .Where(s => s.ParentId == chapterId &&
-                        s.NodeType == NodeType.Document &&
-                        !s.IsSoftDeleted)
-            .ToList();
-
-    private static IReadOnlyList<(Section Section, int Depth)> SortDepthFirst(
-        IReadOnlyList<Section> sections)
-    {
-        var root   = Guid.Empty;
-        var lookup = new Dictionary<Guid, List<Section>>();
-
-        foreach (var s in sections)
-        {
-            var key = s.ParentId ?? root;
-            if (!lookup.ContainsKey(key)) lookup[key] = [];
-            lookup[key].Add(s);
-        }
-
-        foreach (var key in lookup.Keys.ToList())
-            lookup[key] = [.. lookup[key].OrderBy(s => s.SortOrder)];
-
-        var result = new List<(Section, int)>();
-
-        void Walk(Guid parentId, int depth)
-        {
-            if (!lookup.TryGetValue(parentId, out var children)) return;
-            foreach (var child in children)
+            Document             = d.Document,
+            CurrentVersionNumber = d.CurrentVersionNumber,
+            CurrentVersionLabel  = d.CurrentVersionLabel,
+            HasChanges           = d.HasChanges,
+            Classification       = d.Classification,
+            CanRevoke            = d.CanRevoke,
+            VersionHistory       = d.VersionHistory.Select(v => new VersionHistoryItem
             {
-                result.Add((child, depth));
-                Walk(child.Id, depth + 1);
-            }
-        }
-
-        Walk(root, 0);
-        return result;
-    }
+                VersionId      = v.VersionId,
+                VersionNumber  = v.VersionNumber,
+                VersionLabel   = v.VersionLabel,
+                CreatedAt      = v.CreatedAt,
+                Classification = v.Classification,
+                CanDelete      = v.CanDelete
+            }).ToList(),
+            ShowVersionHistory   = d.ShowVersionHistory,
+            RetentionLimit       = d.RetentionLimit
+        };
 }

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -114,6 +114,8 @@ namespace DraftView.Web.Extensions
             services.AddScoped<IProjectManagementService, ProjectManagementService>();
             services.AddScoped<ICommentDisplayService, CommentDisplayService>();
             services.AddScoped<ISyncOrchestrationService, SyncOrchestrationService>();
+            services.AddScoped<IContentNavigationService, ContentNavigationService>();
+            services.AddScoped<IReaderManagementService, ReaderManagementService>();
 
             return services;
         }

--- a/DraftView.Web/Models/AuthorViewModels.cs
+++ b/DraftView.Web/Models/AuthorViewModels.cs
@@ -3,7 +3,6 @@ using DraftView.Domain.Entities;
 using DraftView.Domain.Enumerations;
 using DraftView.Domain.Notifications;
 using Microsoft.AspNetCore.Http;
-using DraftView.Domain.Interfaces.Repositories;
 
 namespace DraftView.Web.Models;
 
@@ -25,8 +24,6 @@ public class SectionViewModel
     public IReadOnlyDictionary<Guid, string> CommentAuthorNames { get; set; } = new Dictionary<Guid, string>();
     public int ReadCount { get; set; }
 }
-
-public enum ReaderStatus { Invited, Active, Inactive }
 
 public class ReaderRowViewModel
 {

--- a/DraftView.Web/Views/Author/ManageReaderAccess.cshtml
+++ b/DraftView.Web/Views/Author/ManageReaderAccess.cshtml
@@ -8,10 +8,10 @@
         <p class="page-subtitle">
             @switch (Model.Status)
             {
-                case DraftView.Web.Models.ReaderStatus.Active:
+                case DraftView.Domain.Enumerations.ReaderStatus.Active:
                     <span class="badge badge--success">Active</span>
                     break;
-                case DraftView.Web.Models.ReaderStatus.Invited:
+                case DraftView.Domain.Enumerations.ReaderStatus.Invited:
                     <span class="badge badge--neutral">Invited</span>
                     break;
                 default:

--- a/DraftView.Web/Views/Author/Readers.cshtml
+++ b/DraftView.Web/Views/Author/Readers.cshtml
@@ -1,5 +1,6 @@
 ﻿@using DraftView.Web.Infrastructure
 @using DraftView.Web.Models
+@using DraftView.Domain.Enumerations
 @model IReadOnlyList<ReaderRowViewModel>
 @{ ViewData["Title"] = "Beta Readers"; }
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -22,7 +22,7 @@ Last deployed: 2026-08-17 13:59 (commit: d51d201)
 | MT-Sprint Series | 🔴 HIGH PRIORITY — second author interest accelerates timeline; see `MultiTenancy.md` |
 | RD-Sprint Series | 🟡 In progress — RD-Sprint-1 (Continue Reading CTA) merged to main 2026-08-17; see section 3.7 |
 | DR-Sprint Series | ✅ Complete — merged to main 2026-08-17; see section 3.8 |
-| Incremental Refactor | 🟡 In progress — Phase 2a and 2b complete, Phase 2c next; see section 3.6 |
+| Incremental Refactor | 🟡 In progress — Phase 2a–2d complete, Phase 3 deferred; see section 3.6 |
 | MU-Sprint Series | 🔵 Pre-implementation — design complete; see section 3.10 |
 | Go-Live Prerequisites | 🔴 Blocking — items below must complete before launch |
 | UAT | 🟡 In progress |
@@ -210,9 +210,7 @@ S-Sprint-1 complete — see `HISTORY.md`.
 ### 3.6 Incremental Refactor Roadmap
 See `REFACTORING.md` for full detail. Phase 1 complete — see `HISTORY.md`.
 
-**Status:** 🟡 In progress — Phase 2a and 2b complete (PRs #31, #37, #39 merged 2026-08-17/18). Phase 2c next. Web layer review identified ~530 lines of business logic violations — see `Web-Layer-Business-Logic-Review.md` for full detail.
-
-**Current Focus:** Phase 2c — Extract Domain Mutations
+**Status:** 🟡 In progress — Phase 2a–2d complete (PRs #31, #37, #39, #40, #41 merged). Phase 3 deferred. Web layer review identified ~530 lines of business logic violations — see `Web-Layer-Business-Logic-Review.md` for full detail.
 
 - [x] **Phase 2a — Extract Critical Controller Orchestration** ✅ Complete (merged PR #31)
   - [x] Create `ISectionManagementService.GetSectionsSummaryAsync(projectId)` — extracted from `AuthorController.Sections`
@@ -222,13 +220,13 @@ See `REFACTORING.md` for full detail. Phase 1 complete — see `HISTORY.md`.
 - [x] **Phase 2b — Standardize Background Sync** ✅ Complete (merged PRs #37, #39)
   - [x] Create `ISyncOrchestrationService.StartSyncAsync(projectId)` — extracted from `AuthorController.Sync`; dead `ISyncService` and `IServiceScopeFactory` constructor params removed from controller
   - [x] Remove inline `Task.Run` from `ProjectManagementService.StartBackgroundSync` — delegates to `ISyncOrchestrationService`; dead `IServiceScopeFactory` and `ILogger` constructor params removed
-- [ ] **Phase 2c — Extract Domain Mutations**
-  - [ ] Move project activation/deactivation to `IProjectManagementService`
-  - [ ] Move version deletion rules to `IVersioningService`
-  - [ ] Remove all direct entity mutations from controllers
-- [ ] **Phase 2d — Extract Helper Orchestration**
-  - [ ] Create `IContentNavigationService` for tree-building helpers
-  - [ ] Extract reader management summary logic to `IReaderManagementService`
+- [x] **Phase 2c — Extract Domain Mutations** ✅ Complete (merged PR #40)
+  - [x] Move project activation/deactivation to `IProjectManagementService`
+  - [x] Move version deletion rules to `IVersioningService`
+  - [x] Remove all direct entity mutations from controllers
+- [x] **Phase 2d — Extract Helper Orchestration** ✅ Complete (merged PR #41)
+  - [x] Create `IContentNavigationService` for tree-building helpers
+  - [x] Extract reader management summary logic to `IReaderManagementService`
 
 **Original roadmap (deferred pending Web layer cleanup):**
 - [ ] Phase 3 — Decompose startup/seeding


### PR DESCRIPTION
## Summary

Phase 2d of the Incremental Refactor series — extracts the two remaining blocks of business/orchestration logic from `AuthorController` into proper application-layer services.

- **`ReaderStatus` moved to Domain** — was defined inline in `DraftView.Web.Models`; moved to `DraftView.Domain.Enumerations` so Domain-layer service interfaces can reference it without a circular dependency
- **`IContentNavigationService` + `ContentNavigationService`** — all eight private tree-building helpers (`BuildPublishingChapterViewModelsAsync`, `BuildPublishingDocumentViewModelAsync`, `GetSubscriptionTier`, `TryClassifyDocumentChanges`, `GetPublishedLeafChapters`, `GetPublishedDocumentsForChapter`, `SortDepthFirst`, …) extracted from `AuthorController` into a proper application service; parallel DTO records (`PublishingChapterData`, `PublishingDocumentData`, `VersionHistoryData`) defined alongside the interface in the Domain layer
- **`IReaderManagementService` + `ReaderManagementService`** — reader summary assembly logic (soft-delete filter, status derivation, display-name fallback, sort) extracted from `AuthorController.Readers` into an application service returning `ReaderSummaryRow` DTOs
- **`AuthorController`** slimmed to two static view-model mappers (`MapChapterData`, `MapDocumentData`) and two thin action methods; no business logic remains in the controller for these flows
- **13 new tests** — `ContentNavigationServiceTests` (7) and `ReaderManagementServiceTests` (6) covering the extracted behaviour
- **`AuthorControllerTests`** updated to mock `IContentNavigationService` and `IReaderManagementService` instead of the four lower-level dependencies they replaced
- **DI** — both new services registered as scoped in `ServiceCollectionExtensions.AddApplicationServices`

## Test plan

- [ ] `dotnet test --filter ContentNavigationServiceTests` — 7 tests green
- [ ] `dotnet test --filter ReaderManagementServiceTests` — 6 tests green
- [ ] `dotnet test --filter AuthorControllerTests` — existing suite green with updated mocks
- [ ] `dotnet test` — full suite green, no regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_018cmg5HSAwjvPtE1uXVg2bH)_