### PR TITLE
refactor: extract remaining controller violations to services (Phase 2e)

### DIFF
--- a/DraftView.Application.Tests/Services/ReaderManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderManagementServiceTests.cs
@@ -3,23 +3,31 @@ using DraftView.Application.Services;
 using DraftView.Domain.Entities;
 using DraftView.Domain.Enumerations;
 using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
 
 namespace DraftView.Application.Tests.Services;
 
 /// <summary>
-/// Tests for ReaderManagementService.GetReaderSummaryAsync.
-/// Covers: soft-deleted exclusion, status derivation (Active/Invited/Inactive),
-/// display name defaulting, alphabetical ordering.
+/// Tests for ReaderManagementService: GetReaderSummaryAsync, GetReaderAccessDataAsync,
+/// UpdateReaderAccessAsync, SoftDeleteReaderAsync.
 /// Excludes: EF Core persistence, invitation issuance, reader deactivation.
 /// </summary>
 public class ReaderManagementServiceTests
 {
-    private readonly Mock<IUserRepository>       _userRepo       = new();
-    private readonly Mock<IInvitationRepository> _invitationRepo = new();
+    private readonly Mock<IUserRepository>        _userRepo            = new();
+    private readonly Mock<IInvitationRepository>  _invitationRepo      = new();
+    private readonly Mock<IProjectRepository>     _projectRepo         = new();
+    private readonly Mock<IReaderAccessRepository> _readerAccessRepo   = new();
+    private readonly Mock<IUserService>            _userService         = new();
+    private readonly Mock<IUnitOfWork>             _unitOfWork          = new();
 
     private ReaderManagementService CreateSut() => new(
         _userRepo.Object,
-        _invitationRepo.Object);
+        _invitationRepo.Object,
+        _projectRepo.Object,
+        _readerAccessRepo.Object,
+        _userService.Object,
+        _unitOfWork.Object);
 
     private void SetupNoPendingInvitations(Guid userId)
     {
@@ -118,5 +126,128 @@ public class ReaderManagementServiceTests
         var result = await CreateSut().GetReaderSummaryAsync();
 
         Assert.Equal(["Alice", "Bob", "Charlie"], result.Select(r => r.DisplayName));
+    }
+
+    // -----------------------------------------------------------------------
+    // GetReaderAccessDataAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetReaderAccessDataAsync_ReaderNotFound_ReturnsNull()
+    {
+        var readerId = Guid.NewGuid();
+        _userRepo.Setup(r => r.GetByIdAsync(readerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var result = await CreateSut().GetReaderAccessDataAsync(readerId);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetReaderAccessDataAsync_ActiveReader_ReturnsActiveStatus()
+    {
+        var reader  = User.Create("r@example.test", "Alice", Role.BetaReader);
+        reader.Activate();
+        var project = Project.Create("Book", "/path", Guid.NewGuid(), "root");
+
+        _userRepo.Setup(r => r.GetByIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reader);
+        _projectRepo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([project]);
+        _readerAccessRepo.Setup(r => r.GetByReaderIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _invitationRepo.Setup(r => r.GetByUserIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Invitation?)null);
+
+        var result = await CreateSut().GetReaderAccessDataAsync(reader.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(ReaderStatus.Active, result!.Status);
+    }
+
+    [Fact]
+    public async Task GetReaderAccessDataAsync_PartitionsProjectsCorrectly()
+    {
+        var authorId  = Guid.NewGuid();
+        var reader    = User.Create("r@example.test", "Alice", Role.BetaReader);
+        var projectA  = Project.Create("A", "/a", authorId, "root-a");
+        var projectB  = Project.Create("B", "/b", authorId, "root-b");
+        var access    = ReaderAccess.Grant(reader.Id, authorId, projectA.Id);
+
+        _userRepo.Setup(r => r.GetByIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reader);
+        _projectRepo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([projectA, projectB]);
+        _readerAccessRepo.Setup(r => r.GetByReaderIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([access]);
+        _invitationRepo.Setup(r => r.GetByUserIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Invitation?)null);
+
+        var result = await CreateSut().GetReaderAccessDataAsync(reader.Id);
+
+        Assert.NotNull(result);
+        Assert.Single(result!.ProjectsWithAccess);
+        Assert.Equal(projectA.Id, result.ProjectsWithAccess[0].Id);
+        Assert.Single(result.ProjectsWithoutAccess);
+        Assert.Equal(projectB.Id, result.ProjectsWithoutAccess[0].Id);
+    }
+
+    // -----------------------------------------------------------------------
+    // UpdateReaderAccessAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateReaderAccessAsync_GrantsNewAccess_AndSaves()
+    {
+        var authorId  = Guid.NewGuid();
+        var readerId  = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+
+        _readerAccessRepo.Setup(r => r.GetByReaderAndProjectAsync(readerId, projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ReaderAccess?)null);
+
+        await CreateSut().UpdateReaderAccessAsync(readerId, [projectId], [], authorId);
+
+        _readerAccessRepo.Verify(r => r.AddAsync(It.IsAny<ReaderAccess>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateReaderAccessAsync_RevokesExistingAccess_AndSaves()
+    {
+        var authorId  = Guid.NewGuid();
+        var readerId  = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        var access    = ReaderAccess.Grant(readerId, authorId, projectId);
+
+        _readerAccessRepo.Setup(r => r.GetByReaderAndProjectAsync(readerId, projectId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(access);
+
+        await CreateSut().UpdateReaderAccessAsync(readerId, [], [projectId], authorId);
+
+        Assert.False(access.IsActive);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // -----------------------------------------------------------------------
+    // SoftDeleteReaderAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SoftDeleteReaderAsync_RevokesAllAccessThenSoftDeletesUser()
+    {
+        var authorId = Guid.NewGuid();
+        var userId   = Guid.NewGuid();
+
+        await CreateSut().SoftDeleteReaderAsync(userId, authorId);
+
+        _readerAccessRepo.Verify(
+            r => r.RevokeAllForReaderAsync(userId, authorId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _userService.Verify(
+            s => s.SoftDeleteUserAsync(userId, authorId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/DraftView.Application.Tests/Services/SectionManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/SectionManagementServiceTests.cs
@@ -9,19 +9,23 @@ using DraftView.Domain.Interfaces.Services;
 namespace DraftView.Application.Tests.Services;
 
 /// <summary>
-/// Tests for SectionManagementService.GetSectionsSummaryAsync.
+/// Tests for SectionManagementService.GetSectionsSummaryAsync and GetSectionDetailAsync.
 /// Covers: depth-first ordering, publishability flagging, change classification
-/// for published chapters with edited documents, and null return for unknown projects.
+/// for published chapters with edited documents, null return for unknown projects,
+/// section detail aggregation.
 /// Excludes: EF Core persistence (unit tests only), UI rendering.
 /// </summary>
 public class SectionManagementServiceTests
 {
-    private readonly Mock<IProjectRepository>              _projectRepo               = new();
-    private readonly Mock<ISectionRepository>               _sectionRepo               = new();
-    private readonly Mock<ISectionVersionRepository>         _sectionVersionRepo        = new();
-    private readonly Mock<IPublicationService>                _publicationService        = new();
-    private readonly Mock<IHtmlDiffService>                    _htmlDiffService           = new();
-    private readonly Mock<IChangeClassificationService>          _changeClassificationService = new();
+    private readonly Mock<IProjectRepository>            _projectRepo                 = new();
+    private readonly Mock<ISectionRepository>             _sectionRepo                 = new();
+    private readonly Mock<ISectionVersionRepository>       _sectionVersionRepo          = new();
+    private readonly Mock<IPublicationService>              _publicationService          = new();
+    private readonly Mock<IHtmlDiffService>                  _htmlDiffService             = new();
+    private readonly Mock<IChangeClassificationService>        _changeClassificationService = new();
+    private readonly Mock<ICommentService>                      _commentService              = new();
+    private readonly Mock<IUserRepository>                       _userRepository              = new();
+    private readonly Mock<IReadEventRepository>                   _readEventRepository         = new();
 
     private SectionManagementService CreateSut() => new(
         _projectRepo.Object,
@@ -29,7 +33,10 @@ public class SectionManagementServiceTests
         _sectionVersionRepo.Object,
         _publicationService.Object,
         _htmlDiffService.Object,
-        _changeClassificationService.Object);
+        _changeClassificationService.Object,
+        _commentService.Object,
+        _userRepository.Object,
+        _readEventRepository.Object);
 
     [Fact]
     public async Task GetSectionsSummaryAsync_ProjectNotFound_ReturnsNull()
@@ -128,5 +135,84 @@ public class SectionManagementServiceTests
 
         Assert.DoesNotContain(chapter.Id, result!.ChapterHasChanges);
         Assert.False(result.ClassificationMap.ContainsKey(chapter.Id));
+    }
+
+    // -----------------------------------------------------------------------
+    // GetSectionDetailAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetSectionDetailAsync_SectionNotFound_ReturnsNull()
+    {
+        var sectionId = Guid.NewGuid();
+        _sectionRepo.Setup(r => r.GetByIdAsync(sectionId, default)).ReturnsAsync((Section?)null);
+
+        var result = await CreateSut().GetSectionDetailAsync(sectionId, Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetSectionDetailAsync_SceneWithParent_ResolvesChapterTitle()
+    {
+        var project  = Project.Create("Book", "/path", Guid.NewGuid(), "root-uuid");
+        var chapter  = Section.CreateFolder(project.Id, "c1", "Chapter One", null, 0);
+        var scene    = Section.CreateDocument(project.Id, "s1", "Scene 1", chapter.Id, 0, "<p>a</p>", "h1", null);
+        var authorId = Guid.NewGuid();
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default)).ReturnsAsync([]);
+        _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default)).ReturnsAsync([]);
+
+        var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
+
+        Assert.NotNull(result);
+        Assert.Equal("Chapter One", result!.ChapterTitle);
+        Assert.Same(scene, result.Section);
+    }
+
+    [Fact]
+    public async Task GetSectionDetailAsync_ReturnsReadCount()
+    {
+        var project  = Project.Create("Book", "/path", Guid.NewGuid(), "root-uuid");
+        var scene    = Section.CreateDocument(project.Id, "s1", "Scene 1", null, 0, "<p>a</p>", "h1", null);
+        var authorId = Guid.NewGuid();
+        var readerId = Guid.NewGuid();
+        var readEvent1 = ReadEvent.Create(scene.Id, readerId);
+        var readEvent2 = ReadEvent.Create(scene.Id, Guid.NewGuid());
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
+        _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default)).ReturnsAsync([]);
+        _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
+            .ReturnsAsync([readEvent1, readEvent2]);
+
+        var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.ReadCount);
+    }
+
+    [Fact]
+    public async Task GetSectionDetailAsync_BuildsCommentAuthorNameMap()
+    {
+        var project    = Project.Create("Book", "/path", Guid.NewGuid(), "root-uuid");
+        var scene      = Section.CreateDocument(project.Id, "s1", "Scene 1", null, 0, "<p>a</p>", "h1", null);
+        var authorId   = Guid.NewGuid();
+        var readerId   = Guid.NewGuid();
+        var readerUser = User.Create("r@example.test", "Alice", Role.BetaReader);
+        var comment    = Comment.CreateRoot(scene.Id, readerId, "Great scene!", Domain.Enumerations.Visibility.Public);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
+        _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default))
+            .ReturnsAsync([comment]);
+        _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default)).ReturnsAsync([]);
+        _userRepository.Setup(r => r.GetByIdAsync(readerId, default)).ReturnsAsync(readerUser);
+
+        var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
+
+        Assert.NotNull(result);
+        Assert.True(result!.CommentAuthorNames.ContainsKey(readerId));
+        Assert.Equal("Alice", result.CommentAuthorNames[readerId]);
     }
 }

--- a/DraftView.Application.Tests/Services/UserServiceResendInvitationTests.cs
+++ b/DraftView.Application.Tests/Services/UserServiceResendInvitationTests.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.Configuration;
+using Moq;
+using DraftView.Application.Services;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Tests.Services;
+
+public class UserServiceResendInvitationTests
+{
+    private readonly Mock<IUserRepository>              _userRepo       = new();
+    private readonly Mock<IInvitationRepository>        _inviteRepo     = new();
+    private readonly Mock<IUserPreferencesRepository>   _prefsRepo      = new();
+    private readonly Mock<IEmailSender>                 _emailSender    = new();
+    private readonly Mock<IUnitOfWork>                  _unitOfWork     = new();
+    private readonly Mock<IConfiguration>               _config         = new();
+    private readonly Mock<IReaderAccessRepository>      _readerAccess   = new();
+    private readonly Mock<IAuthorizationFacade>         _authFacade     = new();
+    private readonly Mock<IAuthorNotificationRepository> _notifRepo     = new();
+
+    public UserServiceResendInvitationTests()
+    {
+        _config.Setup(c => c["App:BaseUrl"]).Returns("https://app.draftview.co.uk");
+        _authFacade.Setup(f => f.IsAuthor()).Returns(true);
+        _authFacade.Setup(f => f.IsSystemSupport()).Returns(false);
+        _inviteRepo.Setup(r => r.GetPendingByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _prefsRepo.Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserPreferences?)null);
+    }
+
+    private UserService CreateSut() => new(
+        _userRepo.Object,
+        _inviteRepo.Object,
+        _prefsRepo.Object,
+        _emailSender.Object,
+        _unitOfWork.Object,
+        _config.Object,
+        _readerAccess.Object,
+        _authFacade.Object,
+        _notifRepo.Object);
+
+    [Fact]
+    public async Task ResendInvitationAsync_ReaderNotFound_ThrowsInvariantViolation()
+    {
+        var userId = Guid.NewGuid();
+        _userRepo.Setup(r => r.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var ex = await Assert.ThrowsAsync<InvariantViolationException>(
+            () => CreateSut().ResendInvitationAsync(userId, Guid.NewGuid()));
+
+        Assert.Equal("U-RESEND-NOT-FOUND", ex.InvariantCode);
+    }
+
+    [Fact]
+    public async Task ResendInvitationAsync_ActiveReader_DeactivatesBeforeReissuing()
+    {
+        var authorId = Guid.NewGuid();
+        var reader   = User.Create("r@example.test", "Alice", Role.BetaReader);
+        reader.Activate();
+
+        _userRepo.Setup(r => r.GetByIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reader);
+        _userRepo.Setup(r => r.GetByEmailAsync(reader.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+        _userRepo.Setup(r => r.EmailExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _prefsRepo.Setup(r => r.GetByUserIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UserPreferences.CreateForBetaReader(reader.Id));
+
+        await CreateSut().ResendInvitationAsync(reader.Id, authorId);
+
+        Assert.False(reader.IsActive);
+        _emailSender.Verify(e => e.SendAsync(
+            reader.Email,
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResendInvitationAsync_WithPendingInvitation_UsesExistingPolicy()
+    {
+        var authorId  = Guid.NewGuid();
+        var reader    = User.Create("r@example.test", "Alice", Role.BetaReader);
+        var expiresAt = DateTime.UtcNow.AddDays(14);
+        var pending   = Invitation.CreateWithExpiry(reader.Id, expiresAt);
+
+        _userRepo.Setup(r => r.GetByIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reader);
+        _userRepo.Setup(r => r.GetByEmailAsync(reader.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+        _inviteRepo.Setup(r => r.GetPendingByUserIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([pending]);
+
+        await CreateSut().ResendInvitationAsync(reader.Id, authorId);
+
+        _emailSender.Verify(e => e.SendAsync(
+            reader.Email,
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.Is<string>(body => body.Contains(expiresAt.ToString("d MMMM yyyy"))),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResendInvitationAsync_NoPendingInvitation_DefaultsToAlwaysOpen()
+    {
+        var authorId = Guid.NewGuid();
+        var reader   = User.Create("r@example.test", "Alice", Role.BetaReader);
+
+        _userRepo.Setup(r => r.GetByIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(reader);
+        _userRepo.Setup(r => r.GetByEmailAsync(reader.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+        _inviteRepo.Setup(r => r.GetPendingByUserIdAsync(reader.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await CreateSut().ResendInvitationAsync(reader.Id, authorId);
+
+        _emailSender.Verify(e => e.SendAsync(
+            reader.Email,
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.Is<string>(body => body.Contains("does not expire")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/DraftView.Application/Services/ReaderManagementService.cs
+++ b/DraftView.Application/Services/ReaderManagementService.cs
@@ -1,3 +1,4 @@
+using DraftView.Domain.Entities;
 using DraftView.Domain.Enumerations;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
@@ -5,12 +6,16 @@ using DraftView.Domain.Interfaces.Services;
 namespace DraftView.Application.Services;
 
 /// <summary>
-/// Builds the aggregated reader summary for the author's Readers management page,
-/// resolving each reader's derived status from invitation and activation state.
+/// Provides reader management operations for the author's Readers management page,
+/// including summary listing, access management, and reader removal.
 /// </summary>
 public class ReaderManagementService(
     IUserRepository userRepository,
-    IInvitationRepository invitationRepository) : IReaderManagementService
+    IInvitationRepository invitationRepository,
+    IProjectRepository projectRepository,
+    IReaderAccessRepository readerAccessRepository,
+    IUserService userService,
+    IUnitOfWork unitOfWork) : IReaderManagementService
 {
     /// <summary>
     /// Returns all non-soft-deleted beta readers with their derived lifecycle status,
@@ -42,5 +47,80 @@ public class ReaderManagementService(
         }
 
         return [.. rows.OrderBy(r => r.DisplayName)];
+    }
+
+    /// <summary>
+    /// Returns the reader access data for the ManageReaderAccess page, including the
+    /// reader's derived status and the partition of non-deleted projects into those with
+    /// and without access. Returns null when the reader does not exist.
+    /// </summary>
+    public async Task<ReaderAccessData?> GetReaderAccessDataAsync(
+        Guid readerId, CancellationToken ct = default)
+    {
+        var reader = await userRepository.GetByIdAsync(readerId, ct);
+        if (reader is null) return null;
+
+        var allProjects   = await projectRepository.GetAllAsync(ct);
+        var activeProjects = allProjects.Where(p => !p.IsSoftDeleted).ToList();
+
+        var accessRecords    = await readerAccessRepository.GetByReaderIdAsync(readerId, ct);
+        var accessProjectIds = accessRecords.Select(a => a.ProjectId).ToHashSet();
+
+        var invitation = await invitationRepository.GetByUserIdAsync(readerId, ct);
+        var isPending  = invitation is not null && invitation.Status == InvitationStatus.Pending;
+        var status     = reader.IsActive
+            ? ReaderStatus.Active
+            : isPending ? ReaderStatus.Invited : ReaderStatus.Inactive;
+
+        return new ReaderAccessData
+        {
+            ReaderId              = reader.Id,
+            DisplayName           = reader.DisplayName,
+            Status                = status,
+            ProjectsWithAccess    = [.. activeProjects.Where(p => accessProjectIds.Contains(p.Id))],
+            ProjectsWithoutAccess = [.. activeProjects.Where(p => !accessProjectIds.Contains(p.Id))]
+        };
+    }
+
+    /// <summary>
+    /// Grants access to projects in <paramref name="grantIds"/>, reinstating revoked
+    /// records when they exist, and revokes access to projects in
+    /// <paramref name="revokeIds"/>. Saves all changes in a single unit of work.
+    /// </summary>
+    public async Task UpdateReaderAccessAsync(
+        Guid readerId, IReadOnlyList<Guid> grantIds, IReadOnlyList<Guid> revokeIds,
+        Guid authorId, CancellationToken ct = default)
+    {
+        foreach (var projectId in grantIds)
+        {
+            var existing = await readerAccessRepository.GetByReaderAndProjectAsync(readerId, projectId, ct);
+            if (existing is null)
+            {
+                var access = ReaderAccess.Grant(readerId, authorId, projectId);
+                await readerAccessRepository.AddAsync(access, ct);
+            }
+            else if (!existing.IsActive)
+            {
+                existing.Reinstate();
+            }
+        }
+
+        foreach (var projectId in revokeIds)
+        {
+            var existing = await readerAccessRepository.GetByReaderAndProjectAsync(readerId, projectId, ct);
+            existing?.Revoke();
+        }
+
+        await unitOfWork.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Revokes all project access for the reader then soft-deletes the reader record.
+    /// </summary>
+    public async Task SoftDeleteReaderAsync(Guid userId, Guid authorId, CancellationToken ct = default)
+    {
+        await readerAccessRepository.RevokeAllForReaderAsync(userId, authorId, ct);
+        await userService.SoftDeleteUserAsync(userId, authorId, ct);
+        await unitOfWork.SaveChangesAsync(ct);
     }
 }

--- a/DraftView.Application/Services/SectionManagementService.cs
+++ b/DraftView.Application/Services/SectionManagementService.cs
@@ -6,9 +6,9 @@ using DraftView.Domain.Interfaces.Services;
 namespace DraftView.Application.Services;
 
 /// <summary>
-/// Builds the aggregated sections summary for the author's Sections page,
-/// encapsulating depth-first tree ordering, publishability evaluation, and
-/// change classification across all project chapters.
+/// Builds the aggregated sections summary and section detail data for the author's
+/// Sections and Section pages, encapsulating depth-first tree ordering, publishability
+/// evaluation, change classification, and comment author resolution.
 /// </summary>
 public class SectionManagementService(
     IProjectRepository projectRepo,
@@ -16,7 +16,10 @@ public class SectionManagementService(
     ISectionVersionRepository sectionVersionRepo,
     IPublicationService publicationService,
     IHtmlDiffService htmlDiffService,
-    IChangeClassificationService changeClassificationService) : ISectionManagementService
+    IChangeClassificationService changeClassificationService,
+    ICommentService commentService,
+    IUserRepository userRepository,
+    IReadEventRepository readEventRepository) : ISectionManagementService
 {
     /// <summary>
     /// Loads the project and its full section tree, evaluates publishability
@@ -95,6 +98,44 @@ public class SectionManagementService(
             Publishable       = publishable,
             ChapterHasChanges = chapterHasChanges,
             ClassificationMap = classificationMap
+        };
+    }
+
+    /// <summary>
+    /// Loads a section with its parent chapter title, all comment threads,
+    /// a display-name map for every comment author, and the read count.
+    /// Returns null when the section does not exist.
+    /// </summary>
+    public async Task<SectionDetailDto?> GetSectionDetailAsync(
+        Guid sectionId, Guid authorId, CancellationToken ct = default)
+    {
+        var section = await sectionRepo.GetByIdAsync(sectionId, ct);
+        if (section is null) return null;
+
+        string? chapterTitle = null;
+        if (section.ParentId.HasValue)
+        {
+            var parent = await sectionRepo.GetByIdAsync(section.ParentId.Value, ct);
+            chapterTitle = parent?.Title;
+        }
+
+        var comments = await commentService.GetThreadsForSectionAsync(sectionId, authorId, ct);
+        var events   = await readEventRepository.GetBySectionIdAsync(sectionId, ct);
+
+        var nameMap = new Dictionary<Guid, string>();
+        foreach (var uid in comments.Select(c => c.AuthorId).Distinct())
+        {
+            var u = await userRepository.GetByIdAsync(uid, ct);
+            nameMap[uid] = u?.DisplayName ?? "Unknown";
+        }
+
+        return new SectionDetailDto
+        {
+            Section            = section,
+            ChapterTitle       = chapterTitle,
+            Comments           = comments,
+            CommentAuthorNames = nameMap,
+            ReadCount          = events.Count
         };
     }
 

--- a/DraftView.Application/Services/UserService.cs
+++ b/DraftView.Application/Services/UserService.cs
@@ -185,6 +185,28 @@ public class UserService(
         await unitOfWork.SaveChangesAsync(ct);
     }
 
+    /// <summary>
+    /// Re-issues an invitation to an existing reader. Deactivates the reader first
+    /// if they were manually activated without completing the invitation flow.
+    /// Uses the reader's most recent pending invitation policy when available,
+    /// otherwise defaults to AlwaysOpen.
+    /// </summary>
+    public async Task ResendInvitationAsync(Guid userId, Guid authorId, CancellationToken ct = default)
+    {
+        var reader = await userRepo.GetByIdAsync(userId, ct);
+        if (reader is null)
+            throw new InvariantViolationException("U-RESEND-NOT-FOUND", "Reader not found.");
+
+        if (reader.IsActive)
+            await DeactivateUserAsync(userId, authorId, ct);
+
+        var pending   = (await invitationRepo.GetPendingByUserIdAsync(userId, ct)).FirstOrDefault();
+        var policy    = pending?.ExpiryPolicy ?? ExpiryPolicy.AlwaysOpen;
+        var expiresAt = pending?.ExpiresAt;
+
+        await IssueInvitationAsync(reader.Email, reader.DisplayName, policy, expiresAt, authorId, ct);
+    }
+
     public async Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default)
     {
         var validatedDisplayName = ValidateDisplayName(displayName);

--- a/DraftView.Domain/Interfaces/Services/IReaderManagementService.cs
+++ b/DraftView.Domain/Interfaces/Services/IReaderManagementService.cs
@@ -1,3 +1,4 @@
+using DraftView.Domain.Entities;
 using DraftView.Domain.Enumerations;
 
 namespace DraftView.Domain.Interfaces.Services;
@@ -11,7 +12,20 @@ public sealed record ReaderSummaryRow(
     bool HasPendingInvitation);
 
 /// <summary>
-/// Provides a summary of all beta readers for the author's Readers management page.
+/// All data required to render the ManageReaderAccess page: the reader's identity,
+/// derived status, and the partition of projects into those with and without access.
+/// </summary>
+public sealed class ReaderAccessData
+{
+    public required Guid ReaderId { get; init; }
+    public required string DisplayName { get; init; }
+    public required ReaderStatus Status { get; init; }
+    public required IReadOnlyList<Project> ProjectsWithAccess { get; init; }
+    public required IReadOnlyList<Project> ProjectsWithoutAccess { get; init; }
+}
+
+/// <summary>
+/// Provides reader management operations for the author's Readers management page.
 /// </summary>
 public interface IReaderManagementService
 {
@@ -20,4 +34,23 @@ public interface IReaderManagementService
     /// invitation state, ordered by display name.
     /// </summary>
     Task<IReadOnlyList<ReaderSummaryRow>> GetReaderSummaryAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the reader access data for the ManageReaderAccess page, including
+    /// the reader's derived status and the project partition. Returns null when
+    /// the reader does not exist.
+    /// </summary>
+    Task<ReaderAccessData?> GetReaderAccessDataAsync(Guid readerId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Grants access to projects in <paramref name="grantIds"/> and revokes access
+    /// to projects in <paramref name="revokeIds"/> for the given reader.
+    /// </summary>
+    Task UpdateReaderAccessAsync(Guid readerId, IReadOnlyList<Guid> grantIds,
+        IReadOnlyList<Guid> revokeIds, Guid authorId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Revokes all project access for the reader, then soft-deletes the reader record.
+    /// </summary>
+    Task SoftDeleteReaderAsync(Guid userId, Guid authorId, CancellationToken ct = default);
 }

--- a/DraftView.Domain/Interfaces/Services/ISectionManagementService.cs
+++ b/DraftView.Domain/Interfaces/Services/ISectionManagementService.cs
@@ -24,6 +24,20 @@ public sealed class SectionsSummaryDto
     public required IReadOnlyDictionary<Guid, ChangeClassification> ClassificationMap { get; init; }
 }
 
+/// <summary>
+/// All data required to render the author's section detail page, including
+/// the section itself, its parent chapter title, comments with author names,
+/// and the read count.
+/// </summary>
+public sealed class SectionDetailDto
+{
+    public required Section Section { get; init; }
+    public string? ChapterTitle { get; init; }
+    public required IReadOnlyList<Comment> Comments { get; init; }
+    public required IReadOnlyDictionary<Guid, string> CommentAuthorNames { get; init; }
+    public required int ReadCount { get; init; }
+}
+
 public interface ISectionManagementService
 {
     /// <summary>
@@ -33,4 +47,12 @@ public interface ISectionManagementService
     /// </summary>
     Task<SectionsSummaryDto?> GetSectionsSummaryAsync(
         Guid projectId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the section detail including comments, comment author names,
+    /// and read count for the author's section view. Returns null when the
+    /// section does not exist.
+    /// </summary>
+    Task<SectionDetailDto?> GetSectionDetailAsync(
+        Guid sectionId, Guid authorId, CancellationToken ct = default);
 }

--- a/DraftView.Domain/Interfaces/Services/IUserService.cs
+++ b/DraftView.Domain/Interfaces/Services/IUserService.cs
@@ -16,6 +16,7 @@ public interface IUserService
     Task UpdateProseFontPreferencesAsync(Guid userId, ProseFont proseFont, ProseFontSize proseFontSize, CancellationToken ct = default);
     Task UpdateEmailAsync(Guid userId, string email, CancellationToken ct = default);
     Task UpdateReaderProfileAsync(Guid userId, string? bio, string? genreInterests, DraftView.Domain.Enumerations.ReaderPace? pace, CancellationToken ct = default);
+    Task ResendInvitationAsync(Guid userId, Guid authorId, CancellationToken ct = default);
 }
 
 

--- a/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
@@ -19,16 +19,13 @@ namespace DraftView.Web.Tests.Controllers;
 public class AuthorControllerTests
 {
     private readonly Mock<IProjectRepository> projectRepo = new();
-    private readonly Mock<ISectionRepository> sectionRepo = new();
     private readonly Mock<IPublicationService> publicationService = new();
     private readonly Mock<IUserService> userService = new();
     private readonly Mock<IDashboardService> dashboardService = new();
     private readonly Mock<IUserRepository> userRepo = new();
     private readonly Mock<IProjectDiscoveryService> discoveryService = new();
-    private readonly Mock<IInvitationRepository> invitationRepo = new();
     private readonly Mock<ISyncProgressTracker> progressTracker = new();
     private readonly Mock<ISyncOrchestrationService> syncOrchestrationService = new();
-    private readonly Mock<IReaderAccessRepository> readerAccessRepo = new();
     private readonly Mock<IVersioningService> versioningService = new();
     private readonly Mock<IImportService> importService = new();
     private readonly Mock<ISectionTreeService> sectionTreeService = new();
@@ -61,16 +58,13 @@ public class AuthorControllerTests
     {
         var controller = new AuthorController(
             projectRepo.Object,
-            sectionRepo.Object,
             publicationService.Object,
             userService.Object,
             dashboardService.Object,
             userRepo.Object,
             discoveryService.Object,
-            invitationRepo.Object,
             progressTracker.Object,
             syncOrchestrationService.Object,
-            readerAccessRepo.Object,
             versioningService.Object,
             importService.Object,
             sectionTreeService.Object,
@@ -194,27 +188,22 @@ public class AuthorControllerTests
     }
 
     [Fact]
-    public async Task SoftDeleteReader_WhenAuthorRemovesReader_SoftDeletesUser()
+    public async Task SoftDeleteReader_WhenAuthorRemovesReader_DelegatesToReaderManagementService()
     {
         var author = User.Create("author@example.test", "Author", Role.Author);
-        var project = Project.Create("Project One", "/Apps/Scrivener/ProjectOne", author.Id, "sync-root");
         var sut = CreateSut();
         var readerId = Guid.NewGuid();
 
         userRepo.Setup(r => r.GetByEmailAsync("author@example.test", It.IsAny<CancellationToken>()))
             .ReturnsAsync(author);
-        projectRepo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([project]);
-        readerAccessRepo.Setup(r => r.GetByReaderAndProjectAsync(readerId, project.Id, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ReaderAccess?)null);
 
         var result = await sut.SoftDeleteReader(readerId);
 
         var redirect = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal("Readers", redirect.ActionName);
-        userService.Verify(s => s.SoftDeleteUserAsync(readerId, author.Id, It.IsAny<CancellationToken>()), Times.Once);
-        userService.Verify(s => s.DeactivateUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
-        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        readerManagementService.Verify(
+            s => s.SoftDeleteReaderAsync(readerId, author.Id, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/DraftView.Web/Controllers/AuthorController.cs
+++ b/DraftView.Web/Controllers/AuthorController.cs
@@ -3,7 +3,6 @@ using DraftView.Domain.Enumerations;
 using DraftView.Domain.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using DraftView.Domain.Entities;
 using DraftView.Domain.Interfaces.Services;
 using DraftView.Web.Models;
@@ -17,16 +16,13 @@ namespace DraftView.Web.Controllers;
 [Authorize(Policy = "RequireAuthorPolicy")]
 public class AuthorController(
     IProjectRepository projectRepo,
-    ISectionRepository sectionRepo,
     IPublicationService publicationService,
     IUserService userService,
     IDashboardService dashboardService,
     IUserRepository userRepo,
     IProjectDiscoveryService discoveryService,
-    IInvitationRepository invitationRepo,
     ISyncProgressTracker progressTracker,
     ISyncOrchestrationService syncOrchestrationService,
-    IReaderAccessRepository readerAccessRepo,
     IVersioningService versioningService,
     IImportService importService,
     ISectionTreeService sectionTreeService,
@@ -701,23 +697,15 @@ public class AuthorController(
         var (author, error) = await RequireCurrentAuthorAsync();
         if (error is not null || author is null) return error ?? Forbid();
 
-        var reader = await userRepo.GetByIdAsync(userId, ct);
-        if (reader is null) return NotFound();
-
-        // Reader was manually activated without completing the invitation flow —
-        // deactivate first so IssueInvitationAsync can accept the re-invite.
-        if (reader.IsActive)
-            await userService.DeactivateUserAsync(userId, author.Id, ct);
-
-        var pending = (await invitationRepo.GetPendingByUserIdAsync(userId, ct)).FirstOrDefault();
-        var policy = pending?.ExpiryPolicy ?? DraftView.Domain.Enumerations.ExpiryPolicy.AlwaysOpen;
-        var expiresAt = pending?.ExpiresAt;
-
         try
         {
-            await userService.IssueInvitationAsync(reader.Email, reader.DisplayName, policy, expiresAt, author.Id, ct);
+            await userService.ResendInvitationAsync(userId, author.Id, ct);
             TempData["Success"] = "Invitation resent.";
             return RedirectToAction("Readers");
+        }
+        catch (InvariantViolationException)
+        {
+            return NotFound();
         }
         catch (Exception ex)
         {
@@ -746,34 +734,16 @@ public class AuthorController(
         var (author, error) = await RequireCurrentAuthorAsync();
         if (error is not null || author is null) return error ?? Forbid();
 
-        var s = await sectionRepo.GetByIdAsync(id);
-        if (s is null) return NotFound();
-
-        // Resolve parent chapter title if this is a scene
-        string? chapterTitle = null;
-        if (s.ParentId.HasValue)
-        {
-            var parent = await sectionRepo.GetByIdAsync(s.ParentId.Value);
-            chapterTitle = parent?.Title;
-        }
-
-        var comments = await GetCommentService().GetThreadsForSectionAsync(id, author.Id);
-        var events   = await GetReadEventRepo().GetBySectionIdAsync(id);
-
-        var nameMap = new Dictionary<Guid, string>();
-        foreach (var uid in comments.Select(c => c.AuthorId).Distinct())
-        {
-            var u = await userRepo.GetByIdAsync(uid);
-            nameMap[uid] = u?.DisplayName ?? "Unknown";
-        }
+        var detail = await sectionManagementService.GetSectionDetailAsync(id, author.Id);
+        if (detail is null) return NotFound();
 
         return View(new SectionViewModel
         {
-            Section            = s,
-            ChapterTitle       = chapterTitle,
-            Comments           = comments,
-            ReadCount          = events.Count,
-            CommentAuthorNames = nameMap
+            Section            = detail.Section,
+            ChapterTitle       = detail.ChapterTitle,
+            Comments           = detail.Comments,
+            ReadCount          = detail.ReadCount,
+            CommentAuthorNames = detail.CommentAuthorNames
         });
     }
 
@@ -892,30 +862,17 @@ public class AuthorController(
         var (author, error) = await RequireCurrentAuthorAsync();
         if (error is not null || author is null) return error ?? Forbid();
 
-        var reader = await userRepo.GetByIdAsync(readerId);
-        if (reader is null) return NotFound();
-
-        var allProjects = await projectRepo.GetAllAsync();
-        var activeProjects = allProjects.Where(p => !p.IsSoftDeleted).ToList();
-
-        var accessRecords = await readerAccessRepo.GetByReaderIdAsync(readerId);
-        var accessProjectIds = accessRecords.Select(a => a.ProjectId).ToHashSet();
-
-        var invitation = await invitationRepo.GetByUserIdAsync(readerId);
-        var isPending = invitation is not null
-                     && invitation.Status == Domain.Enumerations.InvitationStatus.Pending;
-        var status = reader.IsActive
-            ? ReaderStatus.Active
-            : isPending ? ReaderStatus.Invited : ReaderStatus.Inactive;
+        var data = await readerManagementService.GetReaderAccessDataAsync(readerId);
+        if (data is null) return NotFound();
 
         return View(new ReaderAccessViewModel
         {
-            ReaderId            = reader.Id,
-            DisplayName         = reader.DisplayName,
-            Email               = string.Empty,
-            Status              = status,
-            ProjectsWithAccess = [.. activeProjects.Where(p => accessProjectIds.Contains(p.Id))],
-            ProjectsWithoutAccess = [.. activeProjects.Where(p => !accessProjectIds.Contains(p.Id))]
+            ReaderId              = data.ReaderId,
+            DisplayName           = data.DisplayName,
+            Email                 = string.Empty,
+            Status                = data.Status,
+            ProjectsWithAccess    = [.. data.ProjectsWithAccess],
+            ProjectsWithoutAccess = [.. data.ProjectsWithoutAccess]
         });
     }
 
@@ -927,27 +884,7 @@ public class AuthorController(
         var (author, error) = await RequireCurrentAuthorAsync();
         if (error is not null || author is null) return error ?? Forbid();
 
-        foreach (var projectId in grantIds)
-        {
-            var existing = await readerAccessRepo.GetByReaderAndProjectAsync(readerId, projectId);
-            if (existing is null)
-            {
-                var access = ReaderAccess.Grant(readerId, author.Id, projectId);
-                await readerAccessRepo.AddAsync(access);
-            }
-            else if (!existing.IsActive)
-            {
-                existing.Reinstate();
-            }
-        }
-
-        foreach (var projectId in revokeIds)
-        {
-            var existing = await readerAccessRepo.GetByReaderAndProjectAsync(readerId, projectId);
-            existing?.Revoke();
-        }
-
-        await GetUnitOfWork().SaveChangesAsync();
+        await readerManagementService.UpdateReaderAccessAsync(readerId, grantIds, revokeIds, author.Id);
         TempData["Success"] = "Project access updated.";
         return RedirectToAction("Readers");
     }
@@ -962,17 +899,7 @@ public class AuthorController(
         var (author, error) = await RequireCurrentAuthorAsync();
         if (error is not null || author is null) return error ?? Forbid();
 
-        // Revoke all ReaderAccess for this author
-        var allProjects = await projectRepo.GetAllAsync();
-        foreach (var project in allProjects.Where(p => !p.IsSoftDeleted))
-        {
-            var access = await readerAccessRepo.GetByReaderAndProjectAsync(userId, project.Id);
-            access?.Revoke();
-        }
-
-        await userService.SoftDeleteUserAsync(userId, author.Id);
-
-        await GetUnitOfWork().SaveChangesAsync();
+        await readerManagementService.SoftDeleteReaderAsync(userId, author.Id);
         TempData["Success"] = "Reader removed.";
         return RedirectToAction("Readers");
     }
@@ -1025,9 +952,6 @@ public class AuthorController(
 
     private ICommentService GetCommentService() =>
         HttpContext.RequestServices.GetRequiredService<ICommentService>();
-
-    private IReadEventRepository GetReadEventRepo() =>
-        HttpContext.RequestServices.GetRequiredService<IReadEventRepository>();
 
     private static PublishingChapterViewModel MapChapterData(PublishingChapterData d) =>
         new()

--- a/TASKS.md
+++ b/TASKS.md
@@ -22,7 +22,7 @@ Last deployed: 2026-08-17 13:59 (commit: d51d201)
 | MT-Sprint Series | 🔴 HIGH PRIORITY — second author interest accelerates timeline; see `MultiTenancy.md` |
 | RD-Sprint Series | 🟡 In progress — RD-Sprint-1 (Continue Reading CTA) merged to main 2026-08-17; see section 3.7 |
 | DR-Sprint Series | ✅ Complete — merged to main 2026-08-17; see section 3.8 |
-| Incremental Refactor | 🟡 In progress — Phase 2a–2d complete, Phase 3 deferred; see section 3.6 |
+| Incremental Refactor | 🟡 In progress — Phase 2a–2e complete, Phase 3 deferred; see section 3.6 |
 | MU-Sprint Series | 🔵 Pre-implementation — design complete; see section 3.10 |
 | Go-Live Prerequisites | 🔴 Blocking — items below must complete before launch |
 | UAT | 🟡 In progress |
@@ -210,7 +210,7 @@ S-Sprint-1 complete — see `HISTORY.md`.
 ### 3.6 Incremental Refactor Roadmap
 See `REFACTORING.md` for full detail. Phase 1 complete — see `HISTORY.md`.
 
-**Status:** 🟡 In progress — Phase 2a–2d complete (PRs #31, #37, #39, #40, #41 merged). Phase 3 deferred. Web layer review identified ~530 lines of business logic violations — see `Web-Layer-Business-Logic-Review.md` for full detail.
+**Status:** 🟡 In progress — Phase 2a–2e complete (PRs #31, #37, #39, #40, #41 merged). Phase 3 deferred. Web layer review identified ~530 lines of business logic violations — see `Web-Layer-Business-Logic-Review.md` for full detail.
 
 - [x] **Phase 2a — Extract Critical Controller Orchestration** ✅ Complete (merged PR #31)
   - [x] Create `ISectionManagementService.GetSectionsSummaryAsync(projectId)` — extracted from `AuthorController.Sections`
@@ -227,6 +227,12 @@ See `REFACTORING.md` for full detail. Phase 1 complete — see `HISTORY.md`.
 - [x] **Phase 2d — Extract Helper Orchestration** ✅ Complete (merged PR #41)
   - [x] Create `IContentNavigationService` for tree-building helpers
   - [x] Extract reader management summary logic to `IReaderManagementService`
+- [x] **Phase 2e — Extract Remaining Violations** ✅ Complete
+  - [x] Extract `Section` action data gathering to `ISectionManagementService.GetSectionDetailAsync`
+  - [x] Extract `ResendInvitation` business logic to `IUserService.ResendInvitationAsync`
+  - [x] Extract `ManageReaderAccess` GET, `UpdateReaderAccess` POST, `SoftDeleteReader` POST to `IReaderManagementService`
+  - [x] Remove 3 unused constructor params from `AuthorController` (`sectionRepo`, `invitationRepo`, `readerAccessRepo`)
+  - [x] Full TDD: all new methods covered with unit tests
 
 **Original roadmap (deferred pending Web layer cleanup):**
 - [ ] Phase 3 — Decompose startup/seeding


### PR DESCRIPTION
## Summary

Phase 2e of the incremental refactor series. Extracts the remaining business logic violations from `AuthorController` identified in `Web-Layer-Business-Logic-Review.md`.

### Changes

**New service methods:**
- `ISectionManagementService.GetSectionDetailAsync` — aggregates section + parent chapter title + comment threads + comment author name map + read count (was scattered across `AuthorController.Section` with direct repo calls and a foreach loop)
- `IUserService.ResendInvitationAsync` — encapsulates deactivate-if-active + pending policy lookup + re-issue invitation (was all inline in the controller action)
- `IReaderManagementService.GetReaderAccessDataAsync` — status derivation + project partition (was inline in the `ManageReaderAccess` GET action)
- `IReaderManagementService.UpdateReaderAccessAsync` — grant/revoke foreach loops (was inline in the `UpdateReaderAccess` POST action)
- `IReaderManagementService.SoftDeleteReaderAsync` — uses `RevokeAllForReaderAsync` (replaces a per-project forEach loop that duplicated existing batch logic)

**`AuthorController` cleanup:**
- Removed 3 now-unused constructor parameters: `ISectionRepository`, `IInvitationRepository`, `IReaderAccessRepository`
- Removed `GetReadEventRepo()` service-locator helper (no longer needed)
- Removed unused `using Microsoft.EntityFrameworkCore`
- `Section`, `ResendInvitation`, `ManageReaderAccess`, `UpdateReaderAccess`, `SoftDeleteReader` actions reduced to single service calls

**Tests added/updated:**
- `SectionManagementServiceTests` — 3 new mock fields, updated `CreateSut`, 4 new `GetSectionDetailAsync` tests
- `ReaderManagementServiceTests` — 4 new mock fields, updated `CreateSut`, tests for all 3 new methods
- `UserServiceResendInvitationTests` — new file, 4 tests covering not-found, active reader deactivation, pending policy reuse, AlwaysOpen default
- `AuthorControllerTests` — removed 3 removed mock fields, updated `CreateSut`, updated `SoftDeleteReader` test to verify delegation to `IReaderManagementService`

---
_Generated by [Claude Code](https://claude.ai/code/session_018cmg5HSAwjvPtE1uXVg2bH)_