### PR TITLE
MU-Sprint-1: Domain entities and repository interfaces for manual chapter upload

### DIFF
--- a/DraftView.Domain.Tests/Entities/ManualChapterTests.cs
+++ b/DraftView.Domain.Tests/Entities/ManualChapterTests.cs
@@ -1,0 +1,170 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Tests.Entities;
+
+/// <summary>
+/// Tests for ManualChapter.Create and ManualChapterVersion.Create factory invariants.
+/// Covers: valid construction, title validation, sort-order validation, content validation,
+/// version number validation, and immutable-version construction.
+/// Excludes: persistence, repository behaviour, application service orchestration.
+/// </summary>
+public class ManualChapterTests
+{
+    private static readonly Guid ValidAuthorId  = Guid.NewGuid();
+    private static readonly Guid ValidProjectId = Guid.NewGuid();
+    private static readonly DateTime ValidUploadedAt =
+        new DateTime(2026, 8, 18, 10, 0, 0, DateTimeKind.Utc);
+
+    // ── ManualChapter.Create ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_WithValidData_CreatesManualChapter()
+    {
+        var chapter = ManualChapter.Create(
+            ValidAuthorId,
+            ValidProjectId,
+            "Chapter One",
+            0,
+            "Once upon a time…",
+            "chapter-one.txt",
+            ValidUploadedAt);
+
+        Assert.NotEqual(Guid.Empty, chapter.Id);
+        Assert.Equal(ValidAuthorId,  chapter.AuthorId);
+        Assert.Equal(ValidProjectId, chapter.ProjectId);
+        Assert.Equal("Chapter One",  chapter.Title);
+        Assert.Equal(0,              chapter.SortOrder);
+        Assert.Equal("Once upon a time…", chapter.RawContent);
+        Assert.Equal("chapter-one.txt",   chapter.OriginalFileName);
+        Assert.Equal(ValidUploadedAt,     chapter.UploadedAt);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithEmptyTitle_ThrowsInvariantViolation(string? title)
+    {
+#pragma warning disable CS8604
+        var ex = Assert.Throws<InvariantViolationException>(() =>
+            ManualChapter.Create(
+                ValidAuthorId, ValidProjectId,
+                title, 0, "content", null, ValidUploadedAt));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-MC-01", ex.InvariantCode);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Create_WithNegativeSortOrder_ThrowsInvariantViolation(int sortOrder)
+    {
+        var ex = Assert.Throws<InvariantViolationException>(() =>
+            ManualChapter.Create(
+                ValidAuthorId, ValidProjectId,
+                "Title", sortOrder, "content", null, ValidUploadedAt));
+
+        Assert.Equal("I-MC-02", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void Create_WithNullContent_ThrowsInvariantViolation()
+    {
+#pragma warning disable CS8625
+        var ex = Assert.Throws<InvariantViolationException>(() =>
+            ManualChapter.Create(
+                ValidAuthorId, ValidProjectId,
+                "Title", 0, null, null, ValidUploadedAt));
+#pragma warning restore CS8625
+
+        Assert.Equal("I-MC-03", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void Create_AllowsNullOriginalFileName()
+    {
+        var chapter = ManualChapter.Create(
+            ValidAuthorId, ValidProjectId,
+            "Pasted Chapter", 1, "pasted content", null, ValidUploadedAt);
+
+        Assert.Null(chapter.OriginalFileName);
+    }
+
+    [Fact]
+    public void Create_WithAuthorIdEmpty_ThrowsInvariantViolation()
+    {
+        var ex = Assert.Throws<InvariantViolationException>(() =>
+            ManualChapter.Create(
+                Guid.Empty, ValidProjectId,
+                "Title", 0, "content", null, ValidUploadedAt));
+
+        Assert.Equal("I-MC-04", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void Create_WithProjectIdEmpty_ThrowsInvariantViolation()
+    {
+        var ex = Assert.Throws<InvariantViolationException>(() =>
+            ManualChapter.Create(
+                ValidAuthorId, Guid.Empty,
+                "Title", 0, "content", null, ValidUploadedAt));
+
+        Assert.Equal("I-MC-05", ex.InvariantCode);
+    }
+
+    // ── ManualChapterVersion.Create ───────────────────────────────────────────
+
+    [Fact]
+    public void CreateVersion_WithValidData_CreatesManualChapterVersion()
+    {
+        var chapterId = Guid.NewGuid();
+        var snapshotAt = new DateTime(2026, 8, 18, 11, 0, 0, DateTimeKind.Utc);
+
+        var version = ManualChapterVersion.Create(
+            chapterId,
+            ValidAuthorId,
+            1,
+            "original content",
+            SnapshotReason.FileUpload,
+            snapshotAt);
+
+        Assert.NotEqual(Guid.Empty, version.Id);
+        Assert.Equal(chapterId,              version.ManualChapterId);
+        Assert.Equal(ValidAuthorId,          version.AuthorId);
+        Assert.Equal(1,                      version.VersionNumber);
+        Assert.Equal("original content",     version.RawContent);
+        Assert.Equal(SnapshotReason.FileUpload, version.SnapshotReason);
+        Assert.Equal(snapshotAt,             version.SnapshotAt);
+    }
+
+    [Fact]
+    public void CreateVersion_WithNullContent_ThrowsInvariantViolation()
+    {
+#pragma warning disable CS8625
+        var ex = Assert.Throws<InvariantViolationException>(() =>
+            ManualChapterVersion.Create(
+                Guid.NewGuid(), ValidAuthorId,
+                1, null, SnapshotReason.FileUpload,
+                DateTime.UtcNow));
+#pragma warning restore CS8625
+
+        Assert.Equal("I-MCV-01", ex.InvariantCode);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void CreateVersion_WithInvalidVersionNumber_ThrowsInvariantViolation(int versionNumber)
+    {
+        var ex = Assert.Throws<InvariantViolationException>(() =>
+            ManualChapterVersion.Create(
+                Guid.NewGuid(), ValidAuthorId,
+                versionNumber, "content", SnapshotReason.InlineEdit,
+                DateTime.UtcNow));
+
+        Assert.Equal("I-MCV-02", ex.InvariantCode);
+    }
+}

--- a/DraftView.Domain/Entities/ManualChapter.cs
+++ b/DraftView.Domain/Entities/ManualChapter.cs
@@ -1,0 +1,87 @@
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Entities;
+
+/// <summary>
+/// Represents a single chapter contributed to a manual-upload project.
+/// One file or paste submission equals one chapter — no auto-splitting.
+/// </summary>
+public sealed class ManualChapter
+{
+    public Guid Id { get; private set; }
+    public Guid AuthorId { get; private set; }
+    public Guid ProjectId { get; private set; }
+    public string Title { get; private set; } = default!;
+    public int SortOrder { get; private set; }
+    public string RawContent { get; private set; } = default!;
+    public string? OriginalFileName { get; private set; }
+    public DateTime UploadedAt { get; private set; }
+
+    private ManualChapter() { }
+
+    /// <summary>
+    /// Creates a new ManualChapter, enforcing all domain invariants.
+    /// </summary>
+    public static ManualChapter Create(
+        Guid authorId,
+        Guid projectId,
+        string title,
+        int sortOrder,
+        string rawContent,
+        string? originalFileName,
+        DateTime uploadedAt)
+    {
+        if (authorId == Guid.Empty)
+            throw new InvariantViolationException("I-MC-04", "AuthorId must not be empty.");
+        if (projectId == Guid.Empty)
+            throw new InvariantViolationException("I-MC-05", "ProjectId must not be empty.");
+        if (string.IsNullOrWhiteSpace(title))
+            throw new InvariantViolationException("I-MC-01", "Title must not be null or whitespace.");
+        if (sortOrder < 0)
+            throw new InvariantViolationException("I-MC-02", "SortOrder must be zero or positive.");
+        if (rawContent is null)
+            throw new InvariantViolationException("I-MC-03", "RawContent must not be null.");
+
+        return new ManualChapter
+        {
+            Id               = Guid.NewGuid(),
+            AuthorId         = authorId,
+            ProjectId        = projectId,
+            Title            = title.Trim(),
+            SortOrder        = sortOrder,
+            RawContent       = rawContent,
+            OriginalFileName = originalFileName,
+            UploadedAt       = uploadedAt
+        };
+    }
+
+    /// <summary>
+    /// Replaces the chapter's stored content in-place. Called before creating a version snapshot.
+    /// </summary>
+    public void UpdateContent(string rawContent)
+    {
+        if (rawContent is null)
+            throw new InvariantViolationException("I-MC-03", "RawContent must not be null.");
+        RawContent = rawContent;
+    }
+
+    /// <summary>
+    /// Changes the chapter title.
+    /// </summary>
+    public void UpdateTitle(string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new InvariantViolationException("I-MC-01", "Title must not be null or whitespace.");
+        Title = title.Trim();
+    }
+
+    /// <summary>
+    /// Changes the sort order.
+    /// </summary>
+    public void UpdateSortOrder(int sortOrder)
+    {
+        if (sortOrder < 0)
+            throw new InvariantViolationException("I-MC-02", "SortOrder must be zero or positive.");
+        SortOrder = sortOrder;
+    }
+}

--- a/DraftView.Domain/Entities/ManualChapterVersion.cs
+++ b/DraftView.Domain/Entities/ManualChapterVersion.cs
@@ -1,0 +1,49 @@
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Entities;
+
+/// <summary>
+/// Immutable snapshot of a ManualChapter's content at a point in time.
+/// Records are never modified after creation; hard-delete is the only removal path.
+/// </summary>
+public sealed class ManualChapterVersion
+{
+    public Guid Id { get; private set; }
+    public Guid ManualChapterId { get; private set; }
+    public Guid AuthorId { get; private set; }
+    public int VersionNumber { get; private set; }
+    public string RawContent { get; private set; } = default!;
+    public SnapshotReason SnapshotReason { get; private set; }
+    public DateTime SnapshotAt { get; private set; }
+
+    private ManualChapterVersion() { }
+
+    /// <summary>
+    /// Creates a new immutable ManualChapterVersion, enforcing all domain invariants.
+    /// </summary>
+    public static ManualChapterVersion Create(
+        Guid manualChapterId,
+        Guid authorId,
+        int versionNumber,
+        string rawContent,
+        SnapshotReason snapshotReason,
+        DateTime snapshotAt)
+    {
+        if (rawContent is null)
+            throw new InvariantViolationException("I-MCV-01", "RawContent must not be null.");
+        if (versionNumber <= 0)
+            throw new InvariantViolationException("I-MCV-02", "VersionNumber must be greater than zero.");
+
+        return new ManualChapterVersion
+        {
+            Id               = Guid.NewGuid(),
+            ManualChapterId  = manualChapterId,
+            AuthorId         = authorId,
+            VersionNumber    = versionNumber,
+            RawContent       = rawContent,
+            SnapshotReason   = snapshotReason,
+            SnapshotAt       = snapshotAt
+        };
+    }
+}

--- a/DraftView.Domain/Enumerations/SnapshotReason.cs
+++ b/DraftView.Domain/Enumerations/SnapshotReason.cs
@@ -1,0 +1,12 @@
+namespace DraftView.Domain.Enumerations;
+
+/// <summary>
+/// Records why a <see cref="DraftView.Domain.Entities.ManualChapterVersion"/> snapshot was created.
+/// </summary>
+public enum SnapshotReason
+{
+    FileUpload  = 0,
+    Replace     = 1,
+    PasteUpload = 2,
+    InlineEdit  = 3
+}

--- a/DraftView.Domain/Interfaces/Repositories/IManualChapterRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/IManualChapterRepository.cs
@@ -1,0 +1,27 @@
+using DraftView.Domain.Entities;
+
+namespace DraftView.Domain.Interfaces.Repositories;
+
+/// <summary>
+/// Persistence contract for ManualChapter. All queries are author-scoped.
+/// </summary>
+public interface IManualChapterRepository
+{
+    /// <summary>Returns all chapters for the given project, ordered by SortOrder ascending.</summary>
+    Task<IReadOnlyList<ManualChapter>> GetByProjectAsync(Guid projectId, Guid authorId, CancellationToken ct = default);
+
+    /// <summary>Returns the chapter with the given id, scoped to the author, or null if not found.</summary>
+    Task<ManualChapter?> GetByIdAsync(Guid chapterId, Guid authorId, CancellationToken ct = default);
+
+    /// <summary>Adds a new ManualChapter.</summary>
+    Task AddAsync(ManualChapter chapter, CancellationToken ct = default);
+
+    /// <summary>Persists in-place changes to an existing ManualChapter (content, title, sort order).</summary>
+    Task UpdateAsync(ManualChapter chapter, CancellationToken ct = default);
+
+    /// <summary>Hard-deletes the chapter with the given id.</summary>
+    Task DeleteAsync(Guid chapterId, Guid authorId, CancellationToken ct = default);
+
+    /// <summary>Returns the count of chapters in the given project.</summary>
+    Task<int> CountByProjectAsync(Guid projectId, Guid authorId, CancellationToken ct = default);
+}

--- a/DraftView.Domain/Interfaces/Repositories/IManualChapterVersionRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/IManualChapterVersionRepository.cs
@@ -1,0 +1,25 @@
+using DraftView.Domain.Entities;
+
+namespace DraftView.Domain.Interfaces.Repositories;
+
+/// <summary>
+/// Persistence contract for ManualChapterVersion. Versions are immutable after creation.
+/// The only removal path is ClearForChapterAsync (hard delete).
+/// </summary>
+public interface IManualChapterVersionRepository
+{
+    /// <summary>Returns all versions for the given chapter, ordered by VersionNumber descending.</summary>
+    Task<IReadOnlyList<ManualChapterVersion>> GetByChapterAsync(Guid chapterId, CancellationToken ct = default);
+
+    /// <summary>Adds a new ManualChapterVersion snapshot.</summary>
+    Task AddAsync(ManualChapterVersion version, CancellationToken ct = default);
+
+    /// <summary>
+    /// Hard-deletes all version records for the given chapter.
+    /// Does not affect the live ManualChapter content.
+    /// </summary>
+    Task ClearForChapterAsync(Guid chapterId, CancellationToken ct = default);
+
+    /// <summary>Returns the highest VersionNumber for the given chapter, or 0 if none exist.</summary>
+    Task<int> GetNextVersionNumberAsync(Guid chapterId, CancellationToken ct = default);
+}


### PR DESCRIPTION
## Summary

Implements MU-Sprint-1 (Domain layer) for the Manual Chapter Upload feature (issue #43).

- Introduces `ManualChapter` entity with full invariant enforcement (title non-empty, sort order ≥ 0, content non-null, author/project ids non-empty) and mutation methods `UpdateContent`, `UpdateTitle`, `UpdateSortOrder`
- Introduces `ManualChapterVersion` as an immutable snapshot entity — no setters, create-only, invariants on content non-null and version number > 0
- Adds `SnapshotReason` enum (`FileUpload | Replace | PasteUpload | InlineEdit`)
- Adds `IManualChapterRepository` — author-scoped CRUD + chapter count query
- Adds `IManualChapterVersionRepository` — add snapshot, list by chapter, `ClearForChapterAsync` (hard-delete path), next-version-number query
- Domain unit tests in `ManualChapterTests.cs` covering all six required test cases plus additional invariant coverage (author/project id empty, null original filename allowed)

## Architecture notes

- Entities follow the `Comment` / `AuthorNotification` factory pattern (private constructor, static `Create`, `InvariantViolationException` with coded invariant ids)
- `ManualChapterVersion` has no mutation methods — immutability is enforced structurally
- `ProjectType.Manual` already existed in the domain; no enum change needed
- Repository interfaces live in `DraftView.Domain.Interfaces.Repositories` — no infrastructure code in this sprint

## Test plan

- [ ] CI runs domain unit tests (`ManualChapterTests`) — no database dependency, should pass in all environments
- [ ] Verify `Create_WithValidData_CreatesManualChapter` sets all properties correctly
- [ ] Verify invariant codes `I-MC-01` through `I-MC-05` and `I-MCV-01`, `I-MCV-02` are thrown for invalid inputs
- [ ] Verify `CreateVersion_WithValidData_CreatesManualChapterVersion` sets all properties including `SnapshotReason`

## Cloud execution note

.NET SDK is not available in the remote execution container. Tests were written first (TDD requirement met) and will be validated by CI on this PR. No integration tests are included in this sprint — those arrive in MU-Sprint-2 alongside infrastructure and EF configuration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L52HgAVtkgswEti2QAmyhB)_