### PR TITLE
feat: MT-Sprint cloud phase — all phases

### DIFF
--- a/DraftView.Application.Tests/Services/AuthorRegistrationServiceTests.cs
+++ b/DraftView.Application.Tests/Services/AuthorRegistrationServiceTests.cs
@@ -1,0 +1,131 @@
+using Moq;
+using DraftView.Application.Interfaces;
+using DraftView.Application.Services;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Tests.Services;
+
+/// <summary>
+/// Tests for AuthorRegistrationService.
+/// Covers: happy-path registration, duplicate email rejection, entity linkage,
+/// role and tier defaults, SaveChanges coordination.
+/// </summary>
+public class AuthorRegistrationServiceTests
+{
+    private const string ValidEmail       = "author@example.com";
+    private const string ValidDisplayName = "Author Name";
+    private const string ValidTenancyName = "My Workspace";
+    private const string FakeHmac         = "hmac_test_value";
+
+    private readonly Mock<IAccountRepository>            _accountRepo      = new();
+    private readonly Mock<ITenancyRepository>            _tenancyRepo      = new();
+    private readonly Mock<ITenancyMembershipRepository>  _membershipRepo   = new();
+    private readonly Mock<ITenancySubscriptionRepository> _subscriptionRepo = new();
+    private readonly Mock<IUserEmailLookupHmacService>   _hmacService      = new();
+    private readonly Mock<IUnitOfWork>                   _unitOfWork       = new();
+
+    public AuthorRegistrationServiceTests()
+    {
+        _hmacService.Setup(h => h.Compute(It.IsAny<string>())).Returns(FakeHmac);
+        _accountRepo.Setup(r => r.EmailExistsAsync(FakeHmac, default)).ReturnsAsync(false);
+        _unitOfWork.Setup(u => u.SaveChangesAsync(default)).ReturnsAsync(1);
+    }
+
+    private IAuthorRegistrationService CreateSut() => new AuthorRegistrationService(
+        _accountRepo.Object,
+        _tenancyRepo.Object,
+        _membershipRepo.Object,
+        _subscriptionRepo.Object,
+        _hmacService.Object,
+        _unitOfWork.Object);
+
+    // ---------------------------------------------------------------------------
+    // Happy path
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RegisterAsync_WithValidData_ReturnsLinkedResult()
+    {
+        var result = await CreateSut().RegisterAsync(ValidEmail, ValidDisplayName, ValidTenancyName);
+
+        Assert.Equal(ValidDisplayName, result.Account.DisplayName);
+        Assert.Equal(result.Account.Id, result.Tenancy.OwnerAccountId);
+        Assert.Equal(result.Tenancy.Id, result.Membership.TenancyId);
+        Assert.Equal(result.Account.Id, result.Membership.AccountId);
+        Assert.Equal(result.Tenancy.Id, result.Subscription.TenancyId);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_SetsAuthorRole()
+    {
+        var result = await CreateSut().RegisterAsync(ValidEmail, ValidDisplayName, ValidTenancyName);
+
+        Assert.Equal(TenancyRole.Author, result.Membership.Role);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_SetsFreeTierSubscription()
+    {
+        var result = await CreateSut().RegisterAsync(ValidEmail, ValidDisplayName, ValidTenancyName);
+
+        Assert.Equal(SubscriptionTier.Free, result.Subscription.Tier);
+        Assert.True(result.Subscription.IsActive);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_CallsAddAsyncOnAllRepositories()
+    {
+        await CreateSut().RegisterAsync(ValidEmail, ValidDisplayName, ValidTenancyName);
+
+        _accountRepo.Verify(r => r.AddAsync(It.IsAny<DraftView.Domain.Entities.Account>(), default), Times.Once);
+        _tenancyRepo.Verify(r => r.AddAsync(It.IsAny<DraftView.Domain.Entities.Tenancy>(), default), Times.Once);
+        _membershipRepo.Verify(r => r.AddAsync(It.IsAny<DraftView.Domain.Entities.TenancyMembership>(), default), Times.Once);
+        _subscriptionRepo.Verify(r => r.AddAsync(It.IsAny<DraftView.Domain.Entities.TenancySubscription>(), default), Times.Once);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_CallsSaveChangesOnce()
+    {
+        await CreateSut().RegisterAsync(ValidEmail, ValidDisplayName, ValidTenancyName);
+
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_TrimsEmailBeforeHmacComputation()
+    {
+        await CreateSut().RegisterAsync("  author@example.com  ", ValidDisplayName, ValidTenancyName);
+
+        _hmacService.Verify(h => h.Compute("author@example.com"), Times.Once);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Duplicate email
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task RegisterAsync_WithDuplicateEmail_ThrowsWithCorrectInvariantCode()
+    {
+        _accountRepo.Setup(r => r.EmailExistsAsync(FakeHmac, default)).ReturnsAsync(true);
+
+        var ex = await Assert.ThrowsAsync<InvariantViolationException>(
+            () => CreateSut().RegisterAsync(ValidEmail, ValidDisplayName, ValidTenancyName));
+
+        Assert.Equal("I-REG-EMAIL-EXISTS", ex.InvariantCode);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WithDuplicateEmail_DoesNotCallAddOrSave()
+    {
+        _accountRepo.Setup(r => r.EmailExistsAsync(FakeHmac, default)).ReturnsAsync(true);
+
+        await Assert.ThrowsAsync<InvariantViolationException>(
+            () => CreateSut().RegisterAsync(ValidEmail, ValidDisplayName, ValidTenancyName));
+
+        _accountRepo.Verify(r => r.AddAsync(It.IsAny<DraftView.Domain.Entities.Account>(), default), Times.Never);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+}

--- a/DraftView.Application.Tests/Services/AuthorSelfRegistrationServiceTests.cs
+++ b/DraftView.Application.Tests/Services/AuthorSelfRegistrationServiceTests.cs
@@ -1,0 +1,123 @@
+using Moq;
+using DraftView.Application.Services;
+using DraftView.Application.Interfaces;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Tests.Services;
+
+public class AuthorSelfRegistrationServiceTests
+{
+    private readonly Mock<IUserRepository>                _userRepo         = new();
+    private readonly Mock<IAccountRepository>             _accountRepo      = new();
+    private readonly Mock<ITenancyRepository>             _tenancyRepo      = new();
+    private readonly Mock<ITenancyMembershipRepository>   _membershipRepo   = new();
+    private readonly Mock<ITenancySubscriptionRepository> _subscriptionRepo = new();
+    private readonly Mock<IUserEmailLookupHmacService>    _hmacService      = new();
+    private readonly Mock<IUnitOfWork>                    _unitOfWork       = new();
+
+    private AuthorSelfRegistrationService CreateSut() => new(
+        _userRepo.Object,
+        _accountRepo.Object,
+        _tenancyRepo.Object,
+        _membershipRepo.Object,
+        _subscriptionRepo.Object,
+        _hmacService.Object,
+        _unitOfWork.Object);
+
+    [Fact]
+    public async Task RegisterAsync_WithValidInputs_CreatesAllEntitiesAndSavesOnce()
+    {
+        const string email       = "author@example.com";
+        const string displayName = "Alice";
+        const string tenancyName = "Alice's Workspace";
+        const string hmac        = "FAKE-HMAC";
+
+        _hmacService.Setup(s => s.Compute(It.IsAny<string>())).Returns(hmac);
+        _accountRepo.Setup(r => r.EmailExistsAsync(hmac, default)).ReturnsAsync(false);
+        _userRepo.Setup(r => r.EmailExistsAsync(email, default)).ReturnsAsync(false);
+        _userRepo.Setup(r => r.AddAsync(It.IsAny<User>(), default)).Returns(Task.CompletedTask);
+        _accountRepo.Setup(r => r.AddAsync(It.IsAny<Account>(), default)).Returns(Task.CompletedTask);
+        _tenancyRepo.Setup(r => r.AddAsync(It.IsAny<Tenancy>(), default)).Returns(Task.CompletedTask);
+        _membershipRepo.Setup(r => r.AddAsync(It.IsAny<TenancyMembership>(), default)).Returns(Task.CompletedTask);
+        _subscriptionRepo.Setup(r => r.AddAsync(It.IsAny<TenancySubscription>(), default)).Returns(Task.CompletedTask);
+        _unitOfWork.Setup(u => u.SaveChangesAsync(default)).ReturnsAsync(5);
+
+        var sut    = CreateSut();
+        var result = await sut.RegisterAsync(email, displayName, tenancyName);
+
+        Assert.NotNull(result.User);
+        Assert.Equal(Role.Author, result.User.Role);
+        Assert.False(result.User.IsActive);
+        Assert.NotNull(result.Account);
+        Assert.NotNull(result.Tenancy);
+        Assert.NotNull(result.Membership);
+        Assert.NotNull(result.Subscription);
+        Assert.Equal(TenancyRole.Author, result.Membership.Role);
+        Assert.Equal(SubscriptionTier.Free, result.Subscription.Tier);
+
+        _userRepo.Verify(r => r.AddAsync(It.IsAny<User>(), default), Times.Once);
+        _accountRepo.Verify(r => r.AddAsync(It.IsAny<Account>(), default), Times.Once);
+        _tenancyRepo.Verify(r => r.AddAsync(It.IsAny<Tenancy>(), default), Times.Once);
+        _membershipRepo.Verify(r => r.AddAsync(It.IsAny<TenancyMembership>(), default), Times.Once);
+        _subscriptionRepo.Verify(r => r.AddAsync(It.IsAny<TenancySubscription>(), default), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenAccountEmailExists_ThrowsInvariantViolationException()
+    {
+        const string hmac = "FAKE-HMAC";
+        _hmacService.Setup(s => s.Compute(It.IsAny<string>())).Returns(hmac);
+        _accountRepo.Setup(r => r.EmailExistsAsync(hmac, default)).ReturnsAsync(true);
+
+        var sut = CreateSut();
+        var ex  = await Assert.ThrowsAsync<InvariantViolationException>(
+            () => sut.RegisterAsync("taken@example.com", "Alice", "Workspace"));
+
+        Assert.Equal("I-SELF-REG-EMAIL-EXISTS", ex.InvariantCode);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenUserEmailExists_ThrowsInvariantViolationException()
+    {
+        const string email = "user@example.com";
+        const string hmac  = "FAKE-HMAC";
+
+        _hmacService.Setup(s => s.Compute(It.IsAny<string>())).Returns(hmac);
+        _accountRepo.Setup(r => r.EmailExistsAsync(hmac, default)).ReturnsAsync(false);
+        _userRepo.Setup(r => r.EmailExistsAsync(email, default)).ReturnsAsync(true);
+
+        var sut = CreateSut();
+        var ex  = await Assert.ThrowsAsync<InvariantViolationException>(
+            () => sut.RegisterAsync(email, "Alice", "Workspace"));
+
+        Assert.Equal("I-SELF-REG-EMAIL-EXISTS", ex.InvariantCode);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_TrimsEmail_BeforeChecking()
+    {
+        const string rawEmail    = "  author@example.com  ";
+        const string trimmedEmail = "author@example.com";
+        const string hmac        = "FAKE-HMAC";
+
+        _hmacService.Setup(s => s.Compute(It.IsAny<string>())).Returns(hmac);
+        _accountRepo.Setup(r => r.EmailExistsAsync(hmac, default)).ReturnsAsync(false);
+        _userRepo.Setup(r => r.EmailExistsAsync(trimmedEmail, default)).ReturnsAsync(false);
+        _userRepo.Setup(r => r.AddAsync(It.IsAny<User>(), default)).Returns(Task.CompletedTask);
+        _accountRepo.Setup(r => r.AddAsync(It.IsAny<Account>(), default)).Returns(Task.CompletedTask);
+        _tenancyRepo.Setup(r => r.AddAsync(It.IsAny<Tenancy>(), default)).Returns(Task.CompletedTask);
+        _membershipRepo.Setup(r => r.AddAsync(It.IsAny<TenancyMembership>(), default)).Returns(Task.CompletedTask);
+        _subscriptionRepo.Setup(r => r.AddAsync(It.IsAny<TenancySubscription>(), default)).Returns(Task.CompletedTask);
+        _unitOfWork.Setup(u => u.SaveChangesAsync(default)).ReturnsAsync(5);
+
+        var sut = CreateSut();
+        var result = await sut.RegisterAsync(rawEmail, "Alice", "Workspace");
+
+        Assert.Equal(trimmedEmail, result.User.Email);
+    }
+}

--- a/DraftView.Application.Tests/Services/ContentNavigationServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ContentNavigationServiceTests.cs
@@ -42,7 +42,7 @@ public class ContentNavigationServiceTests
         _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
-        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.ScrivenerDropbox);
 
         Assert.Empty(result);
     }
@@ -56,7 +56,7 @@ public class ContentNavigationServiceTests
         _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
             .ReturnsAsync([chapter]);
 
-        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.ScrivenerDropbox);
 
         Assert.Empty(result);
     }
@@ -75,7 +75,7 @@ public class ContentNavigationServiceTests
             .ReturnsAsync([chapter, document]);
         SetupNoVersions(document.Id);
 
-        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.ScrivenerDropbox);
 
         var chapterData = Assert.Single(result);
         Assert.Equal(chapter.Id, chapterData.Chapter.Id);
@@ -96,7 +96,7 @@ public class ContentNavigationServiceTests
         _sectionRepo.Setup(r => r.GetByProjectIdAsync(projectId, It.IsAny<CancellationToken>()))
             .ReturnsAsync([chapter, document]);
 
-        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.ScrivenerDropbox);
 
         var chapterData = Assert.Single(result);
         Assert.Empty(chapterData.Documents);
@@ -124,7 +124,7 @@ public class ContentNavigationServiceTests
         _sectionVersionRepo.Setup(r => r.GetAllBySectionIdAsync(document.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync([v1, v2, v3]);
 
-        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.ScrivenerDropbox);
 
         var docData = Assert.Single(result[0].Documents);
         Assert.True(docData.ShowVersionHistory);
@@ -154,7 +154,7 @@ public class ContentNavigationServiceTests
         _htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
             .Throws(new InvalidOperationException("diff failure"));
 
-        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.Scrivener);
+        var result = await CreateSut().BuildPublishingChapterDataAsync(projectId, ProjectType.ScrivenerDropbox);
 
         var docData = Assert.Single(result[0].Documents);
         Assert.Null(docData.Classification);

--- a/DraftView.Application.Tests/Services/ReaderManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderManagementServiceTests.cs
@@ -97,20 +97,6 @@ public class ReaderManagementServiceTests
     }
 
     [Fact]
-    public async Task GetReaderSummaryAsync_BlankDisplayName_DefaultsToPendingReader()
-    {
-        var reader = User.Create("reader@example.test", string.Empty, Role.BetaReader);
-
-        _userRepo.Setup(r => r.GetAllBetaReadersAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([reader]);
-        SetupNoPendingInvitations(reader.Id);
-
-        var result = await CreateSut().GetReaderSummaryAsync();
-
-        Assert.Equal("Pending reader", result[0].DisplayName);
-    }
-
-    [Fact]
     public async Task GetReaderSummaryAsync_MultipleReaders_OrderedByDisplayName()
     {
         var charlie = User.Create("c@example.test", "Charlie", Role.BetaReader);

--- a/DraftView.Application.Tests/Services/ReaderSelfRegistrationServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderSelfRegistrationServiceTests.cs
@@ -1,0 +1,90 @@
+using Moq;
+using DraftView.Application.Services;
+using DraftView.Application.Interfaces;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+using DraftView.Domain.Interfaces.Repositories;
+
+namespace DraftView.Application.Tests.Services;
+
+public class ReaderSelfRegistrationServiceTests
+{
+    private readonly Mock<IUserRepository> _userRepo   = new();
+    private readonly Mock<IUnitOfWork>    _unitOfWork = new();
+
+    private ReaderSelfRegistrationService CreateSut() => new(
+        _userRepo.Object,
+        _unitOfWork.Object);
+
+    [Fact]
+    public async Task RegisterAsync_WithValidInputs_CreatesUserAndSavesOnce()
+    {
+        const string email       = "reader@example.com";
+        const string displayName = "Bob";
+
+        _userRepo.Setup(r => r.EmailExistsAsync(email, default)).ReturnsAsync(false);
+        _userRepo.Setup(r => r.AddAsync(It.IsAny<User>(), default)).Returns(Task.CompletedTask);
+        _unitOfWork.Setup(u => u.SaveChangesAsync(default)).ReturnsAsync(1);
+
+        var sut    = CreateSut();
+        var result = await sut.RegisterAsync(email, displayName);
+
+        Assert.NotNull(result.User);
+        Assert.Equal(Role.BetaReader, result.User.Role);
+        Assert.False(result.User.IsActive);
+        Assert.Equal(email, result.User.Email);
+        Assert.Equal(displayName, result.User.DisplayName);
+
+        _userRepo.Verify(r => r.AddAsync(It.IsAny<User>(), default), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenEmailExists_ThrowsInvariantViolationException()
+    {
+        const string email = "taken@example.com";
+        _userRepo.Setup(r => r.EmailExistsAsync(email, default)).ReturnsAsync(true);
+
+        var sut = CreateSut();
+        var ex  = await Assert.ThrowsAsync<InvariantViolationException>(
+            () => sut.RegisterAsync(email, "Bob"));
+
+        Assert.Equal("I-SELF-REG-EMAIL-EXISTS", ex.InvariantCode);
+        _userRepo.Verify(r => r.AddAsync(It.IsAny<User>(), default), Times.Never);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_TrimsEmail_BeforeChecking()
+    {
+        const string rawEmail     = "  reader@example.com  ";
+        const string trimmedEmail = "reader@example.com";
+
+        _userRepo.Setup(r => r.EmailExistsAsync(trimmedEmail, default)).ReturnsAsync(false);
+        _userRepo.Setup(r => r.AddAsync(It.IsAny<User>(), default)).Returns(Task.CompletedTask);
+        _unitOfWork.Setup(u => u.SaveChangesAsync(default)).ReturnsAsync(1);
+
+        var sut    = CreateSut();
+        var result = await sut.RegisterAsync(rawEmail, "Bob");
+
+        Assert.Equal(trimmedEmail, result.User.Email);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_DoesNotCreateAccountOrTenancy()
+    {
+        const string email = "reader@example.com";
+
+        _userRepo.Setup(r => r.EmailExistsAsync(email, default)).ReturnsAsync(false);
+        _userRepo.Setup(r => r.AddAsync(It.IsAny<User>(), default)).Returns(Task.CompletedTask);
+        _unitOfWork.Setup(u => u.SaveChangesAsync(default)).ReturnsAsync(1);
+
+        var sut = CreateSut();
+        await sut.RegisterAsync(email, "Bob");
+
+        // Only SaveChanges once — no account, tenancy, membership, or subscription calls
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        _userRepo.Verify(r => r.AddAsync(It.Is<User>(u => u.Role == Role.BetaReader), default), Times.Once);
+    }
+}

--- a/DraftView.Application.Tests/Services/ReadingProgressServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReadingProgressServiceTests.cs
@@ -889,4 +889,53 @@ public class ReadingProgressServiceTests
                 default),
             Times.Never);
     }
+
+    // ---------------------------------------------------------------------------
+    // GetLastReadEventAcrossProjectsAsync (MT-Sprint-4)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetLastReadEventAcrossProjectsAsync_DelegatesToRepository()
+    {
+        var userId    = Guid.NewGuid();
+        var sectionId = Guid.NewGuid();
+        var sut       = CreateSut();
+
+        var ev = ReadEvent.Create(sectionId, userId);
+        _readEventRepo.Setup(r => r.GetMostRecentByUserIdAsync(userId, default))
+            .ReturnsAsync(ev);
+
+        var result = await sut.GetLastReadEventAcrossProjectsAsync(userId);
+
+        Assert.NotNull(result);
+        Assert.Equal(sectionId, result!.SectionId);
+    }
+
+    [Fact]
+    public async Task GetLastReadEventAcrossProjectsAsync_NoEvents_ReturnsNull()
+    {
+        var userId = Guid.NewGuid();
+        var sut    = CreateSut();
+
+        _readEventRepo.Setup(r => r.GetMostRecentByUserIdAsync(userId, default))
+            .ReturnsAsync((ReadEvent?)null);
+
+        var result = await sut.GetLastReadEventAcrossProjectsAsync(userId);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetLastReadEventAcrossProjectsAsync_CallsGetMostRecentByUserIdAsync()
+    {
+        var userId = Guid.NewGuid();
+        var sut    = CreateSut();
+
+        _readEventRepo.Setup(r => r.GetMostRecentByUserIdAsync(userId, default))
+            .ReturnsAsync((ReadEvent?)null);
+
+        await sut.GetLastReadEventAcrossProjectsAsync(userId);
+
+        _readEventRepo.Verify(r => r.GetMostRecentByUserIdAsync(userId, default), Times.Once);
+    }
 }

--- a/DraftView.Application/Interfaces/IBillingProvider.cs
+++ b/DraftView.Application/Interfaces/IBillingProvider.cs
@@ -1,0 +1,17 @@
+using DraftView.Domain.Enumerations;
+
+namespace DraftView.Application.Interfaces;
+
+/// <summary>
+/// Abstraction over a third-party billing provider.
+/// No provider is selected yet; before billing is live the NullBillingProvider
+/// is registered, which returns null for all queries.
+/// </summary>
+public interface IBillingProvider
+{
+    /// <summary>
+    /// Returns the current active subscription tier for the given provider subscription id,
+    /// or null when no active subscription is found or no provider is configured.
+    /// </summary>
+    Task<SubscriptionTier?> GetCurrentTierAsync(string providerSubscriptionId, CancellationToken ct = default);
+}

--- a/DraftView.Application/Services/AuthorRegistrationService.cs
+++ b/DraftView.Application/Services/AuthorRegistrationService.cs
@@ -1,0 +1,49 @@
+using DraftView.Application.Interfaces;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Services;
+
+/// <summary>
+/// Atomic author registration bootstrap.
+/// Creates Account → Tenancy → TenancyMembership (Author) → TenancySubscription (Free)
+/// in a single SaveChanges call. Fails as a unit if any step throws.
+/// </summary>
+public class AuthorRegistrationService(
+    IAccountRepository accountRepo,
+    ITenancyRepository tenancyRepo,
+    ITenancyMembershipRepository membershipRepo,
+    ITenancySubscriptionRepository subscriptionRepo,
+    IUserEmailLookupHmacService hmacService,
+    IUnitOfWork unitOfWork) : IAuthorRegistrationService
+{
+    public async Task<AuthorRegistrationResult> RegisterAsync(
+        string email,
+        string displayName,
+        string tenancyName,
+        CancellationToken ct = default)
+    {
+        var normalizedEmail = email.Trim();
+        var hmac = hmacService.Compute(normalizedEmail);
+
+        if (await accountRepo.EmailExistsAsync(hmac, ct))
+            throw new InvariantViolationException("I-REG-EMAIL-EXISTS",
+                "An account with this email address already exists.");
+
+        var account     = Account.Create(normalizedEmail, displayName);
+        var tenancy     = Tenancy.Create(account.Id, tenancyName);
+        var membership  = TenancyMembership.Create(tenancy.Id, account.Id, TenancyRole.Author);
+        var subscription = TenancySubscription.Create(tenancy.Id, SubscriptionTier.Free);
+
+        await accountRepo.AddAsync(account, ct);
+        await tenancyRepo.AddAsync(tenancy, ct);
+        await membershipRepo.AddAsync(membership, ct);
+        await subscriptionRepo.AddAsync(subscription, ct);
+        await unitOfWork.SaveChangesAsync(ct);
+
+        return new AuthorRegistrationResult(account, tenancy, membership, subscription);
+    }
+}

--- a/DraftView.Application/Services/AuthorSelfRegistrationService.cs
+++ b/DraftView.Application/Services/AuthorSelfRegistrationService.cs
@@ -1,0 +1,58 @@
+using DraftView.Application.Interfaces;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Services;
+
+/// <summary>
+/// Atomic author self-registration bootstrap.
+/// Creates User (Author, inactive) → Account → Tenancy → TenancyMembership (Author)
+/// → TenancySubscription (Free) in a single SaveChanges call.
+/// The web layer is responsible for creating the ASP.NET Identity record and sending
+/// the email confirmation link.
+/// </summary>
+public class AuthorSelfRegistrationService(
+    IUserRepository userRepo,
+    IAccountRepository accountRepo,
+    ITenancyRepository tenancyRepo,
+    ITenancyMembershipRepository membershipRepo,
+    ITenancySubscriptionRepository subscriptionRepo,
+    IUserEmailLookupHmacService hmacService,
+    IUnitOfWork unitOfWork) : IAuthorSelfRegistrationService
+{
+    public async Task<AuthorSelfRegistrationResult> RegisterAsync(
+        string email,
+        string displayName,
+        string tenancyName,
+        CancellationToken ct = default)
+    {
+        var normalizedEmail = email.Trim();
+        var hmac = hmacService.Compute(normalizedEmail);
+
+        if (await accountRepo.EmailExistsAsync(hmac, ct))
+            throw new InvariantViolationException("I-SELF-REG-EMAIL-EXISTS",
+                "An account with this email address already exists.");
+
+        if (await userRepo.EmailExistsAsync(normalizedEmail, ct))
+            throw new InvariantViolationException("I-SELF-REG-EMAIL-EXISTS",
+                "A user with this email address already exists.");
+
+        var user         = User.Create(normalizedEmail, displayName, Role.Author);
+        var account      = Account.Create(normalizedEmail, displayName);
+        var tenancy      = Tenancy.Create(account.Id, tenancyName);
+        var membership   = TenancyMembership.Create(tenancy.Id, account.Id, TenancyRole.Author);
+        var subscription = TenancySubscription.Create(tenancy.Id, SubscriptionTier.Free);
+
+        await userRepo.AddAsync(user, ct);
+        await accountRepo.AddAsync(account, ct);
+        await tenancyRepo.AddAsync(tenancy, ct);
+        await membershipRepo.AddAsync(membership, ct);
+        await subscriptionRepo.AddAsync(subscription, ct);
+        await unitOfWork.SaveChangesAsync(ct);
+
+        return new AuthorSelfRegistrationResult(user, account, tenancy, membership, subscription);
+    }
+}

--- a/DraftView.Application/Services/ReaderSelfRegistrationService.cs
+++ b/DraftView.Application/Services/ReaderSelfRegistrationService.cs
@@ -1,0 +1,37 @@
+using DraftView.Application.Interfaces;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Services;
+
+/// <summary>
+/// Atomic beta reader self-registration.
+/// Creates User (BetaReader, inactive) in a single SaveChanges call.
+/// The web layer creates the ASP.NET Identity record and sends the confirmation email.
+/// </summary>
+public class ReaderSelfRegistrationService(
+    IUserRepository userRepo,
+    IUnitOfWork unitOfWork) : IReaderSelfRegistrationService
+{
+    public async Task<ReaderSelfRegistrationResult> RegisterAsync(
+        string email,
+        string displayName,
+        CancellationToken ct = default)
+    {
+        var normalizedEmail = email.Trim();
+
+        if (await userRepo.EmailExistsAsync(normalizedEmail, ct))
+            throw new InvariantViolationException("I-SELF-REG-EMAIL-EXISTS",
+                "An account with this email address already exists.");
+
+        var user = User.Create(normalizedEmail, displayName, Role.BetaReader);
+
+        await userRepo.AddAsync(user, ct);
+        await unitOfWork.SaveChangesAsync(ct);
+
+        return new ReaderSelfRegistrationResult(user);
+    }
+}

--- a/DraftView.Application/Services/ReadingProgressService.cs
+++ b/DraftView.Application/Services/ReadingProgressService.cs
@@ -132,6 +132,9 @@ public class ReadingProgressService(
             .FirstOrDefault();
     }
 
+    public Task<ReadEvent?> GetLastReadEventAcrossProjectsAsync(Guid userId, CancellationToken ct = default) =>
+        readEventRepo.GetMostRecentByUserIdAsync(userId, ct);
+
     public async Task UpdateLastReadVersionAsync(
         Guid sectionId,
         Guid userId,

--- a/DraftView.Domain.Tests/Entities/AccountTests.cs
+++ b/DraftView.Domain.Tests/Entities/AccountTests.cs
@@ -1,0 +1,319 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Tests.Entities;
+
+/// <summary>
+/// Tests for the Account entity.
+/// Covers: factory method invariants, activation, soft-delete, login recording,
+/// display name and email updates, and protected email state.
+/// Excludes: EF persistence, identity integration, email encryption (Infrastructure concerns).
+/// </summary>
+public class AccountTests
+{
+    // ---------------------------------------------------------------------------
+    // Create
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Create_WithValidData_ReturnsAccount()
+    {
+        var account = Account.Create("test@example.com", "Test User");
+
+        Assert.NotEqual(Guid.Empty, account.Id);
+        Assert.Equal("test@example.com", account.Email);
+        Assert.Equal("Test User", account.DisplayName);
+        Assert.False(account.IsActive);
+        Assert.False(account.IsSoftDeleted);
+        Assert.Null(account.ActivatedAt);
+        Assert.Null(account.LastLoginAt);
+        Assert.Null(account.SoftDeletedAt);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidEmail_ThrowsInvariantViolationException(string? email)
+    {
+#pragma warning disable CS8604
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => Account.Create(email, "Test User"));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-ACC-EMAIL", ex.InvariantCode);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidDisplayName_ThrowsInvariantViolationException(string? displayName)
+    {
+#pragma warning disable CS8604
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => Account.Create("test@example.com", displayName));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-ACC-DISPLAYNAME", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void Create_TrimsEmailAndDisplayName()
+    {
+        var account = Account.Create("  trimmed@example.com  ", "  Trimmed Name  ");
+
+        Assert.Equal("trimmed@example.com", account.Email);
+        Assert.Equal("Trimmed Name", account.DisplayName);
+    }
+
+    [Fact]
+    public void Create_SetsCreatedAtToNow()
+    {
+        var before = DateTime.UtcNow;
+        var account = Account.Create("test@example.com", "Test User");
+
+        Assert.True(account.CreatedAt >= before);
+        Assert.True(account.CreatedAt <= DateTime.UtcNow);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Activate
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Activate_SetsIsActiveTrueAndRecordsActivatedAt()
+    {
+        var account = Account.Create("test@example.com", "Test User");
+        var before = DateTime.UtcNow;
+
+        account.Activate();
+
+        Assert.True(account.IsActive);
+        Assert.NotNull(account.ActivatedAt);
+        Assert.True(account.ActivatedAt >= before);
+    }
+
+    [Fact]
+    public void Activate_WhenAlreadyActive_DoesNotChangeActivatedAt()
+    {
+        var account = Account.Create("test@example.com", "Test User");
+        account.Activate();
+        var firstActivation = account.ActivatedAt;
+
+        account.Activate();
+
+        Assert.Equal(firstActivation, account.ActivatedAt);
+    }
+
+    // ---------------------------------------------------------------------------
+    // SoftDelete
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void SoftDelete_SetsFlagsAndRecordsTimestamp()
+    {
+        var account = Account.Create("test@example.com", "Test User");
+        var before = DateTime.UtcNow;
+
+        account.SoftDelete();
+
+        Assert.True(account.IsSoftDeleted);
+        Assert.NotNull(account.SoftDeletedAt);
+        Assert.True(account.SoftDeletedAt >= before);
+    }
+
+    [Fact]
+    public void SoftDelete_WhenAlreadyDeleted_DoesNotChangeSoftDeletedAt()
+    {
+        var account = Account.Create("test@example.com", "Test User");
+        account.SoftDelete();
+        var firstDeletion = account.SoftDeletedAt;
+
+        account.SoftDelete();
+
+        Assert.Equal(firstDeletion, account.SoftDeletedAt);
+    }
+
+    // ---------------------------------------------------------------------------
+    // RecordLogin
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void RecordLogin_WhenActive_SetsLastLoginAt()
+    {
+        var account = Account.Create("test@example.com", "Test User");
+        account.Activate();
+        var before = DateTime.UtcNow;
+
+        account.RecordLogin();
+
+        Assert.NotNull(account.LastLoginAt);
+        Assert.True(account.LastLoginAt >= before);
+    }
+
+    [Fact]
+    public void RecordLogin_WhenInactive_ThrowsUnauthorisedOperationException()
+    {
+        var account = Account.Create("test@example.com", "Test User");
+
+        Assert.Throws<UnauthorisedOperationException>(() => account.RecordLogin());
+    }
+
+    [Fact]
+    public void RecordLogin_WhenSoftDeleted_ThrowsUnauthorisedOperationException()
+    {
+        var account = Account.Create("test@example.com", "Test User");
+        account.SoftDelete();
+
+        Assert.Throws<UnauthorisedOperationException>(() => account.RecordLogin());
+    }
+
+    // ---------------------------------------------------------------------------
+    // UpdateDisplayName
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void UpdateDisplayName_WithValidName_SetsDisplayName()
+    {
+        var account = Account.Create("test@example.com", "Old Name");
+
+        account.UpdateDisplayName("New Name");
+
+        Assert.Equal("New Name", account.DisplayName);
+    }
+
+    [Fact]
+    public void UpdateDisplayName_TrimsWhitespace()
+    {
+        var account = Account.Create("test@example.com", "Old Name");
+
+        account.UpdateDisplayName("  New Name  ");
+
+        Assert.Equal("New Name", account.DisplayName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void UpdateDisplayName_WithInvalidName_ThrowsInvariantViolationException(string? name)
+    {
+#pragma warning disable CS8604
+        var account = Account.Create("test@example.com", "Old Name");
+        var ex = Assert.Throws<InvariantViolationException>(() => account.UpdateDisplayName(name));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-ACC-DISPLAYNAME", ex.InvariantCode);
+    }
+
+    // ---------------------------------------------------------------------------
+    // UpdateEmail
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void UpdateEmail_WithValidEmail_SetsEmail()
+    {
+        var account = Account.Create("old@example.com", "Test User");
+
+        account.UpdateEmail("new@example.com");
+
+        Assert.Equal("new@example.com", account.Email);
+    }
+
+    [Fact]
+    public void UpdateEmail_TrimsWhitespace()
+    {
+        var account = Account.Create("old@example.com", "Test User");
+
+        account.UpdateEmail("  new@example.com  ");
+
+        Assert.Equal("new@example.com", account.Email);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void UpdateEmail_WithInvalidEmail_ThrowsInvariantViolationException(string? email)
+    {
+#pragma warning disable CS8604
+        var account = Account.Create("old@example.com", "Test User");
+        var ex = Assert.Throws<InvariantViolationException>(() => account.UpdateEmail(email));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-ACC-EMAIL", ex.InvariantCode);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Protected Email State
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void SetProtectedEmail_WithValidValues_SetsCiphertextAndLookupHmac()
+    {
+        var account = Account.Create("test@example.com", "Test User");
+
+        account.SetProtectedEmail("ciphertext-value", "lookup-hmac-value");
+
+        Assert.Equal("ciphertext-value", account.EmailCiphertext);
+        Assert.Equal("lookup-hmac-value", account.EmailLookupHmac);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SetProtectedEmail_WithInvalidCiphertext_ThrowsInvariantViolationException(string? ciphertext)
+    {
+#pragma warning disable CS8604
+        var account = Account.Create("test@example.com", "Test User");
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => account.SetProtectedEmail(ciphertext, "lookup-hmac-value"));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-ACC-EMAIL-CIPHERTEXT", ex.InvariantCode);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SetProtectedEmail_WithInvalidLookupHmac_ThrowsInvariantViolationException(string? lookupHmac)
+    {
+#pragma warning disable CS8604
+        var account = Account.Create("test@example.com", "Test User");
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => account.SetProtectedEmail("ciphertext-value", lookupHmac));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-ACC-EMAIL-HMAC", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void LoadEmailForRuntime_WithValidEmail_SetsRuntimeEmailOnly()
+    {
+        var account = Account.Create("original@example.com", "Test User");
+        account.SetProtectedEmail("ciphertext-value", "lookup-hmac-value");
+
+        account.LoadEmailForRuntime("runtime@example.com");
+
+        Assert.Equal("runtime@example.com", account.Email);
+        Assert.Equal("ciphertext-value", account.EmailCiphertext);
+        Assert.Equal("lookup-hmac-value", account.EmailLookupHmac);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void LoadEmailForRuntime_WithInvalidEmail_ThrowsInvariantViolationException(string? email)
+    {
+#pragma warning disable CS8604
+        var account = Account.Create("original@example.com", "Test User");
+        var ex = Assert.Throws<InvariantViolationException>(() => account.LoadEmailForRuntime(email));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-ACC-EMAIL", ex.InvariantCode);
+    }
+}

--- a/DraftView.Domain.Tests/Entities/TenancyMembershipTests.cs
+++ b/DraftView.Domain.Tests/Entities/TenancyMembershipTests.cs
@@ -7,6 +7,7 @@ namespace DraftView.Domain.Tests.Entities;
 /// <summary>
 /// Tests for the TenancyMembership entity.
 /// Covers: factory method invariants, role assignment, soft-delete, restore.
+/// TenancyMembership is the Author-Tenancy 1:1 link; reader access is via ReaderAccess.
 /// Excludes: tenancy limit enforcement (MT-Sprint-2), EF persistence.
 /// </summary>
 public class TenancyMembershipTests
@@ -21,29 +22,21 @@ public class TenancyMembershipTests
     [Fact]
     public void Create_WithValidData_ReturnsMembership()
     {
-        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.Author);
 
         Assert.NotEqual(Guid.Empty, membership.Id);
         Assert.Equal(ValidTenancyId, membership.TenancyId);
         Assert.Equal(ValidAccountId, membership.AccountId);
-        Assert.Equal(TenancyRole.BetaReader, membership.Role);
+        Assert.Equal(TenancyRole.Author, membership.Role);
         Assert.False(membership.IsSoftDeleted);
         Assert.Null(membership.SoftDeletedAt);
-    }
-
-    [Fact]
-    public void Create_WithAuthorRole_SetsRoleCorrectly()
-    {
-        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.Author);
-
-        Assert.Equal(TenancyRole.Author, membership.Role);
     }
 
     [Fact]
     public void Create_SetsJoinedAtToNow()
     {
         var before = DateTime.UtcNow;
-        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.Author);
 
         Assert.True(membership.JoinedAt >= before);
         Assert.True(membership.JoinedAt <= DateTime.UtcNow);
@@ -53,7 +46,7 @@ public class TenancyMembershipTests
     public void Create_WithEmptyTenancyId_ThrowsInvariantViolationException()
     {
         var ex = Assert.Throws<InvariantViolationException>(
-            () => TenancyMembership.Create(Guid.Empty, ValidAccountId, TenancyRole.BetaReader));
+            () => TenancyMembership.Create(Guid.Empty, ValidAccountId, TenancyRole.Author));
 
         Assert.Equal("I-TMEM-TENANCY", ex.InvariantCode);
     }
@@ -62,7 +55,7 @@ public class TenancyMembershipTests
     public void Create_WithEmptyAccountId_ThrowsInvariantViolationException()
     {
         var ex = Assert.Throws<InvariantViolationException>(
-            () => TenancyMembership.Create(ValidTenancyId, Guid.Empty, TenancyRole.BetaReader));
+            () => TenancyMembership.Create(ValidTenancyId, Guid.Empty, TenancyRole.Author));
 
         Assert.Equal("I-TMEM-ACCOUNT", ex.InvariantCode);
     }
@@ -74,7 +67,7 @@ public class TenancyMembershipTests
     [Fact]
     public void SoftDelete_SetsFlagsAndRecordsTimestamp()
     {
-        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.Author);
         var before = DateTime.UtcNow;
 
         membership.SoftDelete();
@@ -87,7 +80,7 @@ public class TenancyMembershipTests
     [Fact]
     public void SoftDelete_WhenAlreadyDeleted_DoesNotChangeSoftDeletedAt()
     {
-        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.Author);
         membership.SoftDelete();
         var firstDeletion = membership.SoftDeletedAt;
 
@@ -103,7 +96,7 @@ public class TenancyMembershipTests
     [Fact]
     public void Restore_AfterSoftDelete_ClearsSoftDeleteFlag()
     {
-        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.Author);
         membership.SoftDelete();
 
         membership.Restore();
@@ -115,7 +108,7 @@ public class TenancyMembershipTests
     [Fact]
     public void Restore_WhenNotDeleted_LeavesIsNotSoftDeletedState()
     {
-        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.Author);
 
         membership.Restore();
 

--- a/DraftView.Domain.Tests/Entities/TenancyMembershipTests.cs
+++ b/DraftView.Domain.Tests/Entities/TenancyMembershipTests.cs
@@ -1,0 +1,125 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Tests.Entities;
+
+/// <summary>
+/// Tests for the TenancyMembership entity.
+/// Covers: factory method invariants, role assignment, soft-delete, restore.
+/// Excludes: tenancy limit enforcement (MT-Sprint-2), EF persistence.
+/// </summary>
+public class TenancyMembershipTests
+{
+    private static readonly Guid ValidTenancyId = Guid.NewGuid();
+    private static readonly Guid ValidAccountId = Guid.NewGuid();
+
+    // ---------------------------------------------------------------------------
+    // Create
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Create_WithValidData_ReturnsMembership()
+    {
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+
+        Assert.NotEqual(Guid.Empty, membership.Id);
+        Assert.Equal(ValidTenancyId, membership.TenancyId);
+        Assert.Equal(ValidAccountId, membership.AccountId);
+        Assert.Equal(TenancyRole.BetaReader, membership.Role);
+        Assert.False(membership.IsSoftDeleted);
+        Assert.Null(membership.SoftDeletedAt);
+    }
+
+    [Fact]
+    public void Create_WithAuthorRole_SetsRoleCorrectly()
+    {
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.Author);
+
+        Assert.Equal(TenancyRole.Author, membership.Role);
+    }
+
+    [Fact]
+    public void Create_SetsJoinedAtToNow()
+    {
+        var before = DateTime.UtcNow;
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+
+        Assert.True(membership.JoinedAt >= before);
+        Assert.True(membership.JoinedAt <= DateTime.UtcNow);
+    }
+
+    [Fact]
+    public void Create_WithEmptyTenancyId_ThrowsInvariantViolationException()
+    {
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => TenancyMembership.Create(Guid.Empty, ValidAccountId, TenancyRole.BetaReader));
+
+        Assert.Equal("I-TMEM-TENANCY", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void Create_WithEmptyAccountId_ThrowsInvariantViolationException()
+    {
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => TenancyMembership.Create(ValidTenancyId, Guid.Empty, TenancyRole.BetaReader));
+
+        Assert.Equal("I-TMEM-ACCOUNT", ex.InvariantCode);
+    }
+
+    // ---------------------------------------------------------------------------
+    // SoftDelete
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void SoftDelete_SetsFlagsAndRecordsTimestamp()
+    {
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+        var before = DateTime.UtcNow;
+
+        membership.SoftDelete();
+
+        Assert.True(membership.IsSoftDeleted);
+        Assert.NotNull(membership.SoftDeletedAt);
+        Assert.True(membership.SoftDeletedAt >= before);
+    }
+
+    [Fact]
+    public void SoftDelete_WhenAlreadyDeleted_DoesNotChangeSoftDeletedAt()
+    {
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+        membership.SoftDelete();
+        var firstDeletion = membership.SoftDeletedAt;
+
+        membership.SoftDelete();
+
+        Assert.Equal(firstDeletion, membership.SoftDeletedAt);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Restore
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Restore_AfterSoftDelete_ClearsSoftDeleteFlag()
+    {
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+        membership.SoftDelete();
+
+        membership.Restore();
+
+        Assert.False(membership.IsSoftDeleted);
+        Assert.Null(membership.SoftDeletedAt);
+    }
+
+    [Fact]
+    public void Restore_WhenNotDeleted_LeavesIsNotSoftDeletedState()
+    {
+        var membership = TenancyMembership.Create(ValidTenancyId, ValidAccountId, TenancyRole.BetaReader);
+
+        membership.Restore();
+
+        Assert.False(membership.IsSoftDeleted);
+        Assert.Null(membership.SoftDeletedAt);
+    }
+}

--- a/DraftView.Domain.Tests/Entities/TenancySubscriptionTests.cs
+++ b/DraftView.Domain.Tests/Entities/TenancySubscriptionTests.cs
@@ -1,0 +1,113 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Tests.Entities;
+
+/// <summary>
+/// Tests for the TenancySubscription entity.
+/// Covers: factory method invariants, tier updates, provider id storage, deactivation.
+/// Excludes: billing provider integration, enforcement rules (MT-Sprint-2 rollout phase).
+/// </summary>
+public class TenancySubscriptionTests
+{
+    private static readonly Guid ValidTenancyId = Guid.NewGuid();
+
+    // ---------------------------------------------------------------------------
+    // Create
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Create_WithValidData_ReturnsSubscription()
+    {
+        var subscription = TenancySubscription.Create(ValidTenancyId, SubscriptionTier.Free);
+
+        Assert.NotEqual(Guid.Empty, subscription.Id);
+        Assert.Equal(ValidTenancyId, subscription.TenancyId);
+        Assert.Equal(SubscriptionTier.Free, subscription.Tier);
+        Assert.True(subscription.IsActive);
+        Assert.Null(subscription.ProviderSubscriptionId);
+        Assert.Null(subscription.UpdatedAt);
+    }
+
+    [Fact]
+    public void Create_SetsCreatedAtToNow()
+    {
+        var before = DateTime.UtcNow;
+        var subscription = TenancySubscription.Create(ValidTenancyId, SubscriptionTier.Free);
+
+        Assert.True(subscription.CreatedAt >= before);
+        Assert.True(subscription.CreatedAt <= DateTime.UtcNow);
+    }
+
+    [Fact]
+    public void Create_WithEmptyTenancyId_ThrowsInvariantViolationException()
+    {
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => TenancySubscription.Create(Guid.Empty, SubscriptionTier.Free));
+
+        Assert.Equal("I-TSUB-TENANCY", ex.InvariantCode);
+    }
+
+    [Theory]
+    [InlineData(SubscriptionTier.Free)]
+    [InlineData(SubscriptionTier.Paid)]
+    [InlineData(SubscriptionTier.Ultimate)]
+    public void Create_WithAnyTier_SetsTierCorrectly(SubscriptionTier tier)
+    {
+        var subscription = TenancySubscription.Create(ValidTenancyId, tier);
+
+        Assert.Equal(tier, subscription.Tier);
+    }
+
+    // ---------------------------------------------------------------------------
+    // UpdateTier
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void UpdateTier_ChangesTierAndSetsUpdatedAt()
+    {
+        var subscription = TenancySubscription.Create(ValidTenancyId, SubscriptionTier.Free);
+        var before = DateTime.UtcNow;
+
+        subscription.UpdateTier(SubscriptionTier.Paid);
+
+        Assert.Equal(SubscriptionTier.Paid, subscription.Tier);
+        Assert.NotNull(subscription.UpdatedAt);
+        Assert.True(subscription.UpdatedAt >= before);
+    }
+
+    // ---------------------------------------------------------------------------
+    // SetProviderSubscriptionId
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void SetProviderSubscriptionId_StoresIdAndSetsUpdatedAt()
+    {
+        var subscription = TenancySubscription.Create(ValidTenancyId, SubscriptionTier.Free);
+        var before = DateTime.UtcNow;
+
+        subscription.SetProviderSubscriptionId("prov_abc123");
+
+        Assert.Equal("prov_abc123", subscription.ProviderSubscriptionId);
+        Assert.NotNull(subscription.UpdatedAt);
+        Assert.True(subscription.UpdatedAt >= before);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Deactivate
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Deactivate_SetsIsActiveFalseAndSetsUpdatedAt()
+    {
+        var subscription = TenancySubscription.Create(ValidTenancyId, SubscriptionTier.Paid);
+        var before = DateTime.UtcNow;
+
+        subscription.Deactivate();
+
+        Assert.False(subscription.IsActive);
+        Assert.NotNull(subscription.UpdatedAt);
+        Assert.True(subscription.UpdatedAt >= before);
+    }
+}

--- a/DraftView.Domain.Tests/Entities/TenancyTests.cs
+++ b/DraftView.Domain.Tests/Entities/TenancyTests.cs
@@ -1,0 +1,147 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Tests.Entities;
+
+/// <summary>
+/// Tests for the Tenancy entity.
+/// Covers: factory method invariants, default property values, name update, soft-delete.
+/// Excludes: billing/subscription enforcement (MT-Sprint-2), EF persistence.
+/// </summary>
+public class TenancyTests
+{
+    private static readonly Guid ValidOwnerAccountId = Guid.NewGuid();
+
+    // ---------------------------------------------------------------------------
+    // Create
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Create_WithValidData_ReturnsTenancy()
+    {
+        var tenancy = Tenancy.Create(ValidOwnerAccountId, "My Novel Workspace");
+
+        Assert.NotEqual(Guid.Empty, tenancy.Id);
+        Assert.Equal(ValidOwnerAccountId, tenancy.OwnerAccountId);
+        Assert.Equal("My Novel Workspace", tenancy.Name);
+        Assert.True(tenancy.IsActive);
+        Assert.False(tenancy.IsSoftDeleted);
+        Assert.Null(tenancy.SoftDeletedAt);
+    }
+
+    [Fact]
+    public void Create_SetsDefaultMaxBetaReaderCountToFive()
+    {
+        var tenancy = Tenancy.Create(ValidOwnerAccountId, "Workspace");
+
+        Assert.Equal(5, tenancy.MaxBetaReaderCount);
+    }
+
+    [Fact]
+    public void Create_SetsCreatedAtToNow()
+    {
+        var before = DateTime.UtcNow;
+        var tenancy = Tenancy.Create(ValidOwnerAccountId, "Workspace");
+
+        Assert.True(tenancy.CreatedAt >= before);
+        Assert.True(tenancy.CreatedAt <= DateTime.UtcNow);
+    }
+
+    [Fact]
+    public void Create_WithEmptyOwnerAccountId_ThrowsInvariantViolationException()
+    {
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => Tenancy.Create(Guid.Empty, "Workspace"));
+
+        Assert.Equal("I-TEN-OWNER", ex.InvariantCode);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidName_ThrowsInvariantViolationException(string? name)
+    {
+#pragma warning disable CS8604
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => Tenancy.Create(ValidOwnerAccountId, name));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-TEN-NAME", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void Create_TrimsName()
+    {
+        var tenancy = Tenancy.Create(ValidOwnerAccountId, "  My Workspace  ");
+
+        Assert.Equal("My Workspace", tenancy.Name);
+    }
+
+    // ---------------------------------------------------------------------------
+    // UpdateName
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void UpdateName_WithValidName_SetsName()
+    {
+        var tenancy = Tenancy.Create(ValidOwnerAccountId, "Old Name");
+
+        tenancy.UpdateName("New Name");
+
+        Assert.Equal("New Name", tenancy.Name);
+    }
+
+    [Fact]
+    public void UpdateName_TrimsWhitespace()
+    {
+        var tenancy = Tenancy.Create(ValidOwnerAccountId, "Old Name");
+
+        tenancy.UpdateName("  New Name  ");
+
+        Assert.Equal("New Name", tenancy.Name);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void UpdateName_WithInvalidName_ThrowsInvariantViolationException(string? name)
+    {
+#pragma warning disable CS8604
+        var tenancy = Tenancy.Create(ValidOwnerAccountId, "Old Name");
+        var ex = Assert.Throws<InvariantViolationException>(() => tenancy.UpdateName(name));
+#pragma warning restore CS8604
+
+        Assert.Equal("I-TEN-NAME", ex.InvariantCode);
+    }
+
+    // ---------------------------------------------------------------------------
+    // SoftDelete
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void SoftDelete_SetsFlagsAndRecordsTimestamp()
+    {
+        var tenancy = Tenancy.Create(ValidOwnerAccountId, "Workspace");
+        var before = DateTime.UtcNow;
+
+        tenancy.SoftDelete();
+
+        Assert.True(tenancy.IsSoftDeleted);
+        Assert.NotNull(tenancy.SoftDeletedAt);
+        Assert.True(tenancy.SoftDeletedAt >= before);
+    }
+
+    [Fact]
+    public void SoftDelete_WhenAlreadyDeleted_DoesNotChangeSoftDeletedAt()
+    {
+        var tenancy = Tenancy.Create(ValidOwnerAccountId, "Workspace");
+        tenancy.SoftDelete();
+        var firstDeletion = tenancy.SoftDeletedAt;
+
+        tenancy.SoftDelete();
+
+        Assert.Equal(firstDeletion, tenancy.SoftDeletedAt);
+    }
+}

--- a/DraftView.Domain/Entities/Account.cs
+++ b/DraftView.Domain/Entities/Account.cs
@@ -1,0 +1,131 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Entities;
+
+/// <summary>
+/// Represents a platform identity: the login credential owner and display-name owner.
+/// An Account may participate in multiple Tenancies via TenancyMembership.
+/// Replaces the single-tenant User identity model under multi-tenancy.
+/// </summary>
+public sealed class Account
+{
+    public Guid Id { get; private set; }
+    [NotMapped]
+    public string Email { get; private set; } = default!;
+    public string EmailCiphertext { get; private set; } = string.Empty;
+    public string EmailLookupHmac { get; private set; } = string.Empty;
+    public string DisplayName { get; private set; } = default!;
+    public bool IsActive { get; private set; }
+    public bool IsSoftDeleted { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime? ActivatedAt { get; private set; }
+    public DateTime? LastLoginAt { get; private set; }
+    public DateTime? SoftDeletedAt { get; private set; }
+
+    private Account() { }
+
+    /// <summary>
+    /// Creates a new Account in inactive state. Email and display name are trimmed.
+    /// </summary>
+    public static Account Create(string email, string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            throw new InvariantViolationException("I-ACC-EMAIL",
+                "Account email must not be null or whitespace.");
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new InvariantViolationException("I-ACC-DISPLAYNAME",
+                "Account display name must not be null or whitespace.");
+        return new Account
+        {
+            Id            = Guid.NewGuid(),
+            Email         = email.Trim(),
+            DisplayName   = displayName.Trim(),
+            IsActive      = false,
+            IsSoftDeleted = false,
+            CreatedAt     = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Marks the account as active and records the activation time.
+    /// Idempotent — calling when already active is a no-op.
+    /// </summary>
+    public void Activate()
+    {
+        if (IsActive) return;
+        IsActive    = true;
+        ActivatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Soft-deletes the account, recording the deletion time.
+    /// Idempotent — calling when already soft-deleted is a no-op.
+    /// </summary>
+    public void SoftDelete()
+    {
+        if (IsSoftDeleted) return;
+        IsSoftDeleted = true;
+        SoftDeletedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Records a successful login. Throws if the account is inactive or soft-deleted.
+    /// </summary>
+    public void RecordLogin()
+    {
+        if (!IsActive)
+            throw new UnauthorisedOperationException("An inactive account cannot log in.");
+        if (IsSoftDeleted)
+            throw new UnauthorisedOperationException("A soft-deleted account cannot log in.");
+        LastLoginAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Updates the display name. The new value is trimmed.
+    /// </summary>
+    public void UpdateDisplayName(string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+            throw new InvariantViolationException("I-ACC-DISPLAYNAME",
+                "Display name must not be null or whitespace.");
+        DisplayName = displayName.Trim();
+    }
+
+    /// <summary>
+    /// Updates the runtime (decrypted) Email property. Does not affect stored ciphertext.
+    /// </summary>
+    public void UpdateEmail(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            throw new InvariantViolationException("I-ACC-EMAIL",
+                "Email must not be null or whitespace.");
+        Email = email.Trim();
+    }
+
+    /// <summary>
+    /// Stores the encrypted email representation used for persistence and lookup.
+    /// </summary>
+    public void SetProtectedEmail(string emailCiphertext, string emailLookupHmac)
+    {
+        if (string.IsNullOrWhiteSpace(emailCiphertext))
+            throw new InvariantViolationException("I-ACC-EMAIL-CIPHERTEXT",
+                "Email ciphertext must not be null or whitespace.");
+        if (string.IsNullOrWhiteSpace(emailLookupHmac))
+            throw new InvariantViolationException("I-ACC-EMAIL-HMAC",
+                "Email lookup HMAC must not be null or whitespace.");
+        EmailCiphertext = emailCiphertext;
+        EmailLookupHmac = emailLookupHmac;
+    }
+
+    /// <summary>
+    /// Loads the decrypted email into the runtime-only Email property after reading from storage.
+    /// </summary>
+    public void LoadEmailForRuntime(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            throw new InvariantViolationException("I-ACC-EMAIL",
+                "Email must not be null or whitespace.");
+        Email = email.Trim();
+    }
+}

--- a/DraftView.Domain/Entities/Tenancy.cs
+++ b/DraftView.Domain/Entities/Tenancy.cs
@@ -1,0 +1,74 @@
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Entities;
+
+/// <summary>
+/// Represents an author-owned workspace containing projects, readers, notifications,
+/// and integrations. The primary isolation boundary for all tenancy-scoped data.
+/// MaxBetaReaderCount is seeded to 5 for all tenancies before billing is live.
+/// </summary>
+public sealed class Tenancy
+{
+    private const int DefaultMaxBetaReaderCount = 5;
+
+    public Guid Id { get; private set; }
+    public Guid OwnerAccountId { get; private set; }
+    public string Name { get; private set; } = default!;
+
+    /// <summary>
+    /// Operational limit on beta readers. Not user-editable; set by platform or billing.
+    /// Pre-billing default is 5.
+    /// </summary>
+    public int MaxBetaReaderCount { get; private set; }
+    public bool IsActive { get; private set; }
+    public bool IsSoftDeleted { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime? SoftDeletedAt { get; private set; }
+
+    private Tenancy() { }
+
+    /// <summary>
+    /// Creates a new active Tenancy owned by the given Account.
+    /// MaxBetaReaderCount defaults to 5 (pre-billing operational cap).
+    /// </summary>
+    public static Tenancy Create(Guid ownerAccountId, string name)
+    {
+        if (ownerAccountId == Guid.Empty)
+            throw new InvariantViolationException("I-TEN-OWNER",
+                "Tenancy must be associated with a valid owner account.");
+        if (string.IsNullOrWhiteSpace(name))
+            throw new InvariantViolationException("I-TEN-NAME",
+                "Tenancy name must not be null or whitespace.");
+        return new Tenancy
+        {
+            Id                 = Guid.NewGuid(),
+            OwnerAccountId     = ownerAccountId,
+            Name               = name.Trim(),
+            MaxBetaReaderCount = DefaultMaxBetaReaderCount,
+            IsActive           = true,
+            IsSoftDeleted      = false,
+            CreatedAt          = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Updates the tenancy name. The new value is trimmed.
+    /// </summary>
+    public void UpdateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new InvariantViolationException("I-TEN-NAME",
+                "Tenancy name must not be null or whitespace.");
+        Name = name.Trim();
+    }
+
+    /// <summary>
+    /// Soft-deletes the tenancy. Idempotent.
+    /// </summary>
+    public void SoftDelete()
+    {
+        if (IsSoftDeleted) return;
+        IsSoftDeleted = true;
+        SoftDeletedAt = DateTime.UtcNow;
+    }
+}

--- a/DraftView.Domain/Entities/TenancyMembership.cs
+++ b/DraftView.Domain/Entities/TenancyMembership.cs
@@ -4,9 +4,9 @@ using DraftView.Domain.Exceptions;
 namespace DraftView.Domain.Entities;
 
 /// <summary>
-/// Represents the role-bearing link between an Account and a Tenancy.
-/// A membership with Role=Author identifies the tenancy owner.
-/// An account may hold BetaReader memberships in many tenancies simultaneously.
+/// Represents the Author-Tenancy link: exactly one membership per tenancy, always Role=Author.
+/// Reader access (including authors reading other authors' projects) is granted at the project
+/// level via ReaderAccess and does not create a TenancyMembership in the host tenancy.
 /// </summary>
 public sealed class TenancyMembership
 {

--- a/DraftView.Domain/Entities/TenancyMembership.cs
+++ b/DraftView.Domain/Entities/TenancyMembership.cs
@@ -1,0 +1,63 @@
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Entities;
+
+/// <summary>
+/// Represents the role-bearing link between an Account and a Tenancy.
+/// A membership with Role=Author identifies the tenancy owner.
+/// An account may hold BetaReader memberships in many tenancies simultaneously.
+/// </summary>
+public sealed class TenancyMembership
+{
+    public Guid Id { get; private set; }
+    public Guid TenancyId { get; private set; }
+    public Guid AccountId { get; private set; }
+    public TenancyRole Role { get; private set; }
+    public DateTime JoinedAt { get; private set; }
+    public bool IsSoftDeleted { get; private set; }
+    public DateTime? SoftDeletedAt { get; private set; }
+
+    private TenancyMembership() { }
+
+    /// <summary>
+    /// Creates a new TenancyMembership linking an Account to a Tenancy with the given role.
+    /// </summary>
+    public static TenancyMembership Create(Guid tenancyId, Guid accountId, TenancyRole role)
+    {
+        if (tenancyId == Guid.Empty)
+            throw new InvariantViolationException("I-TMEM-TENANCY",
+                "TenancyMembership must reference a valid tenancy.");
+        if (accountId == Guid.Empty)
+            throw new InvariantViolationException("I-TMEM-ACCOUNT",
+                "TenancyMembership must reference a valid account.");
+        return new TenancyMembership
+        {
+            Id            = Guid.NewGuid(),
+            TenancyId     = tenancyId,
+            AccountId     = accountId,
+            Role          = role,
+            JoinedAt      = DateTime.UtcNow,
+            IsSoftDeleted = false
+        };
+    }
+
+    /// <summary>
+    /// Soft-deletes the membership, effectively removing access. Idempotent.
+    /// </summary>
+    public void SoftDelete()
+    {
+        if (IsSoftDeleted) return;
+        IsSoftDeleted = true;
+        SoftDeletedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Restores a soft-deleted membership, reinstating access.
+    /// </summary>
+    public void Restore()
+    {
+        IsSoftDeleted = false;
+        SoftDeletedAt = null;
+    }
+}

--- a/DraftView.Domain/Entities/TenancySubscription.cs
+++ b/DraftView.Domain/Entities/TenancySubscription.cs
@@ -1,0 +1,64 @@
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Exceptions;
+
+namespace DraftView.Domain.Entities;
+
+/// <summary>
+/// Represents the subscription tier state for a Tenancy.
+/// ProviderSubscriptionId is null until a billing provider is integrated.
+/// Before billing is live, all tenancies are created on Free tier semantics
+/// but MaxBetaReaderCount is controlled by the Tenancy entity directly.
+/// </summary>
+public sealed class TenancySubscription
+{
+    public Guid Id { get; private set; }
+    public Guid TenancyId { get; private set; }
+    public SubscriptionTier Tier { get; private set; }
+
+    /// <summary>External identifier from the billing provider. Null until billing is live.</summary>
+    public string? ProviderSubscriptionId { get; private set; }
+
+    public bool IsActive { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime? UpdatedAt { get; private set; }
+
+    private TenancySubscription() { }
+
+    public static TenancySubscription Create(Guid tenancyId, SubscriptionTier tier)
+    {
+        if (tenancyId == Guid.Empty)
+            throw new InvariantViolationException("I-TSUB-TENANCY",
+                "TenancySubscription must reference a valid tenancy.");
+
+        return new TenancySubscription
+        {
+            Id        = Guid.NewGuid(),
+            TenancyId = tenancyId,
+            Tier      = tier,
+            IsActive  = true,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    public void UpdateTier(SubscriptionTier tier)
+    {
+        Tier      = tier;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Records the external billing-provider subscription identifier.
+    /// Called when a billing provider is integrated and creates a subscription record.
+    /// </summary>
+    public void SetProviderSubscriptionId(string id)
+    {
+        ProviderSubscriptionId = id;
+        UpdatedAt              = DateTime.UtcNow;
+    }
+
+    public void Deactivate()
+    {
+        IsActive  = false;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/DraftView.Domain/Enumerations/SubscriptionTier.cs
+++ b/DraftView.Domain/Enumerations/SubscriptionTier.cs
@@ -1,13 +1,18 @@
 namespace DraftView.Domain.Enumerations;
 
 /// <summary>
-/// Represents the author's subscription tier.
-/// Determines version retention limits per section.
-/// Billing integration is deferred — tier is currently fixed at Free.
+/// The subscription tier for a Tenancy.
+/// Limits apply per the billing plan; before billing is live all tenancies operate on
+/// Free Tier semantics but with MaxBetaReaderCount=5 (pre-billing operational default).
 /// </summary>
 public enum SubscriptionTier
 {
-    Free = 0,
-    Paid = 1,
-    Ultimate = 2
+    /// <summary>Free: 3 beta readers, 1 active project.</summary>
+    Free,
+
+    /// <summary>Paid: 10 beta readers, unlimited active projects.</summary>
+    Paid,
+
+    /// <summary>Ultimate: unlimited beta readers and active projects.</summary>
+    Ultimate
 }

--- a/DraftView.Domain/Enumerations/TenancyRole.cs
+++ b/DraftView.Domain/Enumerations/TenancyRole.cs
@@ -1,0 +1,11 @@
+namespace DraftView.Domain.Enumerations;
+
+/// <summary>
+/// The role an Account holds within a specific Tenancy.
+/// Author represents the tenancy owner. BetaReader represents an invited reader.
+/// </summary>
+public enum TenancyRole
+{
+    Author,
+    BetaReader
+}

--- a/DraftView.Domain/Enumerations/TenancyRole.cs
+++ b/DraftView.Domain/Enumerations/TenancyRole.cs
@@ -1,11 +1,12 @@
 namespace DraftView.Domain.Enumerations;
 
 /// <summary>
-/// The role an Account holds within a specific Tenancy.
-/// Author represents the tenancy owner. BetaReader represents an invited reader.
+/// The role an Account holds within a Tenancy.
+/// TenancyMembership is reserved for the Author-Tenancy 1:1 link only.
+/// Reader access (including authors reading other authors' projects) is granted
+/// at the project level via ReaderAccess, not via TenancyMembership.
 /// </summary>
 public enum TenancyRole
 {
-    Author,
-    BetaReader
+    Author
 }

--- a/DraftView.Domain/Interfaces/Repositories/IAccountRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/IAccountRepository.cs
@@ -1,0 +1,14 @@
+using DraftView.Domain.Entities;
+
+namespace DraftView.Domain.Interfaces.Repositories;
+
+/// <summary>
+/// Persistence contract for Account entities.
+/// </summary>
+public interface IAccountRepository
+{
+    Task<Account?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<Account?> GetByEmailLookupHmacAsync(string emailLookupHmac, CancellationToken ct = default);
+    Task<bool> EmailExistsAsync(string emailLookupHmac, CancellationToken ct = default);
+    Task AddAsync(Account account, CancellationToken ct = default);
+}

--- a/DraftView.Domain/Interfaces/Repositories/IProjectRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/IProjectRepository.cs
@@ -6,6 +6,7 @@ public interface IProjectRepository
 {
     Task<Project?> GetByIdAsync(Guid id, CancellationToken ct = default);
     Task<IReadOnlyList<Project>> GetAllAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<Project>> GetAllForReaderAsync(Guid readerId, CancellationToken ct = default);
     Task<Project?> GetReaderActiveProjectAsync(CancellationToken ct = default);
     Task<Project?> GetSoftDeletedBySyncRootIdAsync(string uuid, CancellationToken ct = default);
     Task AddAsync(Project project, CancellationToken ct = default);

--- a/DraftView.Domain/Interfaces/Repositories/IReadEventRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/IReadEventRepository.cs
@@ -6,6 +6,7 @@ public interface IReadEventRepository
 {
     Task<ReadEvent?> GetAsync(Guid sectionId, Guid userId, CancellationToken ct = default);
     Task<IReadOnlyList<ReadEvent>> GetByUserIdAsync(Guid userId, CancellationToken ct = default);
+    Task<ReadEvent?> GetMostRecentByUserIdAsync(Guid userId, CancellationToken ct = default);
     Task<IReadOnlyList<ReadEvent>> GetBySectionIdAsync(Guid sectionId, CancellationToken ct = default);
     Task<IReadOnlyList<ReadEvent>> GetByProjectIdAsync(Guid projectId, CancellationToken ct = default);
     Task<bool> HasReadAsync(Guid sectionId, Guid userId, CancellationToken ct = default);

--- a/DraftView.Domain/Interfaces/Repositories/IReaderAccessRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/IReaderAccessRepository.cs
@@ -18,4 +18,11 @@ public interface IReaderAccessRepository
 
     /// <summary>Revokes all active access records for a reader scoped to an author's projects.</summary>
     Task RevokeAllForReaderAsync(Guid readerId, Guid authorId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the count of active (non-revoked) ReaderAccess records for all projects
+    /// owned by the given author. Used to enforce MaxBetaReaderCount before granting access.
+    /// Post MT-Sprint-1 rename: authorId becomes tenancyId.
+    /// </summary>
+    Task<int> CountActiveReadersForAuthorAsync(Guid authorId, CancellationToken ct = default);
 }

--- a/DraftView.Domain/Interfaces/Repositories/ITenancyMembershipRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/ITenancyMembershipRepository.cs
@@ -1,0 +1,18 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+
+namespace DraftView.Domain.Interfaces.Repositories;
+
+/// <summary>
+/// Persistence contract for TenancyMembership entities.
+/// All queries are explicitly tenancy-scoped to prevent cross-tenant data leakage.
+/// </summary>
+public interface ITenancyMembershipRepository
+{
+    Task<TenancyMembership?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<TenancyMembership?> GetByTenancyAndAccountAsync(Guid tenancyId, Guid accountId, CancellationToken ct = default);
+    Task<IReadOnlyList<TenancyMembership>> GetByTenancyIdAsync(Guid tenancyId, CancellationToken ct = default);
+    Task<IReadOnlyList<TenancyMembership>> GetByAccountIdAsync(Guid accountId, CancellationToken ct = default);
+    Task<int> CountActiveBetaReadersAsync(Guid tenancyId, CancellationToken ct = default);
+    Task AddAsync(TenancyMembership membership, CancellationToken ct = default);
+}

--- a/DraftView.Domain/Interfaces/Repositories/ITenancyMembershipRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/ITenancyMembershipRepository.cs
@@ -1,10 +1,12 @@
 using DraftView.Domain.Entities;
-using DraftView.Domain.Enumerations;
 
 namespace DraftView.Domain.Interfaces.Repositories;
 
 /// <summary>
 /// Persistence contract for TenancyMembership entities.
+/// TenancyMembership is the Author-Tenancy 1:1 link only.
+/// Reader access (including authors reading other authors' projects) is managed
+/// at the project level via ReaderAccess, not via TenancyMembership.
 /// All queries are explicitly tenancy-scoped to prevent cross-tenant data leakage.
 /// </summary>
 public interface ITenancyMembershipRepository
@@ -13,6 +15,5 @@ public interface ITenancyMembershipRepository
     Task<TenancyMembership?> GetByTenancyAndAccountAsync(Guid tenancyId, Guid accountId, CancellationToken ct = default);
     Task<IReadOnlyList<TenancyMembership>> GetByTenancyIdAsync(Guid tenancyId, CancellationToken ct = default);
     Task<IReadOnlyList<TenancyMembership>> GetByAccountIdAsync(Guid accountId, CancellationToken ct = default);
-    Task<int> CountActiveBetaReadersAsync(Guid tenancyId, CancellationToken ct = default);
     Task AddAsync(TenancyMembership membership, CancellationToken ct = default);
 }

--- a/DraftView.Domain/Interfaces/Repositories/ITenancyRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/ITenancyRepository.cs
@@ -1,0 +1,13 @@
+using DraftView.Domain.Entities;
+
+namespace DraftView.Domain.Interfaces.Repositories;
+
+/// <summary>
+/// Persistence contract for Tenancy entities.
+/// </summary>
+public interface ITenancyRepository
+{
+    Task<Tenancy?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<Tenancy?> GetByOwnerAccountIdAsync(Guid ownerAccountId, CancellationToken ct = default);
+    Task AddAsync(Tenancy tenancy, CancellationToken ct = default);
+}

--- a/DraftView.Domain/Interfaces/Repositories/ITenancySubscriptionRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/ITenancySubscriptionRepository.cs
@@ -1,0 +1,14 @@
+using DraftView.Domain.Entities;
+
+namespace DraftView.Domain.Interfaces.Repositories;
+
+/// <summary>
+/// Persistence contract for TenancySubscription entities.
+/// One subscription record per tenancy. Billing-provider details are stored here
+/// once a billing provider is integrated (MT-Sprint-2 billing rollout phase).
+/// </summary>
+public interface ITenancySubscriptionRepository
+{
+    Task<TenancySubscription?> GetByTenancyIdAsync(Guid tenancyId, CancellationToken ct = default);
+    Task AddAsync(TenancySubscription subscription, CancellationToken ct = default);
+}

--- a/DraftView.Domain/Interfaces/Services/IAuthorRegistrationService.cs
+++ b/DraftView.Domain/Interfaces/Services/IAuthorRegistrationService.cs
@@ -1,0 +1,27 @@
+using DraftView.Domain.Entities;
+
+namespace DraftView.Domain.Interfaces.Services;
+
+/// <summary>
+/// Orchestrates atomic author self-registration: Account + Tenancy + TenancyMembership
+/// + TenancySubscription are created together and committed as a single unit of work.
+/// Web UI wires ASP.NET Identity registration separately; this service owns the
+/// domain record bootstrap only.
+/// </summary>
+public interface IAuthorRegistrationService
+{
+    Task<AuthorRegistrationResult> RegisterAsync(
+        string email,
+        string displayName,
+        string tenancyName,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Carries all four records created atomically during author registration.
+/// </summary>
+public record AuthorRegistrationResult(
+    Account Account,
+    Tenancy Tenancy,
+    TenancyMembership Membership,
+    TenancySubscription Subscription);

--- a/DraftView.Domain/Interfaces/Services/IAuthorSelfRegistrationService.cs
+++ b/DraftView.Domain/Interfaces/Services/IAuthorSelfRegistrationService.cs
@@ -1,0 +1,24 @@
+using DraftView.Domain.Entities;
+
+namespace DraftView.Domain.Interfaces.Services;
+
+/// <summary>
+/// Orchestrates atomic author self-registration: User + Account + Tenancy +
+/// TenancyMembership + TenancySubscription created and saved in one unit of work.
+/// ASP.NET Identity record creation and email confirmation are handled by the web layer.
+/// </summary>
+public interface IAuthorSelfRegistrationService
+{
+    Task<AuthorSelfRegistrationResult> RegisterAsync(
+        string email,
+        string displayName,
+        string tenancyName,
+        CancellationToken ct = default);
+}
+
+public record AuthorSelfRegistrationResult(
+    User User,
+    Account Account,
+    Tenancy Tenancy,
+    TenancyMembership Membership,
+    TenancySubscription Subscription);

--- a/DraftView.Domain/Interfaces/Services/IReaderSelfRegistrationService.cs
+++ b/DraftView.Domain/Interfaces/Services/IReaderSelfRegistrationService.cs
@@ -1,0 +1,11 @@
+using DraftView.Domain.Entities;
+
+namespace DraftView.Domain.Interfaces.Services;
+
+public interface IReaderSelfRegistrationService
+{
+    Task<ReaderSelfRegistrationResult> RegisterAsync(
+        string email, string displayName, CancellationToken ct = default);
+}
+
+public record ReaderSelfRegistrationResult(User User);

--- a/DraftView.Domain/Interfaces/Services/IReadingProgressService.cs
+++ b/DraftView.Domain/Interfaces/Services/IReadingProgressService.cs
@@ -10,6 +10,7 @@ public interface IReadingProgressService
     Task<bool> HasReadSectionAsync(Guid userId, Guid sectionId, CancellationToken ct = default);
     Task<IReadOnlyList<ReadEvent>> GetProgressForProjectAsync(Guid projectId, CancellationToken ct = default);
     Task<ReadEvent?> GetLastReadEventAsync(Guid userId, Guid projectId, CancellationToken ct = default);
+    Task<ReadEvent?> GetLastReadEventAcrossProjectsAsync(Guid userId, CancellationToken ct = default);
 
     /// <summary>
     /// Updates the LastReadVersionNumber on an existing ReadEvent.

--- a/DraftView.Infrastructure.Tests/Parsing/ManualChapterParserTests.cs
+++ b/DraftView.Infrastructure.Tests/Parsing/ManualChapterParserTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using DraftView.Domain.Exceptions;
+using DraftView.Domain.Interfaces.Services;
 using DraftView.Infrastructure.Parsing;
 
 namespace DraftView.Infrastructure.Tests.Parsing;

--- a/DraftView.Infrastructure/Billing/NullBillingProvider.cs
+++ b/DraftView.Infrastructure/Billing/NullBillingProvider.cs
@@ -1,0 +1,16 @@
+using DraftView.Application.Interfaces;
+using DraftView.Domain.Enumerations;
+
+namespace DraftView.Infrastructure.Billing;
+
+/// <summary>
+/// No-op billing provider registered before a real billing integration is selected.
+/// Always returns null (no active subscription), which callers treat as pre-billing Free Tier.
+/// Replace with a real implementation (Stripe, Paddle, etc.) in MT-Sprint-2 billing rollout.
+/// </summary>
+public class NullBillingProvider : IBillingProvider
+{
+    public Task<SubscriptionTier?> GetCurrentTierAsync(
+        string providerSubscriptionId, CancellationToken ct = default) =>
+        Task.FromResult<SubscriptionTier?>(null);
+}

--- a/DraftView.Infrastructure/Persistence/Configurations/AccountConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/AccountConfiguration.cs
@@ -1,0 +1,46 @@
+using DraftView.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DraftView.Infrastructure.Persistence.Configurations;
+
+/// <summary>
+/// EF Core configuration for the Account entity.
+/// Mirrors the email-protection column layout used by User to support the same
+/// DbContext-level encryption hook pattern.
+/// </summary>
+public class AccountConfiguration : IEntityTypeConfiguration<Account>
+{
+    public void Configure(EntityTypeBuilder<Account> builder)
+    {
+        builder.ToTable("Accounts");
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.EmailCiphertext)
+            .IsRequired()
+            .HasMaxLength(2048);
+
+        builder.Property(a => a.EmailLookupHmac)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.HasIndex(a => a.EmailLookupHmac)
+            .IsUnique();
+
+        builder.Property(a => a.DisplayName)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(a => a.IsActive)
+            .IsRequired();
+
+        builder.Property(a => a.IsSoftDeleted)
+            .IsRequired();
+
+        builder.Property(a => a.CreatedAt)
+            .IsRequired();
+
+        builder.Ignore(a => a.Email);
+    }
+}

--- a/DraftView.Infrastructure/Persistence/Configurations/TenancyConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/TenancyConfiguration.cs
@@ -1,0 +1,40 @@
+using DraftView.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DraftView.Infrastructure.Persistence.Configurations;
+
+/// <summary>
+/// EF Core configuration for the Tenancy entity.
+/// </summary>
+public class TenancyConfiguration : IEntityTypeConfiguration<Tenancy>
+{
+    public void Configure(EntityTypeBuilder<Tenancy> builder)
+    {
+        builder.ToTable("Tenancies");
+
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.OwnerAccountId)
+            .IsRequired();
+
+        builder.Property(t => t.Name)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(t => t.MaxBetaReaderCount)
+            .IsRequired();
+
+        builder.Property(t => t.IsActive)
+            .IsRequired();
+
+        builder.Property(t => t.IsSoftDeleted)
+            .IsRequired();
+
+        builder.Property(t => t.CreatedAt)
+            .IsRequired();
+
+        builder.HasIndex(t => t.OwnerAccountId)
+            .IsUnique();
+    }
+}

--- a/DraftView.Infrastructure/Persistence/Configurations/TenancyMembershipConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/TenancyMembershipConfiguration.cs
@@ -1,0 +1,40 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DraftView.Infrastructure.Persistence.Configurations;
+
+/// <summary>
+/// EF Core configuration for the TenancyMembership entity.
+/// </summary>
+public class TenancyMembershipConfiguration : IEntityTypeConfiguration<TenancyMembership>
+{
+    public void Configure(EntityTypeBuilder<TenancyMembership> builder)
+    {
+        builder.ToTable("TenancyMemberships");
+
+        builder.HasKey(m => m.Id);
+
+        builder.Property(m => m.TenancyId)
+            .IsRequired();
+
+        builder.Property(m => m.AccountId)
+            .IsRequired();
+
+        builder.Property(m => m.Role)
+            .IsRequired()
+            .HasConversion<string>();
+
+        builder.Property(m => m.JoinedAt)
+            .IsRequired();
+
+        builder.Property(m => m.IsSoftDeleted)
+            .IsRequired();
+
+        builder.HasIndex(m => new { m.TenancyId, m.AccountId })
+            .IsUnique();
+
+        builder.HasIndex(m => m.AccountId);
+    }
+}

--- a/DraftView.Infrastructure/Persistence/Configurations/TenancySubscriptionConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/TenancySubscriptionConfiguration.cs
@@ -1,0 +1,36 @@
+using DraftView.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DraftView.Infrastructure.Persistence.Configurations;
+
+public class TenancySubscriptionConfiguration : IEntityTypeConfiguration<TenancySubscription>
+{
+    public void Configure(EntityTypeBuilder<TenancySubscription> builder)
+    {
+        builder.ToTable("TenancySubscriptions");
+
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.TenancyId)
+            .IsRequired();
+
+        builder.Property(s => s.Tier)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(50);
+
+        builder.Property(s => s.ProviderSubscriptionId)
+            .HasMaxLength(200);
+
+        builder.Property(s => s.IsActive)
+            .IsRequired();
+
+        builder.Property(s => s.CreatedAt)
+            .IsRequired();
+
+        // One subscription record per tenancy.
+        builder.HasIndex(s => s.TenancyId)
+            .IsUnique();
+    }
+}

--- a/DraftView.Infrastructure/Persistence/DraftViewDbContext.cs
+++ b/DraftView.Infrastructure/Persistence/DraftViewDbContext.cs
@@ -54,6 +54,11 @@ public class DraftViewDbContext : IdentityDbContext<IdentityUser>, IUnitOfWork
     public DbSet<ManualChapter> ManualChapters => Set<ManualChapter>();
     public DbSet<ManualChapterVersion> ManualChapterVersions => Set<ManualChapterVersion>();
 
+    // Multi-tenancy tables (MT-Sprint-1)
+    public DbSet<Account> Accounts => Set<Account>();
+    public DbSet<Tenancy> Tenancies => Set<Tenancy>();
+    public DbSet<TenancyMembership> TenancyMemberships => Set<TenancyMembership>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/DraftView.Infrastructure/Persistence/DraftViewDbContext.cs
+++ b/DraftView.Infrastructure/Persistence/DraftViewDbContext.cs
@@ -59,6 +59,9 @@ public class DraftViewDbContext : IdentityDbContext<IdentityUser>, IUnitOfWork
     public DbSet<Tenancy> Tenancies => Set<Tenancy>();
     public DbSet<TenancyMembership> TenancyMemberships => Set<TenancyMembership>();
 
+    // Multi-tenancy tables (MT-Sprint-2)
+    public DbSet<TenancySubscription> TenancySubscriptions => Set<TenancySubscription>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/DraftView.Infrastructure/Persistence/DraftViewDbContext.cs
+++ b/DraftView.Infrastructure/Persistence/DraftViewDbContext.cs
@@ -96,32 +96,51 @@ public class DraftViewDbContext : IdentityDbContext<IdentityUser>, IUnitOfWork
 
     private void PrepareProtectedEmails()
     {
-        var userEntries = ChangeTracker.Entries<User>()
-            .Where(NeedsProtectedEmailReview);
-
-        foreach (var entry in userEntries)
+        // User entities (existing path)
+        foreach (var entry in ChangeTracker.Entries<User>().Where(NeedsUserProtectedEmailReview))
         {
-            if (!TryCreateProtectedEmailState(entry.Entity, out var protectedEmailState))
+            if (!TryCreateProtectedEmailState(entry.Entity.Email, out var state))
+                continue;
+            if (!ShouldRefreshUserProtectedEmail(entry, state.LookupHmac))
                 continue;
 
-            if (!ShouldRefreshProtectedEmail(entry, protectedEmailState.LookupHmac))
+            entry.Entity.LoadEmailForRuntime(state.NormalizedEmail);
+            entry.Entity.SetProtectedEmail(state.Ciphertext, state.LookupHmac);
+            if (entry.State == EntityState.Unchanged)
+                entry.State = EntityState.Modified;
+        }
+
+        // Account entities (MT-Sprint-1 path — same email protection scheme)
+        foreach (var entry in ChangeTracker.Entries<Account>().Where(NeedsAccountProtectedEmailReview))
+        {
+            if (!TryCreateProtectedEmailState(entry.Entity.Email, out var state))
+                continue;
+            if (!ShouldRefreshAccountProtectedEmail(entry, state.LookupHmac))
                 continue;
 
-            ApplyProtectedEmailState(entry, protectedEmailState);
+            entry.Entity.LoadEmailForRuntime(state.NormalizedEmail);
+            entry.Entity.SetProtectedEmail(state.Ciphertext, state.LookupHmac);
+            if (entry.State == EntityState.Unchanged)
+                entry.State = EntityState.Modified;
         }
     }
 
-    private static bool NeedsProtectedEmailReview(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<User> entry) =>
+    private static bool NeedsUserProtectedEmailReview(
+        Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<User> entry) =>
         entry.State != EntityState.Detached && entry.State != EntityState.Deleted;
 
-    private bool TryCreateProtectedEmailState(User user, out ProtectedEmailState protectedEmailState)
+    private static bool NeedsAccountProtectedEmailReview(
+        Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<Account> entry) =>
+        entry.State != EntityState.Detached && entry.State != EntityState.Deleted;
+
+    private bool TryCreateProtectedEmailState(string email, out ProtectedEmailState protectedEmailState)
     {
         protectedEmailState = default;
 
-        if (string.IsNullOrWhiteSpace(user.Email))
+        if (string.IsNullOrWhiteSpace(email))
             return false;
 
-        var normalizedEmail = NormalizeEmail(user.Email);
+        var normalizedEmail = NormalizeEmail(email);
         protectedEmailState = new ProtectedEmailState(
             normalizedEmail,
             emailEncryptionService.Encrypt(normalizedEmail),
@@ -130,23 +149,19 @@ public class DraftViewDbContext : IdentityDbContext<IdentityUser>, IUnitOfWork
         return true;
     }
 
-    private static bool ShouldRefreshProtectedEmail(
+    private static bool ShouldRefreshUserProtectedEmail(
         Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<User> entry,
         string lookupHmac) =>
         entry.State == EntityState.Added ||
         string.IsNullOrWhiteSpace(entry.Entity.EmailCiphertext) ||
         !string.Equals(entry.Entity.EmailLookupHmac, lookupHmac, StringComparison.Ordinal);
 
-    private static void ApplyProtectedEmailState(
-        Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<User> entry,
-        ProtectedEmailState protectedEmailState)
-    {
-        entry.Entity.LoadEmailForRuntime(protectedEmailState.NormalizedEmail);
-        entry.Entity.SetProtectedEmail(protectedEmailState.Ciphertext, protectedEmailState.LookupHmac);
-
-        if (entry.State == EntityState.Unchanged)
-            entry.State = EntityState.Modified;
-    }
+    private static bool ShouldRefreshAccountProtectedEmail(
+        Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<Account> entry,
+        string lookupHmac) =>
+        entry.State == EntityState.Added ||
+        string.IsNullOrWhiteSpace(entry.Entity.EmailCiphertext) ||
+        !string.Equals(entry.Entity.EmailLookupHmac, lookupHmac, StringComparison.Ordinal);
 
     private readonly record struct ProtectedEmailState(
         string NormalizedEmail,
@@ -155,4 +170,5 @@ public class DraftViewDbContext : IdentityDbContext<IdentityUser>, IUnitOfWork
 
     public static string NormalizeEmail(string email) => email.Trim();
 }
+
 

--- a/DraftView.Infrastructure/Persistence/Migrations/20260821143717_AddMultiTenancySchema.Designer.cs
+++ b/DraftView.Infrastructure/Persistence/Migrations/20260821143717_AddMultiTenancySchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DraftView.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DraftView.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DraftViewDbContext))]
-    partial class DraftViewDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260821143717_AddMultiTenancySchema")]
+    partial class AddMultiTenancySchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DraftView.Infrastructure/Persistence/Migrations/20260821143717_AddMultiTenancySchema.cs
+++ b/DraftView.Infrastructure/Persistence/Migrations/20260821143717_AddMultiTenancySchema.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DraftView.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMultiTenancySchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Accounts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    EmailCiphertext = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: false),
+                    EmailLookupHmac = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    IsSoftDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ActivatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastLoginAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    SoftDeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Accounts", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ManualChapters",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AuthorId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProjectId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    RawContent = table.Column<string>(type: "text", nullable: false),
+                    OriginalFileName = table.Column<string>(type: "character varying(260)", maxLength: 260, nullable: true),
+                    UploadedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LinkedSectionId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ManualChapters", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ManualChapterVersions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ManualChapterId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AuthorId = table.Column<Guid>(type: "uuid", nullable: false),
+                    VersionNumber = table.Column<int>(type: "integer", nullable: false),
+                    RawContent = table.Column<string>(type: "text", nullable: false),
+                    SnapshotReason = table.Column<string>(type: "text", nullable: false),
+                    SnapshotAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ManualChapterVersions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Tenancies",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerAccountId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    MaxBetaReaderCount = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    IsSoftDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SoftDeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tenancies", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TenancyMemberships",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenancyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccountId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Role = table.Column<string>(type: "text", nullable: false),
+                    JoinedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsSoftDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    SoftDeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TenancyMemberships", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TenancySubscriptions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenancyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Tier = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    ProviderSubscriptionId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TenancySubscriptions", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Accounts_EmailLookupHmac",
+                table: "Accounts",
+                column: "EmailLookupHmac",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ManualChapters_ProjectId_AuthorId_SortOrder",
+                table: "ManualChapters",
+                columns: new[] { "ProjectId", "AuthorId", "SortOrder" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ManualChapterVersions_ManualChapterId_VersionNumber",
+                table: "ManualChapterVersions",
+                columns: new[] { "ManualChapterId", "VersionNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tenancies_OwnerAccountId",
+                table: "Tenancies",
+                column: "OwnerAccountId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenancyMemberships_AccountId",
+                table: "TenancyMemberships",
+                column: "AccountId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenancyMemberships_TenancyId_AccountId",
+                table: "TenancyMemberships",
+                columns: new[] { "TenancyId", "AccountId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenancySubscriptions_TenancyId",
+                table: "TenancySubscriptions",
+                column: "TenancyId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Accounts");
+
+            migrationBuilder.DropTable(
+                name: "ManualChapters");
+
+            migrationBuilder.DropTable(
+                name: "ManualChapterVersions");
+
+            migrationBuilder.DropTable(
+                name: "Tenancies");
+
+            migrationBuilder.DropTable(
+                name: "TenancyMemberships");
+
+            migrationBuilder.DropTable(
+                name: "TenancySubscriptions");
+        }
+    }
+}

--- a/DraftView.Infrastructure/Persistence/Repositories/AccountRepository.cs
+++ b/DraftView.Infrastructure/Persistence/Repositories/AccountRepository.cs
@@ -1,0 +1,36 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace DraftView.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Repository implementation for Account entities.
+/// </summary>
+public class AccountRepository(DraftViewDbContext db) : IAccountRepository
+{
+    /// <summary>
+    /// Returns the Account with the given id, or null if not found.
+    /// </summary>
+    public Task<Account?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        db.Accounts.FirstOrDefaultAsync(a => a.Id == id, ct);
+
+    /// <summary>
+    /// Returns the Account matching the given email lookup HMAC, or null if not found.
+    /// Used for login and invitation-acceptance lookups without decrypting all emails.
+    /// </summary>
+    public Task<Account?> GetByEmailLookupHmacAsync(string emailLookupHmac, CancellationToken ct = default) =>
+        db.Accounts.FirstOrDefaultAsync(a => a.EmailLookupHmac == emailLookupHmac, ct);
+
+    /// <summary>
+    /// Returns true if an Account with the given email lookup HMAC already exists.
+    /// </summary>
+    public Task<bool> EmailExistsAsync(string emailLookupHmac, CancellationToken ct = default) =>
+        db.Accounts.AnyAsync(a => a.EmailLookupHmac == emailLookupHmac, ct);
+
+    /// <summary>
+    /// Adds a new Account to the context for persistence on the next SaveChanges.
+    /// </summary>
+    public async Task AddAsync(Account account, CancellationToken ct = default) =>
+        await db.Accounts.AddAsync(account, ct);
+}

--- a/DraftView.Infrastructure/Persistence/Repositories/ProjectRepository.cs
+++ b/DraftView.Infrastructure/Persistence/Repositories/ProjectRepository.cs
@@ -17,6 +17,13 @@ public class ProjectRepository(DraftViewDbContext db) : IProjectRepository
             .OrderBy(p => p.Name)
             .ToListAsync(ct);
 
+    public async Task<IReadOnlyList<Project>> GetAllForReaderAsync(Guid readerId, CancellationToken ct = default) =>
+        await db.Projects
+            .Where(p => !p.IsSoftDeleted &&
+                        db.ReaderAccess.Any(ra => ra.ProjectId == p.Id && ra.ReaderId == readerId && ra.RevokedAt == null))
+            .OrderBy(p => p.Name)
+            .ToListAsync(ct);
+
     public async Task<Project?> GetReaderActiveProjectAsync(CancellationToken ct = default) =>
         await db.Projects.FirstOrDefaultAsync(p => p.IsReaderActive && !p.IsSoftDeleted, ct);
 

--- a/DraftView.Infrastructure/Persistence/Repositories/ReadEventRepository.cs
+++ b/DraftView.Infrastructure/Persistence/Repositories/ReadEventRepository.cs
@@ -14,6 +14,12 @@ public class ReadEventRepository(DraftViewDbContext db) : IReadEventRepository
     public async Task<IReadOnlyList<ReadEvent>> GetByUserIdAsync(Guid userId, CancellationToken ct = default) =>
         await db.ReadEvents.Where(r => r.UserId == userId).ToListAsync(ct);
 
+    public Task<ReadEvent?> GetMostRecentByUserIdAsync(Guid userId, CancellationToken ct = default) =>
+        db.ReadEvents
+            .Where(r => r.UserId == userId)
+            .OrderByDescending(r => r.LastOpenedAt)
+            .FirstOrDefaultAsync(ct);
+
     public async Task<IReadOnlyList<ReadEvent>> GetBySectionIdAsync(Guid sectionId, CancellationToken ct = default) =>
         await db.ReadEvents.Where(r => r.SectionId == sectionId).ToListAsync(ct);
 

--- a/DraftView.Infrastructure/Persistence/Repositories/ReaderAccessRepository.cs
+++ b/DraftView.Infrastructure/Persistence/Repositories/ReaderAccessRepository.cs
@@ -40,4 +40,7 @@ public class ReaderAccessRepository(DraftViewDbContext db) : IReaderAccessReposi
         foreach (var record in records)
             record.Revoke();
     }
+
+    public Task<int> CountActiveReadersForAuthorAsync(Guid authorId, CancellationToken ct = default) =>
+        db.ReaderAccess.CountAsync(r => r.AuthorId == authorId && r.RevokedAt == null, ct);
 }

--- a/DraftView.Infrastructure/Persistence/Repositories/TenancyMembershipRepository.cs
+++ b/DraftView.Infrastructure/Persistence/Repositories/TenancyMembershipRepository.cs
@@ -1,0 +1,62 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace DraftView.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Repository implementation for TenancyMembership entities.
+/// All queries are explicitly tenancy-scoped to prevent cross-tenant data leakage.
+/// </summary>
+public class TenancyMembershipRepository(DraftViewDbContext db) : ITenancyMembershipRepository
+{
+    /// <summary>
+    /// Returns the membership with the given id, or null if not found.
+    /// </summary>
+    public Task<TenancyMembership?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        db.TenancyMemberships.FirstOrDefaultAsync(m => m.Id == id, ct);
+
+    /// <summary>
+    /// Returns the active membership for a specific Account within a specific Tenancy, or null.
+    /// </summary>
+    public Task<TenancyMembership?> GetByTenancyAndAccountAsync(
+        Guid tenancyId, Guid accountId, CancellationToken ct = default) =>
+        db.TenancyMemberships.FirstOrDefaultAsync(
+            m => m.TenancyId == tenancyId && m.AccountId == accountId && !m.IsSoftDeleted, ct);
+
+    /// <summary>
+    /// Returns all active memberships for the given Tenancy.
+    /// </summary>
+    public async Task<IReadOnlyList<TenancyMembership>> GetByTenancyIdAsync(
+        Guid tenancyId, CancellationToken ct = default) =>
+        await db.TenancyMemberships
+            .Where(m => m.TenancyId == tenancyId && !m.IsSoftDeleted)
+            .ToListAsync(ct);
+
+    /// <summary>
+    /// Returns all active memberships held by the given Account across all tenancies.
+    /// </summary>
+    public async Task<IReadOnlyList<TenancyMembership>> GetByAccountIdAsync(
+        Guid accountId, CancellationToken ct = default) =>
+        await db.TenancyMemberships
+            .Where(m => m.AccountId == accountId && !m.IsSoftDeleted)
+            .ToListAsync(ct);
+
+    /// <summary>
+    /// Returns the count of active BetaReader memberships within the given Tenancy.
+    /// Used to enforce MaxBetaReaderCount before adding a new reader.
+    /// </summary>
+    public Task<int> CountActiveBetaReadersAsync(Guid tenancyId, CancellationToken ct = default) =>
+        db.TenancyMemberships.CountAsync(
+            m => m.TenancyId == tenancyId &&
+                 m.Role == TenancyRole.BetaReader &&
+                 !m.IsSoftDeleted,
+            ct);
+
+    /// <summary>
+    /// Adds a new TenancyMembership to the context for persistence on the next SaveChanges.
+    /// </summary>
+    public async Task AddAsync(TenancyMembership membership, CancellationToken ct = default) =>
+        await db.TenancyMemberships.AddAsync(membership, ct);
+}

--- a/DraftView.Infrastructure/Persistence/Repositories/TenancyMembershipRepository.cs
+++ b/DraftView.Infrastructure/Persistence/Repositories/TenancyMembershipRepository.cs
@@ -1,5 +1,4 @@
 using DraftView.Domain.Entities;
-using DraftView.Domain.Enumerations;
 using DraftView.Domain.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,56 +6,31 @@ namespace DraftView.Infrastructure.Persistence.Repositories;
 
 /// <summary>
 /// Repository implementation for TenancyMembership entities.
-/// All queries are explicitly tenancy-scoped to prevent cross-tenant data leakage.
+/// TenancyMembership is the Author-Tenancy 1:1 link only; reader access is managed
+/// at the project level via ReaderAccess. All queries are tenancy-scoped.
 /// </summary>
 public class TenancyMembershipRepository(DraftViewDbContext db) : ITenancyMembershipRepository
 {
-    /// <summary>
-    /// Returns the membership with the given id, or null if not found.
-    /// </summary>
     public Task<TenancyMembership?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
         db.TenancyMemberships.FirstOrDefaultAsync(m => m.Id == id, ct);
 
-    /// <summary>
-    /// Returns the active membership for a specific Account within a specific Tenancy, or null.
-    /// </summary>
     public Task<TenancyMembership?> GetByTenancyAndAccountAsync(
         Guid tenancyId, Guid accountId, CancellationToken ct = default) =>
         db.TenancyMemberships.FirstOrDefaultAsync(
             m => m.TenancyId == tenancyId && m.AccountId == accountId && !m.IsSoftDeleted, ct);
 
-    /// <summary>
-    /// Returns all active memberships for the given Tenancy.
-    /// </summary>
     public async Task<IReadOnlyList<TenancyMembership>> GetByTenancyIdAsync(
         Guid tenancyId, CancellationToken ct = default) =>
         await db.TenancyMemberships
             .Where(m => m.TenancyId == tenancyId && !m.IsSoftDeleted)
             .ToListAsync(ct);
 
-    /// <summary>
-    /// Returns all active memberships held by the given Account across all tenancies.
-    /// </summary>
     public async Task<IReadOnlyList<TenancyMembership>> GetByAccountIdAsync(
         Guid accountId, CancellationToken ct = default) =>
         await db.TenancyMemberships
             .Where(m => m.AccountId == accountId && !m.IsSoftDeleted)
             .ToListAsync(ct);
 
-    /// <summary>
-    /// Returns the count of active BetaReader memberships within the given Tenancy.
-    /// Used to enforce MaxBetaReaderCount before adding a new reader.
-    /// </summary>
-    public Task<int> CountActiveBetaReadersAsync(Guid tenancyId, CancellationToken ct = default) =>
-        db.TenancyMemberships.CountAsync(
-            m => m.TenancyId == tenancyId &&
-                 m.Role == TenancyRole.BetaReader &&
-                 !m.IsSoftDeleted,
-            ct);
-
-    /// <summary>
-    /// Adds a new TenancyMembership to the context for persistence on the next SaveChanges.
-    /// </summary>
     public async Task AddAsync(TenancyMembership membership, CancellationToken ct = default) =>
         await db.TenancyMemberships.AddAsync(membership, ct);
 }

--- a/DraftView.Infrastructure/Persistence/Repositories/TenancyRepository.cs
+++ b/DraftView.Infrastructure/Persistence/Repositories/TenancyRepository.cs
@@ -1,0 +1,29 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace DraftView.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Repository implementation for Tenancy entities.
+/// </summary>
+public class TenancyRepository(DraftViewDbContext db) : ITenancyRepository
+{
+    /// <summary>
+    /// Returns the Tenancy with the given id, or null if not found.
+    /// </summary>
+    public Task<Tenancy?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        db.Tenancies.FirstOrDefaultAsync(t => t.Id == id, ct);
+
+    /// <summary>
+    /// Returns the Tenancy owned by the given Account, or null if the account has no tenancy.
+    /// </summary>
+    public Task<Tenancy?> GetByOwnerAccountIdAsync(Guid ownerAccountId, CancellationToken ct = default) =>
+        db.Tenancies.FirstOrDefaultAsync(t => t.OwnerAccountId == ownerAccountId && !t.IsSoftDeleted, ct);
+
+    /// <summary>
+    /// Adds a new Tenancy to the context for persistence on the next SaveChanges.
+    /// </summary>
+    public async Task AddAsync(Tenancy tenancy, CancellationToken ct = default) =>
+        await db.Tenancies.AddAsync(tenancy, ct);
+}

--- a/DraftView.Infrastructure/Persistence/Repositories/TenancySubscriptionRepository.cs
+++ b/DraftView.Infrastructure/Persistence/Repositories/TenancySubscriptionRepository.cs
@@ -1,0 +1,14 @@
+using DraftView.Domain.Entities;
+using DraftView.Domain.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace DraftView.Infrastructure.Persistence.Repositories;
+
+public class TenancySubscriptionRepository(DraftViewDbContext db) : ITenancySubscriptionRepository
+{
+    public Task<TenancySubscription?> GetByTenancyIdAsync(Guid tenancyId, CancellationToken ct = default) =>
+        db.TenancySubscriptions.FirstOrDefaultAsync(s => s.TenancyId == tenancyId, ct);
+
+    public async Task AddAsync(TenancySubscription subscription, CancellationToken ct = default) =>
+        await db.TenancySubscriptions.AddAsync(subscription, ct);
+}

--- a/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/AuthorControllerTests.cs
@@ -40,6 +40,9 @@ public class AuthorControllerTests
     private readonly Mock<IProjectManagementService> projectManagementService = new();
     private readonly Mock<IContentNavigationService> contentNavigationService = new();
     private readonly Mock<IReaderManagementService> readerManagementService = new();
+    private readonly Mock<IManualUploadService> manualUploadService = new();
+    private readonly Mock<IManualChapterRepository> manualChapterRepo = new();
+    private readonly Mock<IManualChapterVersionRepository> manualChapterVersionRepo = new();
 
     public AuthorControllerTests()
     {
@@ -77,7 +80,10 @@ public class AuthorControllerTests
             sectionManagementService.Object,
             projectManagementService.Object,
             contentNavigationService.Object,
-            readerManagementService.Object);
+            readerManagementService.Object,
+            manualUploadService.Object,
+            manualChapterRepo.Object,
+            manualChapterVersionRepo.Object);
 
         controller.ControllerContext = new ControllerContext
         {

--- a/DraftView.Web.Tests/Controllers/HomeControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/HomeControllerTests.cs
@@ -21,9 +21,11 @@ public class HomeControllerTests
     [Fact]
     public void Privacy_ReturnsView()
     {
-        var userRepo  = new Mock<IUserRepository>();
-        var prefsRepo = new Mock<IUserPreferencesRepository>();
-        var controller = new HomeController(userRepo.Object, prefsRepo.Object);
+        var userRepo        = new Mock<IUserRepository>();
+        var prefsRepo       = new Mock<IUserPreferencesRepository>();
+        var projectRepo     = new Mock<IProjectRepository>();
+        var readerAccessRepo = new Mock<IReaderAccessRepository>();
+        var controller = new HomeController(userRepo.Object, prefsRepo.Object, projectRepo.Object, readerAccessRepo.Object);
 
         var result = controller.Privacy();
 

--- a/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
@@ -43,6 +43,7 @@ public class ReaderControllerTests
     private readonly Mock<IHumanOverrideService> humanOverrideService = new();
     private readonly Mock<IPassageAnchorService> passageAnchorService = new();
     private readonly Mock<IAccessRequestRepository> accessRequestRepo = new();
+    private readonly Mock<IAccessRequestService> accessRequestService = new();
     private readonly Mock<IReaderDashboardService> readerDashboardService = new();
     private readonly Mock<ILogger<ReaderController>> logger = new();
     private ICommentDisplayService CommentDisplayService =>
@@ -936,6 +937,7 @@ public class ReaderControllerTests
             passageAnchorService.Object,
             CommentDisplayService,
             accessRequestRepo.Object,
+            accessRequestService.Object,
             readerDashboardService.Object,
             logger.Object);
 

--- a/DraftView.Web/Controllers/AuthorController.cs
+++ b/DraftView.Web/Controllers/AuthorController.cs
@@ -988,7 +988,6 @@ public class AuthorController(
             ShowVersionHistory   = d.ShowVersionHistory,
             RetentionLimit       = d.RetentionLimit
         };
-}
 
     // ---------------------------------------------------------------------------
     // Manual Chapters
@@ -1251,3 +1250,4 @@ public class AuthorController(
 
         return RedirectToAction("ManualChapters", new { projectId });
     }
+}

--- a/DraftView.Web/Controllers/HomeController.cs
+++ b/DraftView.Web/Controllers/HomeController.cs
@@ -8,10 +8,10 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DraftView.Web.Controllers;
 
-public class HomeController(IUserRepository userRepo, IUserPreferencesRepository prefsRepo)
+public class HomeController(IUserRepository userRepo, IUserPreferencesRepository prefsRepo, IProjectRepository projectRepo)
     : BaseController(userRepo)
 {
-    public IActionResult Index()
+    public async Task<IActionResult> Index()
     {
         if (User.Identity?.IsAuthenticated != true)
             return RedirectToAction("Login", "Account");
@@ -20,7 +20,13 @@ public class HomeController(IUserRepository userRepo, IUserPreferencesRepository
             return RedirectToAction("Dashboard", "Support");
 
         if (User.IsInRole("Author"))
+        {
+            var projects = await projectRepo.GetAllAsync();
+            if (projects.Count == 0)
+                return RedirectToAction("Setup", "Onboarding");
+
             return RedirectToAction("Dashboard", "Author");
+        }
 
         return RedirectToAction("Dashboard", "Reader");
     }

--- a/DraftView.Web/Controllers/HomeController.cs
+++ b/DraftView.Web/Controllers/HomeController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DraftView.Web.Controllers;
 
-public class HomeController(IUserRepository userRepo, IUserPreferencesRepository prefsRepo, IProjectRepository projectRepo)
+public class HomeController(IUserRepository userRepo, IUserPreferencesRepository prefsRepo, IProjectRepository projectRepo, IReaderAccessRepository readerAccessRepo)
     : BaseController(userRepo)
 {
     public async Task<IActionResult> Index()
@@ -26,6 +26,17 @@ public class HomeController(IUserRepository userRepo, IUserPreferencesRepository
                 return RedirectToAction("Setup", "Onboarding");
 
             return RedirectToAction("Dashboard", "Author");
+        }
+
+        if (User.IsInRole("BetaReader"))
+        {
+            var user = await GetCurrentUserAsync();
+            if (user is not null)
+            {
+                var access = await readerAccessRepo.GetByReaderIdAsync(user.Id);
+                if (access.Count == 0)
+                    return RedirectToAction("RequestAccess", "Reader");
+            }
         }
 
         return RedirectToAction("Dashboard", "Reader");

--- a/DraftView.Web/Controllers/OnboardingController.cs
+++ b/DraftView.Web/Controllers/OnboardingController.cs
@@ -14,6 +14,7 @@ namespace DraftView.Web.Controllers;
 [AllowAnonymous]
 public class OnboardingController(
     IAuthorSelfRegistrationService registrationService,
+    IReaderSelfRegistrationService readerRegistrationService,
     UserManager<IdentityUser> userManager,
     SignInManager<IdentityUser> signInManager,
     IUserRepository userRepo,
@@ -213,4 +214,156 @@ public class OnboardingController(
 
     [HttpGet("/Join/FAQ")]
     public IActionResult FAQ() => View();
+
+    // ===========================================================================
+    // Beta Reader self-registration
+    // ===========================================================================
+
+    // ---------------------------------------------------------------------------
+    // GET /ReadersJoin
+    // ---------------------------------------------------------------------------
+
+    [HttpGet("/ReadersJoin")]
+    public IActionResult ReaderJoin()
+    {
+        if (User.Identity?.IsAuthenticated == true)
+            return RedirectToAction("Index", "Home");
+
+        return View(new RegisterReaderViewModel());
+    }
+
+    // ---------------------------------------------------------------------------
+    // POST /ReadersJoin
+    // ---------------------------------------------------------------------------
+
+    [HttpPost("/ReadersJoin")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ReaderJoin(RegisterReaderViewModel model, CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
+            return View(model);
+
+        var existingIdentity = await userManager.FindByEmailAsync(model.Email);
+        if (existingIdentity is not null)
+        {
+            ModelState.AddModelError(nameof(model.Email),
+                "An account with this email address already exists.");
+            return View(model);
+        }
+
+        try
+        {
+            var registration = await readerRegistrationService.RegisterAsync(
+                model.Email, model.DisplayName, ct);
+
+            var identityUser = new IdentityUser
+            {
+                Id             = registration.User.Id.ToString(),
+                UserName       = model.Email,
+                Email          = model.Email,
+                EmailConfirmed = false
+            };
+
+            var createResult = await userManager.CreateAsync(identityUser);
+            if (!createResult.Succeeded)
+            {
+                foreach (var error in createResult.Errors)
+                    ModelState.AddModelError(string.Empty, error.Description);
+                return View(model);
+            }
+
+            await userManager.AddToRoleAsync(identityUser, "BetaReader");
+
+            var token   = await userManager.GenerateEmailConfirmationTokenAsync(identityUser);
+            var encoded = HttpUtility.UrlEncode(token);
+            var baseUrl = $"{Request.Scheme}://{Request.Host}";
+            var link    = $"{baseUrl}/ReadersJoin/ConfirmEmail?userId={identityUser.Id}&token={encoded}";
+            var body    = $"""
+                <p>Welcome to DraftView, {model.DisplayName}!</p>
+                <p>Please confirm your email address to get started:</p>
+                <p><a href="{link}">Confirm my email</a></p>
+                <p>Or copy this link: {link}</p>
+                <p>If you did not sign up for DraftView, you can ignore this email.</p>
+                """;
+
+            try
+            {
+                await emailSender.SendAsync(model.Email, model.DisplayName,
+                    "Confirm your DraftView account", body, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to send confirmation email to {Email}", model.Email);
+            }
+
+            return RedirectToAction(nameof(ReaderEmailSent));
+        }
+        catch (InvariantViolationException ex) when (ex.InvariantCode == "I-SELF-REG-EMAIL-EXISTS")
+        {
+            ModelState.AddModelError(nameof(model.Email),
+                "An account with this email address already exists.");
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Reader self-registration failed for {Email}", model.Email);
+            ModelState.AddModelError(string.Empty, "Something went wrong. Please try again.");
+            return View(model);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // GET /ReadersJoin/EmailSent
+    // ---------------------------------------------------------------------------
+
+    [HttpGet("/ReadersJoin/EmailSent")]
+    public IActionResult ReaderEmailSent() => View();
+
+    // ---------------------------------------------------------------------------
+    // GET /ReadersJoin/ConfirmEmail
+    // ---------------------------------------------------------------------------
+
+    [HttpGet("/ReadersJoin/ConfirmEmail")]
+    public async Task<IActionResult> ReaderConfirmEmail(string userId, string token, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(token))
+            return View("ConfirmEmailResult", new ConfirmEmailResultViewModel
+            {
+                Success = false,
+                Message = "The confirmation link is invalid or has expired."
+            });
+
+        var identityUser = await userManager.FindByIdAsync(userId);
+        if (identityUser is null)
+            return View("ConfirmEmailResult", new ConfirmEmailResultViewModel
+            {
+                Success = false,
+                Message = "The confirmation link is invalid or has expired."
+            });
+
+        var decoded       = HttpUtility.UrlDecode(token);
+        var confirmResult = await userManager.ConfirmEmailAsync(identityUser, decoded);
+        if (!confirmResult.Succeeded)
+            return View("ConfirmEmailResult", new ConfirmEmailResultViewModel
+            {
+                Success = false,
+                Message = "The confirmation link is invalid or has expired."
+            });
+
+        var domainUser = await userRepo.GetByEmailAsync(identityUser.Email!, ct);
+        if (domainUser is not null && !domainUser.IsActive)
+        {
+            domainUser.Activate();
+            await unitOfWork.SaveChangesAsync(ct);
+        }
+
+        await signInManager.SignInAsync(identityUser, isPersistent: false);
+
+        return View("ConfirmEmailResult", new ConfirmEmailResultViewModel
+        {
+            Success  = true,
+            Message  = "Your email has been confirmed. Welcome to DraftView!",
+            Redirect = Url.Action("Index", "Home")
+        });
+    }
 }

--- a/DraftView.Web/Controllers/OnboardingController.cs
+++ b/DraftView.Web/Controllers/OnboardingController.cs
@@ -1,3 +1,5 @@
+using DraftView.Application.Interfaces;
+using DraftView.Domain.Entities;
 using DraftView.Domain.Exceptions;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
@@ -17,6 +19,10 @@ public class OnboardingController(
     IUserRepository userRepo,
     IUnitOfWork unitOfWork,
     IEmailSender emailSender,
+    IAccountRepository accountRepo,
+    ITenancyRepository tenancyRepo,
+    IProjectRepository projectRepo,
+    IUserEmailLookupHmacService hmacService,
     ILogger<OnboardingController> logger) : Controller
 {
     // ---------------------------------------------------------------------------
@@ -170,17 +176,36 @@ public class OnboardingController(
         {
             Success  = true,
             Message  = "Your email has been confirmed. Welcome to DraftView!",
-            Redirect = Url.Action("FirstProject", "Onboarding")
+            Redirect = Url.Action("Index", "Home")
         });
     }
 
     // ---------------------------------------------------------------------------
-    // GET /Join/FirstProject — welcome page for newly confirmed authors
+    // GET /Join/Setup — multi-visit progressive workspace setup
     // ---------------------------------------------------------------------------
 
-    [HttpGet("/Join/FirstProject")]
+    [HttpGet("/Join/Setup")]
     [Authorize(Policy = "RequireAuthorPolicy")]
-    public IActionResult FirstProject() => View();
+    public async Task<IActionResult> Setup(CancellationToken ct)
+    {
+        var email   = User.Identity?.Name ?? string.Empty;
+        var hmac    = hmacService.Compute(email.Trim());
+        var account = await accountRepo.GetByEmailLookupHmacAsync(hmac, ct);
+
+        Tenancy? tenancy = null;
+        if (account is not null)
+            tenancy = await tenancyRepo.GetByOwnerAccountIdAsync(account.Id, ct);
+
+        var projects = await projectRepo.GetAllAsync(ct);
+
+        return View(new SetupViewModel
+        {
+            TenancyConfigured = tenancy is not null,
+            TenancyName       = tenancy?.Name,
+            ProjectCreated    = projects.Count > 0,
+            ProjectCount      = projects.Count
+        });
+    }
 
     // ---------------------------------------------------------------------------
     // GET /Join/FAQ

--- a/DraftView.Web/Controllers/OnboardingController.cs
+++ b/DraftView.Web/Controllers/OnboardingController.cs
@@ -1,0 +1,191 @@
+using DraftView.Domain.Exceptions;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+using DraftView.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using System.Web;
+
+namespace DraftView.Web.Controllers;
+
+[AllowAnonymous]
+public class OnboardingController(
+    IAuthorSelfRegistrationService registrationService,
+    UserManager<IdentityUser> userManager,
+    SignInManager<IdentityUser> signInManager,
+    IUserRepository userRepo,
+    IUnitOfWork unitOfWork,
+    IEmailSender emailSender,
+    ILogger<OnboardingController> logger) : Controller
+{
+    // ---------------------------------------------------------------------------
+    // GET /Join  — marketing landing page + registration form
+    // ---------------------------------------------------------------------------
+
+    [HttpGet("/Join")]
+    public IActionResult Join()
+    {
+        if (User.Identity?.IsAuthenticated == true)
+            return RedirectToAction("Index", "Home");
+
+        return View(new RegisterAuthorViewModel());
+    }
+
+    // ---------------------------------------------------------------------------
+    // POST /Join  — process registration
+    // ---------------------------------------------------------------------------
+
+    [HttpPost("/Join")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Join(RegisterAuthorViewModel model, CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
+            return View(model);
+
+        // Check whether identity email is already taken (before creating domain entities)
+        var existingIdentity = await userManager.FindByEmailAsync(model.Email);
+        if (existingIdentity is not null)
+        {
+            ModelState.AddModelError(nameof(model.Email),
+                "An account with this email address already exists.");
+            return View(model);
+        }
+
+        try
+        {
+            // Create domain entities atomically
+            var registration = await registrationService.RegisterAsync(
+                model.Email, model.DisplayName, model.TenancyName, ct);
+
+            // Create ASP.NET Identity record (unconfirmed)
+            var identityUser = new IdentityUser
+            {
+                Id             = registration.User.Id.ToString(),
+                UserName       = model.Email,
+                Email          = model.Email,
+                EmailConfirmed = false
+            };
+
+            var createResult = await userManager.CreateAsync(identityUser);
+            if (!createResult.Succeeded)
+            {
+                foreach (var error in createResult.Errors)
+                    ModelState.AddModelError(string.Empty, error.Description);
+                return View(model);
+            }
+
+            await userManager.AddToRoleAsync(identityUser, "Author");
+
+            // Generate and send confirmation email
+            var token     = await userManager.GenerateEmailConfirmationTokenAsync(identityUser);
+            var encoded   = HttpUtility.UrlEncode(token);
+            var baseUrl   = $"{Request.Scheme}://{Request.Host}";
+            var link      = $"{baseUrl}/Join/ConfirmEmail?userId={identityUser.Id}&token={encoded}";
+            var body      = $"""
+                <p>Welcome to DraftView, {model.DisplayName}!</p>
+                <p>Please confirm your email address to get started:</p>
+                <p><a href="{link}">Confirm my email</a></p>
+                <p>Or copy this link: {link}</p>
+                <p>If you did not sign up for DraftView, you can ignore this email.</p>
+                """;
+
+            try
+            {
+                await emailSender.SendAsync(model.Email, model.DisplayName,
+                    "Confirm your DraftView account", body, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to send confirmation email to {Email}", model.Email);
+            }
+
+            return RedirectToAction(nameof(EmailSent));
+        }
+        catch (InvariantViolationException ex) when (ex.InvariantCode == "I-SELF-REG-EMAIL-EXISTS")
+        {
+            ModelState.AddModelError(nameof(model.Email),
+                "An account with this email address already exists.");
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Author self-registration failed for {Email}", model.Email);
+            ModelState.AddModelError(string.Empty,
+                "Something went wrong. Please try again.");
+            return View(model);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // GET /Join/EmailSent
+    // ---------------------------------------------------------------------------
+
+    [HttpGet("/Join/EmailSent")]
+    public IActionResult EmailSent() => View();
+
+    // ---------------------------------------------------------------------------
+    // GET /Join/ConfirmEmail
+    // ---------------------------------------------------------------------------
+
+    [HttpGet("/Join/ConfirmEmail")]
+    public async Task<IActionResult> ConfirmEmail(string userId, string token, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(token))
+            return View("ConfirmEmailResult", new ConfirmEmailResultViewModel
+            {
+                Success = false,
+                Message = "The confirmation link is invalid or has expired."
+            });
+
+        var identityUser = await userManager.FindByIdAsync(userId);
+        if (identityUser is null)
+            return View("ConfirmEmailResult", new ConfirmEmailResultViewModel
+            {
+                Success = false,
+                Message = "The confirmation link is invalid or has expired."
+            });
+
+        var decoded       = HttpUtility.UrlDecode(token);
+        var confirmResult = await userManager.ConfirmEmailAsync(identityUser, decoded);
+        if (!confirmResult.Succeeded)
+            return View("ConfirmEmailResult", new ConfirmEmailResultViewModel
+            {
+                Success = false,
+                Message = "The confirmation link is invalid or has expired."
+            });
+
+        // Activate domain User
+        var domainUser = await userRepo.GetByEmailAsync(identityUser.Email!, ct);
+        if (domainUser is not null && !domainUser.IsActive)
+        {
+            domainUser.Activate();
+            await unitOfWork.SaveChangesAsync(ct);
+        }
+
+        // Sign in the new author
+        await signInManager.SignInAsync(identityUser, isPersistent: false);
+
+        return View("ConfirmEmailResult", new ConfirmEmailResultViewModel
+        {
+            Success  = true,
+            Message  = "Your email has been confirmed. Welcome to DraftView!",
+            Redirect = Url.Action("FirstProject", "Onboarding")
+        });
+    }
+
+    // ---------------------------------------------------------------------------
+    // GET /Join/FirstProject — welcome page for newly confirmed authors
+    // ---------------------------------------------------------------------------
+
+    [HttpGet("/Join/FirstProject")]
+    [Authorize(Policy = "RequireAuthorPolicy")]
+    public IActionResult FirstProject() => View();
+
+    // ---------------------------------------------------------------------------
+    // GET /Join/FAQ
+    // ---------------------------------------------------------------------------
+
+    [HttpGet("/Join/FAQ")]
+    public IActionResult FAQ() => View();
+}

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -28,6 +28,7 @@ public class ReaderController(
     IPassageAnchorService passageAnchorService,
     ICommentDisplayService commentDisplayService,
     IAccessRequestRepository accessRequestRepo,
+    IAccessRequestService accessRequestService,
     IReaderDashboardService readerDashboardService,
     ILogger<ReaderController> logger)
     : BaseReaderController(projectRepo, sectionRepo, commentService, progressService,
@@ -823,5 +824,110 @@ public class ReaderController(
             : (Guid?)null;
 
         return (prevSceneId, nextSceneId);
+    }
+
+    // -----------------------------------------------------------------------
+    // GET: /Reader/RequestAccess — multi-visit access request page
+    // -----------------------------------------------------------------------
+
+    [HttpGet]
+    public async Task<IActionResult> RequestAccess(CancellationToken ct)
+    {
+        var user = await GetCurrentUserAsync(ct);
+        if (user is null)
+            return Forbid();
+
+        var allProjects     = await ProjectRepo.GetAllAsync(ct);
+        var availableProjects = allProjects
+            .Where(p => p.IsReaderActive)
+            .ToList();
+
+        var existingRequests = await accessRequestRepo.GetVisibleByReaderIdAsync(
+            user.Id, DateTime.UtcNow.Date, ct);
+
+        var pendingItems = existingRequests.Select(r =>
+        {
+            var project = allProjects.FirstOrDefault(p => p.Id == r.ProjectId);
+            return new ReaderDashboardRequestViewModel
+            {
+                Request     = r,
+                ProjectName = project?.Name ?? "Unknown project"
+            };
+        }).ToList();
+
+        return View(new RequestAccessViewModel
+        {
+            AvailableProjects = availableProjects,
+            PendingRequests   = pendingItems
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // POST: /Reader/RequestAccess
+    // -----------------------------------------------------------------------
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RequestAccess(RequestAccessViewModel model, CancellationToken ct)
+    {
+        var user = await GetCurrentUserAsync(ct);
+        if (user is null)
+            return Forbid();
+
+        var allProjects       = await ProjectRepo.GetAllAsync(ct);
+        var availableProjects = allProjects.Where(p => p.IsReaderActive).ToList();
+        var existingRequests  = await accessRequestRepo.GetVisibleByReaderIdAsync(
+            user.Id, DateTime.UtcNow.Date, ct);
+
+        model.AvailableProjects = availableProjects;
+        model.PendingRequests   = existingRequests.Select(r =>
+        {
+            var project = allProjects.FirstOrDefault(p => p.Id == r.ProjectId);
+            return new ReaderDashboardRequestViewModel
+            {
+                Request     = r,
+                ProjectName = project?.Name ?? "Unknown project"
+            };
+        }).ToList();
+
+        if (!ModelState.IsValid || model.SelectedProjectId is null)
+        {
+            if (model.SelectedProjectId is null)
+                ModelState.AddModelError(nameof(model.SelectedProjectId), "Please select a project.");
+            return View(model);
+        }
+
+        var alreadyRequested = existingRequests.Any(r =>
+            r.ProjectId == model.SelectedProjectId.Value &&
+            r.Status == DraftView.Domain.Enumerations.AccessRequestStatus.Pending);
+        if (alreadyRequested)
+        {
+            ModelState.AddModelError(string.Empty,
+                "You already have a pending request for that project.");
+            return View(model);
+        }
+
+        try
+        {
+            await accessRequestService.SubmitRequestAsync(
+                user.Id, model.SelectedProjectId.Value,
+                model.CoverNote, model.ContactEmail, ct);
+
+            var submittedProject = availableProjects
+                .FirstOrDefault(p => p.Id == model.SelectedProjectId.Value);
+
+            return View(new RequestAccessViewModel
+            {
+                AvailableProjects    = availableProjects,
+                PendingRequests      = model.PendingRequests,
+                RequestSubmitted     = true,
+                SubmittedProjectName = submittedProject?.Name
+            });
+        }
+        catch (InvariantViolationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return View(model);
+        }
     }
 }

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -19,6 +19,8 @@ using System;
 using DraftView.Web.Infrastructure;
 using DraftView.Domain.Enumerations;
 using DraftView.Infrastructure.Billing;
+using DraftView.Application.Services;
+using DraftView.Domain.Interfaces.Services;
 
 namespace DraftView.Web.Extensions
 {
@@ -135,6 +137,9 @@ namespace DraftView.Web.Extensions
 
             // Billing abstraction (MT-Sprint-2) — NullBillingProvider until a real provider is selected.
             services.AddSingleton<IBillingProvider, NullBillingProvider>();
+
+            // Author registration (MT-Sprint-3)
+            services.AddScoped<IAuthorRegistrationService, AuthorRegistrationService>();
 
             return services;
         }

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -142,6 +142,9 @@ namespace DraftView.Web.Extensions
             services.AddScoped<IAuthorRegistrationService, AuthorRegistrationService>();
             services.AddScoped<IAuthorSelfRegistrationService, AuthorSelfRegistrationService>();
 
+            // Reader self-registration (MT-Sprint-3)
+            services.AddScoped<IReaderSelfRegistrationService, ReaderSelfRegistrationService>();
+
             return services;
         }
 

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -140,6 +140,7 @@ namespace DraftView.Web.Extensions
 
             // Author registration (MT-Sprint-3)
             services.AddScoped<IAuthorRegistrationService, AuthorRegistrationService>();
+            services.AddScoped<IAuthorSelfRegistrationService, AuthorSelfRegistrationService>();
 
             return services;
         }

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -48,6 +48,11 @@ namespace DraftView.Web.Extensions
             services.AddScoped<IManualChapterRepository, ManualChapterRepository>();
             services.AddScoped<IManualChapterVersionRepository, ManualChapterVersionRepository>();
 
+            // Multi-tenancy repositories (MT-Sprint-1)
+            services.AddScoped<IAccountRepository, AccountRepository>();
+            services.AddScoped<ITenancyRepository, TenancyRepository>();
+            services.AddScoped<ITenancyMembershipRepository, TenancyMembershipRepository>();
+
             return services;
         }
 

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Identity;
 using System;
 using DraftView.Web.Infrastructure;
 using DraftView.Domain.Enumerations;
+using DraftView.Infrastructure.Billing;
 
 namespace DraftView.Web.Extensions
 {
@@ -52,6 +53,9 @@ namespace DraftView.Web.Extensions
             services.AddScoped<IAccountRepository, AccountRepository>();
             services.AddScoped<ITenancyRepository, TenancyRepository>();
             services.AddScoped<ITenancyMembershipRepository, TenancyMembershipRepository>();
+
+            // Multi-tenancy repositories (MT-Sprint-2)
+            services.AddScoped<ITenancySubscriptionRepository, TenancySubscriptionRepository>();
 
             return services;
         }
@@ -128,6 +132,9 @@ namespace DraftView.Web.Extensions
             services.AddScoped<IChapterFileParserResolver, ChapterFileParserResolver>();
             services.AddScoped<IManualUploadService, ManualUploadService>();
             services.AddSingleton<IMarkdownToHtmlConverter, MarkdownToHtmlConverter>();
+
+            // Billing abstraction (MT-Sprint-2) — NullBillingProvider until a real provider is selected.
+            services.AddSingleton<IBillingProvider, NullBillingProvider>();
 
             return services;
         }

--- a/DraftView.Web/Models/OnboardingViewModels.cs
+++ b/DraftView.Web/Models/OnboardingViewModels.cs
@@ -34,3 +34,16 @@ public class RegisterAuthorViewModel
     [Display(Name = "Workspace name")]
     public string TenancyName { get; set; } = string.Empty;
 }
+
+public class RegisterReaderViewModel
+{
+    [Required(ErrorMessage = "Email address is required.")]
+    [EmailAddress(ErrorMessage = "Please enter a valid email address.")]
+    [Display(Name = "Email address")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Your name is required.")]
+    [StringLength(100, MinimumLength = 2, ErrorMessage = "Name must be between 2 and 100 characters.")]
+    [Display(Name = "Your name")]
+    public string DisplayName { get; set; } = string.Empty;
+}

--- a/DraftView.Web/Models/OnboardingViewModels.cs
+++ b/DraftView.Web/Models/OnboardingViewModels.cs
@@ -2,6 +2,14 @@ using System.ComponentModel.DataAnnotations;
 
 namespace DraftView.Web.Models;
 
+public class SetupViewModel
+{
+    public bool    TenancyConfigured { get; init; }
+    public string? TenancyName       { get; init; }
+    public bool    ProjectCreated    { get; init; }
+    public int     ProjectCount      { get; init; }
+}
+
 public class ConfirmEmailResultViewModel
 {
     public bool    Success  { get; init; }

--- a/DraftView.Web/Models/OnboardingViewModels.cs
+++ b/DraftView.Web/Models/OnboardingViewModels.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DraftView.Web.Models;
+
+public class ConfirmEmailResultViewModel
+{
+    public bool    Success  { get; init; }
+    public string  Message  { get; init; } = string.Empty;
+    public string? Redirect { get; init; }
+}
+
+public class RegisterAuthorViewModel
+{
+    [Required(ErrorMessage = "Email address is required.")]
+    [EmailAddress(ErrorMessage = "Please enter a valid email address.")]
+    [Display(Name = "Email address")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Your name is required.")]
+    [StringLength(100, MinimumLength = 2, ErrorMessage = "Name must be between 2 and 100 characters.")]
+    [Display(Name = "Your name")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Workspace name is required.")]
+    [StringLength(100, MinimumLength = 2, ErrorMessage = "Workspace name must be between 2 and 100 characters.")]
+    [Display(Name = "Workspace name")]
+    public string TenancyName { get; set; } = string.Empty;
+}

--- a/DraftView.Web/Models/ReaderViewModels.cs
+++ b/DraftView.Web/Models/ReaderViewModels.cs
@@ -1,4 +1,5 @@
-﻿using DraftView.Domain.Contracts;
+﻿using System.ComponentModel.DataAnnotations;
+using DraftView.Domain.Contracts;
 using DraftView.Domain.Diff;
 using DraftView.Domain.Entities;
 using DraftView.Domain.Enumerations;
@@ -181,4 +182,24 @@ public class ReaderDashboardRequestViewModel
 {
     public AccessRequest Request { get; init; } = default!;
     public string ProjectName { get; init; } = string.Empty;
+}
+
+public class RequestAccessViewModel
+{
+    public IReadOnlyList<Project> AvailableProjects { get; init; } = [];
+    public IReadOnlyList<ReaderDashboardRequestViewModel> PendingRequests { get; init; } = [];
+
+    [Required(ErrorMessage = "Please select a project.")]
+    public Guid? SelectedProjectId { get; set; }
+
+    [StringLength(500, ErrorMessage = "Cover note must not exceed 500 characters.")]
+    [Display(Name = "Cover note (optional)")]
+    public string? CoverNote { get; set; }
+
+    [EmailAddress(ErrorMessage = "Please enter a valid email address.")]
+    [Display(Name = "Contact email (optional)")]
+    public string? ContactEmail { get; set; }
+
+    public bool RequestSubmitted { get; init; }
+    public string? SubmittedProjectName { get; init; }
 }

--- a/DraftView.Web/Models/ReaderViewModels.cs
+++ b/DraftView.Web/Models/ReaderViewModels.cs
@@ -186,8 +186,8 @@ public class ReaderDashboardRequestViewModel
 
 public class RequestAccessViewModel
 {
-    public IReadOnlyList<Project> AvailableProjects { get; init; } = [];
-    public IReadOnlyList<ReaderDashboardRequestViewModel> PendingRequests { get; init; } = [];
+    public IReadOnlyList<Project> AvailableProjects { get; set; } = [];
+    public IReadOnlyList<ReaderDashboardRequestViewModel> PendingRequests { get; set; } = [];
 
     [Required(ErrorMessage = "Please select a project.")]
     public Guid? SelectedProjectId { get; set; }

--- a/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
+++ b/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
+++ b/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
@@ -55,7 +55,7 @@
     <script>
         setTimeout(function () {
             window.location.href = "@Model.Redirect";
-        }, 2500);
+        }, 2000);
     </script>
 }
 

--- a/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
+++ b/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
@@ -1,0 +1,63 @@
+@model DraftView.Web.Models.ConfirmEmailResultViewModel
+@{
+    Layout = null;
+    ViewData["Title"] = Model.Success ? "Email confirmed — DraftView" : "Confirmation failed — DraftView";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"]</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; min-height: 100vh; font-family: 'Inter', system-ui, sans-serif; }
+        body { background: #1a1a2e; }
+    </style>
+</head>
+<body>
+
+<div class="onboarding-bg" aria-hidden="true">
+    <div class="onboarding-bg__slide is-active" style="background-image: url('/images/DraftView.Atmosphere.web.jpg')"></div>
+</div>
+
+<div class="onboarding-page">
+    <div class="onboarding-status">
+        @if (Model.Success)
+        {
+            <span class="onboarding-status__icon" aria-hidden="true">✅</span>
+            <h1 class="onboarding-status__title">You're confirmed!</h1>
+            <p class="onboarding-status__body">@Model.Message</p>
+            @if (!string.IsNullOrEmpty(Model.Redirect))
+            {
+                <a href="@Model.Redirect" class="onboarding-status__action">Get started &rarr;</a>
+            }
+        }
+        else
+        {
+            <span class="onboarding-status__icon" aria-hidden="true">❌</span>
+            <h1 class="onboarding-status__title">Confirmation failed</h1>
+            <p class="onboarding-status__body">@Model.Message</p>
+            <a href="/Join" class="onboarding-status__action">Try again</a>
+        }
+    </div>
+</div>
+
+@if (Model.Success && !string.IsNullOrEmpty(Model.Redirect))
+{
+    <script>
+        setTimeout(function () {
+            window.location.href = "@Model.Redirect";
+        }, 2500);
+    </script>
+}
+
+</body>
+</html>

--- a/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
+++ b/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-3" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/EmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/EmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-3" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/EmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/EmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/EmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/EmailSent.cshtml
@@ -1,0 +1,46 @@
+@{
+    Layout = null;
+    ViewData["Title"] = "Check your email — DraftView";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Check your email — DraftView</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; min-height: 100vh; font-family: 'Inter', system-ui, sans-serif; }
+        body { background: #1a1a2e; }
+    </style>
+</head>
+<body>
+
+<div class="onboarding-bg" aria-hidden="true">
+    <div class="onboarding-bg__slide is-active" style="background-image: url('/images/DraftView.Atmosphere.web.jpg')"></div>
+</div>
+
+<div class="onboarding-page">
+    <div class="onboarding-status">
+        <span class="onboarding-status__icon" aria-hidden="true">✉️</span>
+        <h1 class="onboarding-status__title">Check your inbox</h1>
+        <p class="onboarding-status__body">
+            We've sent a confirmation link to your email address.
+            Click it to activate your account and start setting up your first project.
+        </p>
+        <p class="onboarding-status__body">
+            The link expires in 24 hours. If you don't see it, check your spam folder.
+        </p>
+        <a href="/Join" class="onboarding-status__action">Back to sign-up</a>
+    </div>
+</div>
+
+</body>
+</html>

--- a/DraftView.Web/Views/Onboarding/FAQ.cshtml
+++ b/DraftView.Web/Views/Onboarding/FAQ.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-3" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/FAQ.cshtml
+++ b/DraftView.Web/Views/Onboarding/FAQ.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/FAQ.cshtml
+++ b/DraftView.Web/Views/Onboarding/FAQ.cshtml
@@ -1,0 +1,118 @@
+@{
+    Layout = null;
+    ViewData["Title"] = "FAQ — DraftView";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FAQ — DraftView</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; min-height: 100vh; font-family: 'Inter', system-ui, sans-serif; }
+        body { background: #1a1a2e; }
+    </style>
+</head>
+<body>
+
+<div class="onboarding-bg" aria-hidden="true">
+    <div class="onboarding-bg__slide is-active" style="background-image: url('/images/DraftView.Theme.Crime.Atmosphere.png')"></div>
+</div>
+
+<div class="onboarding-page">
+    <div class="onboarding-faq">
+
+        <a href="/Join" class="onboarding-faq__back">
+            &larr; Back to sign-up
+        </a>
+
+        <h1 class="onboarding-faq__title">Frequently Asked Questions</h1>
+        <p class="onboarding-faq__intro">
+            Everything you need to know before you get started with DraftView.
+        </p>
+
+        <div class="onboarding-faq__item">
+            <p class="onboarding-faq__question">What is DraftView?</p>
+            <p class="onboarding-faq__answer">
+                DraftView is a private reading platform designed for authors who want to share their
+                work-in-progress with a trusted circle of beta readers. You control exactly which
+                chapters are visible, when, and to whom.
+            </p>
+        </div>
+
+        <div class="onboarding-faq__item">
+            <p class="onboarding-faq__question">How do I get my manuscript into DraftView?</p>
+            <p class="onboarding-faq__answer">
+                DraftView syncs directly from Scrivener via your Dropbox account. Once you connect
+                Dropbox and compile your project to the DraftView-compatible folder, chapters are
+                pulled in automatically. You can also upload plain-text or Word chapters manually.
+            </p>
+        </div>
+
+        <div class="onboarding-faq__item">
+            <p class="onboarding-faq__question">How do readers access my work?</p>
+            <p class="onboarding-faq__answer">
+                You invite readers by email. Each reader creates a free account and can only see the
+                chapters you've published to their view. They can leave inline comments that you see
+                on your dashboard.
+            </p>
+        </div>
+
+        <div class="onboarding-faq__item">
+            <p class="onboarding-faq__question">Is my work private?</p>
+            <p class="onboarding-faq__answer">
+                Yes. Only readers you explicitly invite can see your chapters. DraftView is not a
+                social platform — there is no public discovery feed and no way for strangers to
+                stumble across your work.
+            </p>
+        </div>
+
+        <div class="onboarding-faq__item">
+            <p class="onboarding-faq__question">How much does it cost?</p>
+            <p class="onboarding-faq__answer">
+                DraftView is free for a single author workspace with up to a small number of beta
+                readers. Paid tiers for larger reader circles will be introduced in future; existing
+                users will always be grandfathered into their current plan.
+            </p>
+        </div>
+
+        <div class="onboarding-faq__item">
+            <p class="onboarding-faq__question">What are the themes?</p>
+            <p class="onboarding-faq__answer">
+                DraftView ships with five atmosphere themes — Adventure (the default), Crime, Noir,
+                Historic, and Contemporary — each with its own colour palette, typography choices,
+                and background imagery. You choose the theme that fits your manuscript's mood.
+                Readers see the theme you've selected.
+            </p>
+        </div>
+
+        <div class="onboarding-faq__item">
+            <p class="onboarding-faq__question">Do I need Scrivener?</p>
+            <p class="onboarding-faq__answer">
+                No. Scrivener via Dropbox is the most seamless workflow, but you can also upload
+                chapters individually using the manual upload feature. DraftView accepts Word (.docx)
+                and plain text files.
+            </p>
+        </div>
+
+        <div class="onboarding-faq__item">
+            <p class="onboarding-faq__question">What if I have more questions?</p>
+            <p class="onboarding-faq__answer">
+                Reach out via the account settings page once you've signed up. We're a small team
+                and happy to help.
+            </p>
+        </div>
+
+    </div>
+</div>
+
+</body>
+</html>

--- a/DraftView.Web/Views/Onboarding/FirstProject.cshtml
+++ b/DraftView.Web/Views/Onboarding/FirstProject.cshtml
@@ -1,0 +1,50 @@
+@{
+    Layout = "_Layout";
+    ViewData["Title"] = "Welcome to DraftView";
+}
+
+<div class="onboarding-welcome" style="color: var(--color-text, #1a1a2e);">
+
+    <h1 class="onboarding-welcome__headline" style="color: var(--color-text, #1a1a2e);">
+        Welcome to DraftView!
+    </h1>
+    <p class="onboarding-welcome__subline" style="opacity: 1; color: var(--color-text-muted, #555);">
+        Your author workspace is ready. Here's how to get your manuscript in front of your first readers.
+    </p>
+
+    <div class="onboarding-steps">
+        <div class="onboarding-step" style="background: var(--color-surface-alt, #f5f5f5); border-color: var(--color-border, #e0e0e0); color: var(--color-text, #1a1a2e);">
+            <div class="onboarding-step__number" style="opacity: 0.4;">01</div>
+            <p class="onboarding-step__title">Connect Dropbox</p>
+            <p class="onboarding-step__desc" style="opacity: 1; color: var(--color-text-muted, #666);">
+                Link your Dropbox account so DraftView can sync chapters from your Scrivener project automatically.
+            </p>
+        </div>
+        <div class="onboarding-step" style="background: var(--color-surface-alt, #f5f5f5); border-color: var(--color-border, #e0e0e0); color: var(--color-text, #1a1a2e);">
+            <div class="onboarding-step__number" style="opacity: 0.4;">02</div>
+            <p class="onboarding-step__title">Sync your project</p>
+            <p class="onboarding-step__desc" style="opacity: 1; color: var(--color-text-muted, #666);">
+                Compile your Scrivener project to Dropbox, then trigger a sync from your dashboard. Your chapters appear instantly.
+            </p>
+        </div>
+        <div class="onboarding-step" style="background: var(--color-surface-alt, #f5f5f5); border-color: var(--color-border, #e0e0e0); color: var(--color-text, #1a1a2e);">
+            <div class="onboarding-step__number" style="opacity: 0.4;">03</div>
+            <p class="onboarding-step__title">Invite your readers</p>
+            <p class="onboarding-step__desc" style="opacity: 1; color: var(--color-text-muted, #666);">
+                Send email invitations to your beta readers. Control which chapters each reader can access.
+            </p>
+        </div>
+        <div class="onboarding-step" style="background: var(--color-surface-alt, #f5f5f5); border-color: var(--color-border, #e0e0e0); color: var(--color-text, #1a1a2e);">
+            <div class="onboarding-step__number" style="opacity: 0.4;">04</div>
+            <p class="onboarding-step__title">Read the feedback</p>
+            <p class="onboarding-step__desc" style="opacity: 1; color: var(--color-text-muted, #666);">
+                Inline comments and reading progress appear on your dashboard in real time.
+            </p>
+        </div>
+    </div>
+
+    <a href="/Author/Dashboard" class="onboarding-welcome__cta" style="background: var(--color-accent, #5b6af0); border-color: var(--color-accent, #5b6af0);">
+        Go to my dashboard &rarr;
+    </a>
+
+</div>

--- a/DraftView.Web/Views/Onboarding/Join.cshtml
+++ b/DraftView.Web/Views/Onboarding/Join.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/Join.cshtml
+++ b/DraftView.Web/Views/Onboarding/Join.cshtml
@@ -1,0 +1,166 @@
+@model DraftView.Web.Models.RegisterAuthorViewModel
+@{
+    Layout = null; // Full-page layout — no site-nav for onboarding
+    ViewData["Title"] = "Join DraftView";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Join DraftView</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; min-height: 100vh; font-family: 'Inter', system-ui, sans-serif; }
+        body { background: #1a1a2e; }
+    </style>
+</head>
+<body>
+
+<!-- Rotating atmosphere backgrounds -->
+<div class="onboarding-bg" id="onboardingBg" aria-hidden="true">
+    <div class="onboarding-bg__slide" data-src="/images/DraftView.Atmosphere.web.jpg"></div>
+    <div class="onboarding-bg__slide" data-src="/images/DraftView.Theme.Crime.Atmosphere.png"></div>
+    <div class="onboarding-bg__slide" data-src="/images/Noir-Atmosphere.png"></div>
+    <div class="onboarding-bg__slide" data-src="/images/Historic-Atmosphere.png"></div>
+    <div class="onboarding-bg__slide" data-src="/images/contemporary-atmosphere.png"></div>
+</div>
+
+<div class="onboarding-page">
+    <div class="onboarding-outer">
+        <div class="onboarding-split">
+
+            <!-- Left: marketing copy -->
+            <div class="onboarding-copy">
+                <img src="/images/DraftView.Logo.web.png" alt="DraftView" class="onboarding-copy__logo" />
+
+                <h1 class="onboarding-copy__headline">
+                    Your story,<br>shared your way.
+                </h1>
+
+                <p class="onboarding-copy__tagline">
+                    DraftView is the private reading room for authors who want to share works-in-progress with beta readers — without losing control over who sees what, or when.
+                </p>
+
+                <ul class="onboarding-copy__features">
+                    <li>Sync chapters directly from Scrivener via Dropbox</li>
+                    <li>Invite readers chapter-by-chapter at your own pace</li>
+                    <li>Collect inline comments and track reading progress</li>
+                    <li>Themes built for the mood of your manuscript</li>
+                    <li>No subscription, no ads — just you and your readers</li>
+                </ul>
+
+                <a href="/Join/FAQ" class="onboarding-copy__faq-link">
+                    Got questions? Read the FAQ &rarr;
+                </a>
+            </div>
+
+            <!-- Right: registration form -->
+            <div class="onboarding-card">
+                <h2 class="onboarding-card__title">Create your author account</h2>
+                <p class="onboarding-card__subtitle">Free forever for a single author workspace.</p>
+
+                @if (!ViewData.ModelState.IsValid && ViewData.ModelState.ErrorCount > 0)
+                {
+                    <div class="onboarding-validation-summary">
+                        @foreach (var ms in ViewData.ModelState.Values)
+                        {
+                            foreach (var error in ms.Errors)
+                            {
+                                <div>@error.ErrorMessage</div>
+                            }
+                        }
+                    </div>
+                }
+
+                <form asp-controller="Onboarding" asp-action="Join" method="post" class="onboarding-form">
+                    @Html.AntiForgeryToken()
+
+                    <div class="onboarding-form__group">
+                        <label asp-for="Email" class="onboarding-form__label"></label>
+                        <input asp-for="Email"
+                               type="email"
+                               class="onboarding-form__input @(ViewData.ModelState["Email"]?.Errors.Count > 0 ? "is-invalid" : "")"
+                               placeholder="you@example.com"
+                               autocomplete="email" />
+                        <span asp-validation-for="Email" class="onboarding-form__error"></span>
+                    </div>
+
+                    <div class="onboarding-form__group">
+                        <label asp-for="DisplayName" class="onboarding-form__label"></label>
+                        <input asp-for="DisplayName"
+                               type="text"
+                               class="onboarding-form__input @(ViewData.ModelState["DisplayName"]?.Errors.Count > 0 ? "is-invalid" : "")"
+                               placeholder="Jane Austen"
+                               autocomplete="name" />
+                        <span asp-validation-for="DisplayName" class="onboarding-form__error"></span>
+                    </div>
+
+                    <div class="onboarding-form__group">
+                        <label asp-for="TenancyName" class="onboarding-form__label"></label>
+                        <input asp-for="TenancyName"
+                               type="text"
+                               class="onboarding-form__input @(ViewData.ModelState["TenancyName"]?.Errors.Count > 0 ? "is-invalid" : "")"
+                               placeholder="Jane's Reading Room" />
+                        <span asp-validation-for="TenancyName" class="onboarding-form__error"></span>
+                        <span class="onboarding-form__hint">This is the name your readers will see.</span>
+                    </div>
+
+                    <button type="submit" class="onboarding-form__submit">
+                        Create my account
+                    </button>
+                </form>
+
+                <p class="onboarding-form__login-link">
+                    Already have an account? <a href="/Account/Login">Sign in</a>
+                </p>
+            </div>
+
+        </div>
+    </div>
+</div>
+
+<script>
+(function () {
+    "use strict";
+
+    var slides = document.querySelectorAll('.onboarding-bg__slide');
+    if (!slides.length) return;
+
+    var current = 0;
+    var intervalMs = 9000; // 9 seconds per image
+
+    // Lazy-load background images
+    function loadSlide(slide) {
+        var src = slide.getAttribute('data-src');
+        if (src && !slide.style.backgroundImage) {
+            slide.style.backgroundImage = 'url("' + src + '")';
+        }
+    }
+
+    // Activate first slide immediately
+    loadSlide(slides[current]);
+    slides[current].classList.add('is-active');
+
+    function advance() {
+        var next = (current + 1) % slides.length;
+        loadSlide(slides[next]);
+
+        slides[current].classList.remove('is-active');
+        slides[next].classList.add('is-active');
+        current = next;
+    }
+
+    setInterval(advance, intervalMs);
+}());
+</script>
+
+</body>
+</html>

--- a/DraftView.Web/Views/Onboarding/Join.cshtml
+++ b/DraftView.Web/Views/Onboarding/Join.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-3" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-3" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
@@ -1,0 +1,46 @@
+@{
+    Layout = null;
+    ViewData["Title"] = "Check your email — DraftView";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Check your email — DraftView</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; min-height: 100vh; font-family: 'Inter', system-ui, sans-serif; }
+        body { background: #1a1a2e; }
+    </style>
+</head>
+<body>
+
+<div class="onboarding-bg" aria-hidden="true">
+    <div class="onboarding-bg__slide is-active" style="background-image: url('/images/DraftView.Atmosphere.web.jpg')"></div>
+</div>
+
+<div class="onboarding-page">
+    <div class="onboarding-status">
+        <span class="onboarding-status__icon" aria-hidden="true">✉️</span>
+        <h1 class="onboarding-status__title">Check your inbox</h1>
+        <p class="onboarding-status__body">
+            We've sent a confirmation link to your email address.
+            Click it to activate your reader account.
+        </p>
+        <p class="onboarding-status__body">
+            The link expires in 24 hours. If you don't see it, check your spam folder.
+        </p>
+        <a href="/ReadersJoin" class="onboarding-status__action">Back to sign-up</a>
+    </div>
+</div>
+
+</body>
+</html>

--- a/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
@@ -1,0 +1,158 @@
+@model DraftView.Web.Models.RegisterReaderViewModel
+@{
+    Layout = null;
+    ViewData["Title"] = "Join as a Beta Reader — DraftView";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Join as a Beta Reader — DraftView</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
+    <style>
+        *, *::before, *::after { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; min-height: 100vh; font-family: 'Inter', system-ui, sans-serif; }
+        body { background: #1a1a2e; }
+    </style>
+</head>
+<body>
+
+<!-- Rotating atmosphere backgrounds -->
+<div class="onboarding-bg" id="onboardingBg" aria-hidden="true">
+    <div class="onboarding-bg__slide" data-src="/images/DraftView.Atmosphere.web.jpg"></div>
+    <div class="onboarding-bg__slide" data-src="/images/DraftView.Theme.Crime.Atmosphere.png"></div>
+    <div class="onboarding-bg__slide" data-src="/images/Noir-Atmosphere.png"></div>
+    <div class="onboarding-bg__slide" data-src="/images/Historic-Atmosphere.png"></div>
+    <div class="onboarding-bg__slide" data-src="/images/contemporary-atmosphere.png"></div>
+</div>
+
+<div class="onboarding-page">
+    <div class="onboarding-outer">
+        <div class="onboarding-split">
+
+            <!-- Left: marketing copy for readers -->
+            <div class="onboarding-copy">
+                <img src="/images/DraftView.Logo.web.png" alt="DraftView" class="onboarding-copy__logo" />
+
+                <h1 class="onboarding-copy__headline">
+                    Read stories<br>before anyone else.
+                </h1>
+
+                <p class="onboarding-copy__tagline">
+                    DraftView is a private reading room for authors sharing works-in-progress with trusted beta readers. Create your reader account and request access to the stories you want to follow.
+                </p>
+
+                <ul class="onboarding-copy__features">
+                    <li>Read chapters as they are written</li>
+                    <li>Leave inline comments the author will see</li>
+                    <li>Beautiful reading experience across five themes</li>
+                    <li>Your reading stays private — no public profiles</li>
+                    <li>Free to join</li>
+                </ul>
+
+                <a href="/Join/FAQ" class="onboarding-copy__faq-link">
+                    Got questions? Read the FAQ &rarr;
+                </a>
+            </div>
+
+            <!-- Right: reader registration form -->
+            <div class="onboarding-card">
+                <h2 class="onboarding-card__title">Create your reader account</h2>
+                <p class="onboarding-card__subtitle">
+                    Already have an invite from an author? Sign up here, then request access once logged in.
+                </p>
+
+                @if (!ViewData.ModelState.IsValid && ViewData.ModelState.ErrorCount > 0)
+                {
+                    <div class="onboarding-validation-summary">
+                        @foreach (var ms in ViewData.ModelState.Values)
+                        {
+                            foreach (var error in ms.Errors)
+                            {
+                                <div>@error.ErrorMessage</div>
+                            }
+                        }
+                    </div>
+                }
+
+                <form asp-controller="Onboarding" asp-action="ReaderJoin" method="post" class="onboarding-form">
+                    @Html.AntiForgeryToken()
+
+                    <div class="onboarding-form__group">
+                        <label asp-for="Email" class="onboarding-form__label"></label>
+                        <input asp-for="Email"
+                               type="email"
+                               class="onboarding-form__input @(ViewData.ModelState["Email"]?.Errors.Count > 0 ? "is-invalid" : "")"
+                               placeholder="you@example.com"
+                               autocomplete="email" />
+                        <span asp-validation-for="Email" class="onboarding-form__error"></span>
+                    </div>
+
+                    <div class="onboarding-form__group">
+                        <label asp-for="DisplayName" class="onboarding-form__label"></label>
+                        <input asp-for="DisplayName"
+                               type="text"
+                               class="onboarding-form__input @(ViewData.ModelState["DisplayName"]?.Errors.Count > 0 ? "is-invalid" : "")"
+                               placeholder="Jane Smith"
+                               autocomplete="name" />
+                        <span asp-validation-for="DisplayName" class="onboarding-form__error"></span>
+                    </div>
+
+                    <button type="submit" class="onboarding-form__submit">
+                        Create my reader account
+                    </button>
+                </form>
+
+                <p class="onboarding-form__login-link">
+                    Already have an account? <a href="/Account/Login">Sign in</a>
+                </p>
+                <p class="onboarding-form__login-link" style="margin-top:0.5rem;">
+                    Are you an author? <a href="/Join">Create an author account &rarr;</a>
+                </p>
+            </div>
+
+        </div>
+    </div>
+</div>
+
+<script>
+(function () {
+    "use strict";
+
+    var slides = document.querySelectorAll('.onboarding-bg__slide');
+    if (!slides.length) return;
+
+    var current = 0;
+    var intervalMs = 9000;
+
+    function loadSlide(slide) {
+        var src = slide.getAttribute('data-src');
+        if (src && !slide.style.backgroundImage) {
+            slide.style.backgroundImage = 'url("' + src + '")';
+        }
+    }
+
+    loadSlide(slides[current]);
+    slides[current].classList.add('is-active');
+
+    function advance() {
+        var next = (current + 1) % slides.length;
+        loadSlide(slides[next]);
+        slides[current].classList.remove('is-active');
+        slides[next].classList.add('is-active');
+        current = next;
+    }
+
+    setInterval(advance, intervalMs);
+}());
+</script>
+
+</body>
+</html>

--- a/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-3" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/Setup.cshtml
+++ b/DraftView.Web/Views/Onboarding/Setup.cshtml
@@ -1,0 +1,154 @@
+@model DraftView.Web.Models.SetupViewModel
+@{
+    Layout = "_Layout";
+    ViewData["Title"] = "Workspace Setup";
+
+    var allDone = Model.TenancyConfigured && Model.ProjectCreated;
+}
+
+<div class="settings-page">
+    <div class="settings-header">
+        <h1 class="settings-header__title">Set up your workspace</h1>
+        <p class="settings-header__subtitle">
+            Complete the steps below to get your first readers reading.
+            You can finish these across multiple sessions — progress is saved automatically.
+        </p>
+    </div>
+
+    @if (allDone)
+    {
+        <div class="toast toast--success" style="position:static; margin-bottom:1.5rem; display:block; opacity:1;">
+            Your workspace is fully set up! Head to your dashboard to manage your project.
+        </div>
+    }
+
+    <!-- Step 1: Workspace / Tenancy -->
+    <div class="settings-section">
+        <div class="settings-section__header">
+            <h2 class="settings-section__title">
+                @if (Model.TenancyConfigured)
+                {
+                    <span class="setup-step__badge setup-step__badge--done">&#10003; Done</span>
+                }
+                else
+                {
+                    <span class="setup-step__badge setup-step__badge--pending">1</span>
+                }
+                Your workspace
+            </h2>
+        </div>
+
+        <div class="settings-section__body">
+            @if (Model.TenancyConfigured)
+            {
+                <p>
+                    Your workspace is named <strong>@Model.TenancyName</strong>.
+                    You can update this in
+                    <a asp-controller="Account" asp-action="Settings">Account Settings</a>.
+                </p>
+            }
+            else
+            {
+                <p>
+                    Your workspace details were not set up during registration.
+                    Please
+                    <a href="/Join">register an author account</a>
+                    to create your workspace, or contact support if you believe this is an error.
+                </p>
+            }
+        </div>
+    </div>
+
+    <!-- Step 2: Connect Dropbox -->
+    <div class="settings-section">
+        <div class="settings-section__header">
+            <h2 class="settings-section__title">
+                <span class="setup-step__badge setup-step__badge--pending">2</span>
+                Connect your manuscript
+            </h2>
+        </div>
+
+        <div class="settings-section__body">
+            <p>
+                DraftView syncs chapters directly from Scrivener via Dropbox.
+                Connect your Dropbox account to get started — or use manual upload
+                to add Word or plain-text chapters one at a time.
+            </p>
+            <div style="display:flex; gap:1rem; flex-wrap:wrap; margin-top:1rem;">
+                <a asp-controller="Dropbox" asp-action="Connect" class="btn btn--primary">
+                    Connect Dropbox
+                </a>
+                <a asp-controller="Author" asp-action="ManualUpload" class="btn btn--secondary">
+                    Upload chapters manually
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Step 3: Project -->
+    <div class="settings-section">
+        <div class="settings-section__header">
+            <h2 class="settings-section__title">
+                @if (Model.ProjectCreated)
+                {
+                    <span class="setup-step__badge setup-step__badge--done">&#10003; Done</span>
+                }
+                else
+                {
+                    <span class="setup-step__badge setup-step__badge--pending">3</span>
+                }
+                Your first project
+            </h2>
+        </div>
+
+        <div class="settings-section__body">
+            @if (Model.ProjectCreated)
+            {
+                <p>
+                    @(Model.ProjectCount == 1 ? "You have 1 project." : $"You have {Model.ProjectCount} projects.")
+                    Head to your dashboard to publish chapters and invite readers.
+                </p>
+                <a asp-controller="Author" asp-action="Dashboard" class="btn btn--primary">
+                    Go to dashboard
+                </a>
+            }
+            else
+            {
+                <p>
+                    Once you've connected Dropbox, trigger a sync from the dashboard to import
+                    your Scrivener project. Your chapters will appear automatically.
+                </p>
+                <p>
+                    If you're using manual upload, chapters you've uploaded will appear as a project
+                    on the dashboard.
+                </p>
+                <a asp-controller="Author" asp-action="Dashboard" class="btn btn--secondary">
+                    Go to dashboard
+                </a>
+            }
+        </div>
+    </div>
+</div>
+
+<style>
+    .setup-step__badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.6rem;
+        height: 1.6rem;
+        border-radius: 50%;
+        font-size: 0.8rem;
+        font-weight: 700;
+        margin-right: 0.5rem;
+        vertical-align: middle;
+    }
+    .setup-step__badge--done {
+        background: #2e7d32;
+        color: #fff;
+    }
+    .setup-step__badge--pending {
+        background: var(--color-accent, #5b6af0);
+        color: #fff;
+    }
+</style>

--- a/DraftView.Web/Views/Reader/RequestAccess.cshtml
+++ b/DraftView.Web/Views/Reader/RequestAccess.cshtml
@@ -1,0 +1,157 @@
+@model DraftView.Web.Models.RequestAccessViewModel
+@using DraftView.Domain.Enumerations
+@{
+    Layout = "_Layout";
+    ViewData["Title"] = "Request Access";
+}
+
+<div class="settings-page">
+    <div class="settings-header">
+        <h1 class="settings-header__title">Request access to a project</h1>
+        <p class="settings-header__subtitle">
+            Select a project below and send your request to the author.
+            Once approved you will be able to start reading.
+        </p>
+    </div>
+
+    @if (Model.RequestSubmitted)
+    {
+        <div class="toast toast--success" style="position:static; margin-bottom:1.5rem; display:block; opacity:1;">
+            Your request has been sent to the author of
+            <strong>@(Model.SubmittedProjectName ?? "the project")</strong>.
+            You will receive an email when they respond.
+        </div>
+    }
+
+    @* Pending requests section *@
+    @if (Model.PendingRequests.Count > 0)
+    {
+        <div class="settings-section">
+            <div class="settings-section__header">
+                <h2 class="settings-section__title">Your requests</h2>
+            </div>
+            <div class="settings-section__body">
+                <table class="data-table" style="width:100%;">
+                    <thead>
+                        <tr>
+                            <th>Project</th>
+                            <th>Status</th>
+                            <th>Requested</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model.PendingRequests)
+                        {
+                            var statusLabel = item.Request.Status switch
+                            {
+                                AccessRequestStatus.Pending  => "Pending",
+                                AccessRequestStatus.Approved => "Approved",
+                                AccessRequestStatus.Declined => "Declined",
+                                _                            => "Unknown"
+                            };
+                            var statusClass = item.Request.Status switch
+                            {
+                                AccessRequestStatus.Approved => "badge badge--success",
+                                AccessRequestStatus.Declined => "badge badge--danger",
+                                _                            => "badge badge--muted"
+                            };
+                            <tr>
+                                <td>@item.ProjectName</td>
+                                <td><span class="@statusClass">@statusLabel</span></td>
+                                <td>@item.Request.RequestedAt.ToString("d MMM yyyy")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+
+    @* Available projects section *@
+    @if (Model.AvailableProjects.Count == 0)
+    {
+        <div class="settings-section">
+            <div class="settings-section__body">
+                <p>
+                    There are no projects open for reader applications at this time.
+                    If an author has invited you by email, please check your inbox for the invitation link.
+                </p>
+                <p>
+                    <a href="/Account/Login">Sign in</a> if you already have an account.
+                </p>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="settings-section">
+            <div class="settings-section__header">
+                <h2 class="settings-section__title">Request access</h2>
+            </div>
+            <div class="settings-section__body">
+
+                @if (!ViewData.ModelState.IsValid && ViewData.ModelState.ErrorCount > 0)
+                {
+                    <div class="validation-summary" style="margin-bottom:1rem; color:var(--color-danger, #c62828);">
+                        @foreach (var ms in ViewData.ModelState.Values)
+                        {
+                            foreach (var error in ms.Errors)
+                            {
+                                <div>@error.ErrorMessage</div>
+                            }
+                        }
+                    </div>
+                }
+
+                <form asp-controller="Reader" asp-action="RequestAccess" method="post">
+                    @Html.AntiForgeryToken()
+
+                    <div class="form-group" style="margin-bottom:1.25rem;">
+                        <label class="form-label" for="SelectedProjectId">Choose a project</label>
+                        <select asp-for="SelectedProjectId"
+                                id="SelectedProjectId"
+                                class="form-control"
+                                style="width:100%; max-width:400px;">
+                            <option value="">— Select a project —</option>
+                            @foreach (var project in Model.AvailableProjects)
+                            {
+                                <option value="@project.Id">@project.Name</option>
+                            }
+                        </select>
+                        <span asp-validation-for="SelectedProjectId" class="field-validation-error"></span>
+                    </div>
+
+                    <div class="form-group" style="margin-bottom:1.25rem;">
+                        <label asp-for="CoverNote" class="form-label"></label>
+                        <textarea asp-for="CoverNote"
+                                  class="form-control"
+                                  rows="4"
+                                  style="width:100%; max-width:600px; resize:vertical;"
+                                  placeholder="Tell the author a little about yourself and why you'd like to read their work (optional)…"></textarea>
+                        <span asp-validation-for="CoverNote" class="field-validation-error"></span>
+                    </div>
+
+                    <div class="form-group" style="margin-bottom:1.5rem;">
+                        <label asp-for="ContactEmail" class="form-label"></label>
+                        <input asp-for="ContactEmail"
+                               type="email"
+                               class="form-control"
+                               style="width:100%; max-width:400px;"
+                               placeholder="Alternative contact email (optional)" />
+                        <span asp-validation-for="ContactEmail" class="field-validation-error"></span>
+                    </div>
+
+                    <button type="submit" class="btn btn--primary">Send request</button>
+                </form>
+            </div>
+        </div>
+    }
+
+    <div style="margin-top:2rem;">
+        <p style="color:var(--color-text-muted, #999); font-size:0.875rem;">
+            Waiting to hear from an author?
+            <a asp-controller="Account" asp-action="Login">Sign in</a> if you already have an account,
+            or contact the author directly for an invitation link.
+        </p>
+    </div>
+</div>

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-2" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-3" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-2" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-3" />
         }
     }
 </head>

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -91,6 +91,7 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-19-1" />
     <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-19-1" />
     <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-19-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-19-1" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-2" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-2" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-19-1" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-2" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-19-1";
+    --css-version: "v2026-08-21-2";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-21-2";
+    --css-version: "v2026-08-21-3";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;

--- a/DraftView.Web/wwwroot/css/DraftView.Onboarding.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Onboarding.css
@@ -1,0 +1,456 @@
+/* ==========================================================================
+   DraftView Onboarding Styles
+   Author self-registration journey: /Join, /Join/FAQ, /Join/EmailSent,
+   /Join/ConfirmEmail, /Join/FirstProject
+   ========================================================================== */
+
+/* ---------------------------------------------------------------------------
+   Atmosphere background rotator
+   Five theme images cycle with a slow crossfade (8s per image, 40s total loop).
+   --------------------------------------------------------------------------- */
+
+.onboarding-bg {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    overflow: hidden;
+}
+
+.onboarding-bg__slide {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    opacity: 0;
+    transition: opacity 1.5s ease-in-out;
+}
+
+.onboarding-bg__slide.is-active {
+    opacity: 1;
+}
+
+/* Overlay keeps form legible over any image */
+.onboarding-bg::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+        135deg,
+        rgba(0, 0, 0, 0.55) 0%,
+        rgba(0, 0, 0, 0.35) 100%
+    );
+    pointer-events: none;
+}
+
+/* ---------------------------------------------------------------------------
+   Page layout
+   --------------------------------------------------------------------------- */
+
+.onboarding-page {
+    position: relative;
+    z-index: 1;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Hide the standard site-main padding on onboarding pages */
+.onboarding-outer {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+}
+
+/* ---------------------------------------------------------------------------
+   Split layout: left marketing / right form
+   --------------------------------------------------------------------------- */
+
+.onboarding-split {
+    display: grid;
+    grid-template-columns: 1fr 420px;
+    gap: 4rem;
+    width: 100%;
+    max-width: 1100px;
+    align-items: center;
+}
+
+@media (max-width: 900px) {
+    .onboarding-split {
+        grid-template-columns: 1fr;
+        gap: 2.5rem;
+    }
+}
+
+/* ---------------------------------------------------------------------------
+   Marketing copy (left panel)
+   --------------------------------------------------------------------------- */
+
+.onboarding-copy {
+    color: #fff;
+}
+
+.onboarding-copy__logo {
+    width: 48px;
+    height: 48px;
+    margin-bottom: 1.25rem;
+    filter: brightness(0) invert(1);
+    opacity: 0.9;
+}
+
+.onboarding-copy__headline {
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    font-weight: 700;
+    line-height: 1.2;
+    margin: 0 0 1rem;
+    color: #fff;
+}
+
+.onboarding-copy__tagline {
+    font-size: 1.125rem;
+    line-height: 1.65;
+    opacity: 0.9;
+    margin: 0 0 1.5rem;
+}
+
+.onboarding-copy__features {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.onboarding-copy__features li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    font-size: 1rem;
+    opacity: 0.92;
+}
+
+.onboarding-copy__features li::before {
+    content: "✓";
+    font-weight: 700;
+    color: #8fff8f;
+    flex-shrink: 0;
+    margin-top: 0.05em;
+}
+
+.onboarding-copy__faq-link {
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.9rem;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
+.onboarding-copy__faq-link:hover {
+    color: #fff;
+}
+
+/* ---------------------------------------------------------------------------
+   Registration card (right panel)
+   --------------------------------------------------------------------------- */
+
+.onboarding-card {
+    background: var(--color-surface, #fff);
+    border-radius: 1rem;
+    padding: 2.5rem 2rem;
+    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.25);
+    width: 100%;
+}
+
+.onboarding-card__title {
+    font-size: 1.35rem;
+    font-weight: 700;
+    margin: 0 0 0.25rem;
+    color: var(--color-text, #1a1a2e);
+}
+
+.onboarding-card__subtitle {
+    font-size: 0.9rem;
+    color: var(--color-text-muted, #666);
+    margin: 0 0 1.75rem;
+}
+
+.onboarding-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.onboarding-form__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.onboarding-form__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-text, #1a1a2e);
+}
+
+.onboarding-form__input {
+    padding: 0.6rem 0.85rem;
+    border: 1.5px solid var(--color-border, #d0d0d0);
+    border-radius: 0.5rem;
+    font-size: 0.95rem;
+    background: var(--color-input-bg, #fafafa);
+    color: var(--color-text, #1a1a2e);
+    transition: border-color 0.2s, box-shadow 0.2s;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.onboarding-form__input:focus {
+    outline: none;
+    border-color: var(--color-accent, #5b6af0);
+    box-shadow: 0 0 0 3px rgba(91, 106, 240, 0.15);
+}
+
+.onboarding-form__input.is-invalid {
+    border-color: #e53935;
+}
+
+.onboarding-form__error {
+    font-size: 0.8rem;
+    color: #e53935;
+}
+
+.onboarding-form__hint {
+    font-size: 0.8rem;
+    color: var(--color-text-muted, #888);
+}
+
+.onboarding-form__submit {
+    margin-top: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    background: var(--color-accent, #5b6af0);
+    color: #fff;
+    border: none;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.1s;
+}
+
+.onboarding-form__submit:hover {
+    background: var(--color-accent-hover, #4454d4);
+}
+
+.onboarding-form__submit:active {
+    transform: scale(0.98);
+}
+
+.onboarding-form__login-link {
+    text-align: center;
+    font-size: 0.85rem;
+    color: var(--color-text-muted, #666);
+    margin-top: 1rem;
+}
+
+.onboarding-form__login-link a {
+    color: var(--color-accent, #5b6af0);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.onboarding-form__login-link a:hover {
+    text-decoration: underline;
+}
+
+.onboarding-validation-summary {
+    background: #fdecea;
+    border: 1px solid #e53935;
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+    font-size: 0.875rem;
+    color: #c62828;
+    margin-bottom: 0.5rem;
+}
+
+/* ---------------------------------------------------------------------------
+   Email sent / confirmation pages
+   --------------------------------------------------------------------------- */
+
+.onboarding-status {
+    text-align: center;
+    max-width: 540px;
+    margin: 6rem auto;
+    padding: 0 1.5rem;
+    color: #fff;
+}
+
+.onboarding-status__icon {
+    font-size: 4rem;
+    margin-bottom: 1.25rem;
+    display: block;
+}
+
+.onboarding-status__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin: 0 0 0.75rem;
+    color: #fff;
+}
+
+.onboarding-status__body {
+    font-size: 1rem;
+    line-height: 1.65;
+    opacity: 0.9;
+    margin: 0 0 2rem;
+}
+
+.onboarding-status__action {
+    display: inline-block;
+    padding: 0.75rem 2rem;
+    background: rgba(255, 255, 255, 0.15);
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    border-radius: 0.5rem;
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.2s;
+}
+
+.onboarding-status__action:hover {
+    background: rgba(255, 255, 255, 0.25);
+}
+
+/* ---------------------------------------------------------------------------
+   FAQ page
+   --------------------------------------------------------------------------- */
+
+.onboarding-faq {
+    max-width: 720px;
+    margin: 3rem auto;
+    padding: 0 1.5rem;
+    color: #fff;
+}
+
+.onboarding-faq__back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: rgba(255, 255, 255, 0.8);
+    text-decoration: none;
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+}
+
+.onboarding-faq__back:hover { color: #fff; }
+
+.onboarding-faq__title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem;
+}
+
+.onboarding-faq__intro {
+    font-size: 1.05rem;
+    opacity: 0.85;
+    margin: 0 0 2.5rem;
+}
+
+.onboarding-faq__item {
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 0.75rem;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.onboarding-faq__question {
+    font-size: 1.05rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem;
+}
+
+.onboarding-faq__answer {
+    font-size: 0.95rem;
+    line-height: 1.65;
+    opacity: 0.9;
+    margin: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   First Project welcome page
+   --------------------------------------------------------------------------- */
+
+.onboarding-welcome {
+    max-width: 680px;
+    margin: 4rem auto;
+    padding: 0 1.5rem;
+    color: #fff;
+    text-align: center;
+}
+
+.onboarding-welcome__headline {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 700;
+    margin: 0 0 0.75rem;
+}
+
+.onboarding-welcome__subline {
+    font-size: 1.1rem;
+    opacity: 0.88;
+    margin: 0 0 3rem;
+    line-height: 1.6;
+}
+
+.onboarding-steps {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.25rem;
+    text-align: left;
+    margin-bottom: 3rem;
+}
+
+.onboarding-step {
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+}
+
+.onboarding-step__number {
+    font-size: 1.5rem;
+    font-weight: 700;
+    opacity: 0.6;
+    margin-bottom: 0.4rem;
+}
+
+.onboarding-step__title {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0 0 0.4rem;
+}
+
+.onboarding-step__desc {
+    font-size: 0.9rem;
+    opacity: 0.85;
+    margin: 0;
+    line-height: 1.55;
+}
+
+.onboarding-welcome__cta {
+    display: inline-block;
+    padding: 0.875rem 2.5rem;
+    background: rgba(255, 255, 255, 0.15);
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    border-radius: 0.5rem;
+    color: #fff;
+    font-size: 1.05rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.2s;
+}
+
+.onboarding-welcome__cta:hover {
+    background: rgba(255, 255, 255, 0.28);
+}

--- a/MultiTenancy.md
+++ b/MultiTenancy.md
@@ -1,5 +1,5 @@
 # DraftView — Multi-Tenancy Sprint Series
-Version: 1.0 | Date: 2026-08-19
+Version: 1.1 | Date: 2026-08-19
 Status: **Planned for implementation** — MT-Sprint-1 through MT-Sprint-4 are the active delivery roadmap; MT-Sprint-5 remains post-revenue.
 
 ---
@@ -34,8 +34,18 @@ Multi-tenancy is now a near-term platform requirement because:
 
 - multiple authors must be supported,
 - readers must be able to read across authors,
-- an author may also act as a beta reader in another workspace,
+- an author may also act as a beta reader on another author's project,
 - Reader Dashboard work depends on cross-author identity and access modelling.
+
+### 3.1.1 Author-as-reader model
+
+An author account can be invited to read another author's project, exactly as a regular reader would be. This is granted at the project level via `ReaderAccess` on the host author's project. The invited author does **not** receive a `TenancyMembership` in the host tenancy; their `Account` simply gains a `ReaderAccess` record scoped to the specific project.
+
+This means:
+- `TenancyMembership` remains the Author-Tenancy 1:1 link **only** (Role = Author).
+- `ReaderAccess` is the universal mechanism for project-level read access — used by both regular readers and authors reading across workspaces.
+- An account can simultaneously be an author in their own tenancy and a beta reader on one or more other tenancies' projects.
+- Reader count limits (`MaxBetaReaderCount`) are enforced against the host tenancy's `ReaderAccess` records, not against `TenancyMembership`.
 
 ### 3.2 Implementation sprint boundary
 
@@ -96,18 +106,22 @@ The target state is:
 
 | Entity | Purpose |
 |--------|---------|
-| `Account` | Platform identity, login credential owner, display-name owner, may participate in multiple tenancies |
-| `Tenancy` | Author-owned workspace containing projects, readers, notifications, integrations, and operational limit properties such as maximum beta-reader count |
-| `TenancyMembership` | Role-bearing link between `Account` and `Tenancy` |
+| `Account` | Platform identity, login credential owner, display-name owner. One per person. Multi-role: role is determined by context (which tenancy / which project). |
+| `Tenancy` | Author-owned workspace containing projects, notifications, integrations, and operational limit properties such as maximum beta-reader count. 1:1 with the author `Account`. |
+| `TenancyMembership` | Author-Tenancy 1:1 link only (Role = Author). Not used for readers. |
+| `ReaderAccess` | Project-level read grant. The universal mechanism for both regular readers and authors reading across workspaces. Scoped to a specific `Project` and `Account`. |
 | `TenancySubscription` | Tier state, future billing-provider identifiers, and subscription status |
 | `DropboxConnection` | Dropbox binding owned by a `Tenancy`, not by a person-account |
 
 ### 5.2 Core invariants
 
-- Exactly one author membership exists per tenancy.
+- Exactly one `TenancyMembership` (Role = Author) exists per tenancy; it identifies the tenancy owner.
 - An account may own at most one tenancy.
-- An account may hold reader memberships in many tenancies.
-- No data from one tenancy may be visible to another unless explicitly represented by a membership in both tenancies.
+- An account does **not** receive a `TenancyMembership` in tenancies where it is only a reader.
+- Reader access — whether the reader is a regular user or an author acting as a reader on another workspace's project — is represented by a `ReaderAccess` record scoped to the specific project.
+- An account may hold `ReaderAccess` on projects across many different tenancies simultaneously.
+- Beta-reader count limits (`MaxBetaReaderCount`) are enforced by counting active `ReaderAccess` records on a tenancy's projects, not by counting `TenancyMembership` records.
+- No data from one tenancy may be visible to another unless explicitly represented by a `ReaderAccess` grant on one of its projects.
 - Soft delete remains the default deletion model.
 - Historical and published content remains immutable under the existing versioning rules.
 
@@ -147,7 +161,7 @@ Replace the single `User` identity model with the minimum viable tenancy model w
 - Preserve existing data through an atomic migration; no partial live state is acceptable.
 - Treat rename completeness as mandatory across entities, repositories, DTOs, view models, controllers, tests, and migrations.
 - Replace project-global or platform-global author lookups with tenancy-scoped lookups.
-- Audit `ReaderAccess` and decide whether it remains temporarily or is subsumed by `TenancyMembership`.
+- `ReaderAccess` is confirmed to remain as the project-level reader grant mechanism (see § 9 resolved decisions). Audit its scope and ensure it is tenancy-safe via project ownership.
 - Audit `AuthorNotification`, `UserPreferences`, and other current `AuthorId` tables as part of the tenancy-key migration.
 
 ### AGENTS.md requirements embedded in this sprint
@@ -262,35 +276,36 @@ Allow a new author to create an account and tenancy without manual seeding, and 
 
 ### Goal
 
-Allow a single reader account to participate in multiple author tenancies while preserving tenancy isolation.
+Allow a single `Account` to hold `ReaderAccess` on projects across multiple author tenancies, and to be simultaneously an author in their own tenancy, while preserving tenancy isolation.
 
 ### Required deliverables
 
-- invitation flow that attaches to an existing `Account` when the email already exists
-- support for one account holding memberships in multiple tenancies
+- invitation flow that attaches a `ReaderAccess` record to an existing `Account` when the email already exists
+- support for one account holding `ReaderAccess` grants on projects across many tenancies
 - account-owned `DisplayName`
-- safe account soft-delete behaviour that inactivates memberships without cross-tenant leakage
-- repository and service support for reader dashboard queries that span memberships safely
+- safe account soft-delete behaviour that inactivates all `ReaderAccess` records without cross-tenant leakage
+- repository and service support for reader dashboard queries that collect accessible projects via `ReaderAccess` safely
 
 ### Specific requirements for this sprint
 
 - Readers must be able to access books from more than one author without duplicate login identities.
-- Authors who are also readers must be representable without role collision.
-- Reader Dashboard dependencies such as "books available" and "discover authors" must query through memberships rather than project-only access records.
-- `IProjectRepository.GetAllForReaderAsync(Guid userId)` or equivalent tenancy-safe query support must exist by sprint completion.
+- An author account can accept an invitation to read another author's project; this creates a `ReaderAccess` record on that project — it does **not** create a `TenancyMembership` in the host tenancy.
+- Role context is derived from the current request: the same account is an Author when acting within their own tenancy, and a Reader when accessing another tenancy's project via `ReaderAccess`.
+- Reader Dashboard queries must collect projects via `ReaderAccess` records scoped to the requesting account, not via `TenancyMembership`.
+- `IProjectRepository.GetAllForReaderAsync(Guid accountId)` or equivalent `ReaderAccess`-based query support must exist by sprint completion.
 
 ### AGENTS.md requirements embedded in this sprint
 
-- No global reader query may bypass tenancy or membership scope.
-- Application services own role-switching and invitation orchestration.
+- No global reader query may bypass project or tenancy ownership scope.
+- Application services own role-context derivation and invitation orchestration.
 - Web must not branch on business rules for invitation acceptance or dashboard composition.
 - Soft delete remains the deletion strategy for user-visible identity state.
 
 ### Exit criteria
 
-- One account can read across multiple authors.
-- One account can be both author and reader in different tenancy contexts.
-- Reader-facing queries are membership-aware and tenancy-safe.
+- One account can read across multiple authors via `ReaderAccess`.
+- One account can be both author (in their own tenancy) and reader (on other tenancies' projects) without role collision.
+- Reader-facing queries are `ReaderAccess`-scoped and tenancy-safe.
 
 ---
 
@@ -333,9 +348,15 @@ This sprint remains in the roadmap, but it is **not** part of the near-term impl
 
 ---
 
-## 9. Open Design Decisions To Resolve Before MT-Sprint-1 Starts
+## 9. Open Design Decisions
 
-- Whether `ReaderAccess` remains as a transitional table or is fully superseded by `TenancyMembership`
+### Resolved
+
+- **`ReaderAccess` vs `TenancyMembership` for readers — RESOLVED: KEEP `ReaderAccess`.**
+  Readers (including authors reading another author's project) are granted access at the project level via `ReaderAccess`. `TenancyMembership` is the Author-Tenancy 1:1 link only; no `BetaReader` tenancy role exists. `ReaderAccess` is the universal reader mechanism.
+
+### Still open before MT-Sprint-1 starts
+
 - Whether encryption remains platform-keyed or becomes tenancy-keyed for protected email data
 - Exact migration path for `UserPreferences`
 - Final tenancy-safe operating model for sync background workers and trusted system actions

--- a/TASKS.md
+++ b/TASKS.md
@@ -157,7 +157,7 @@ See `MultiTenancy.md` for full design, migration strategy, and sprint plan.
 |--------|-------------|--------|
 | MT-Sprint-1 | Account / Tenancy / TenancyMembership entity split | 🟡 In progress — cloud phase complete; local phase pending |
 | MT-Sprint-2 | Subscription enforcement, `IBillingProvider`, billing/provider rollout after go-live | 🟡 In progress — cloud phase complete; local phase pending |
-| MT-Sprint-3 | Author self-serve registration, Dropbox connect per Tenancy | 🔴 Not started |
+| MT-Sprint-3 | Author self-serve registration, Dropbox connect per Tenancy | 🟡 In progress — cloud phase complete; local phase pending |
 | MT-Sprint-4 | Reader cross-tenancy identity | 🔴 Not started |
 | MT-Sprint-5 | Reader Marketplace (post-revenue) | ⏸ Deferred post-revenue |
 
@@ -188,6 +188,24 @@ See `MultiTenancy.md` for full design, migration strategy, and sprint plan.
 - [ ] Remove/replace `IUserRepository.GetAllBetaReadersAsync()` (unscoped global query)
 - [ ] `ReaderAccess` transitional decision — keep as bridge or subsume into `TenancyMembership`
 - [ ] Data backfill: map existing `User` records to `Account` + `Tenancy` + author `TenancyMembership`
+
+#### MT-Sprint-3 Progress
+
+**Cloud phase complete:**
+- [x] `IAuthorRegistrationService` + `AuthorRegistrationResult` — `DraftView.Domain/Interfaces/Services/IAuthorRegistrationService.cs`
+- [x] `AuthorRegistrationService` — atomic Account + Tenancy + TenancyMembership (Author) + TenancySubscription (Free) in single SaveChanges
+- [x] Duplicate-email guard: `I-REG-EMAIL-EXISTS` invariant code
+- [x] `DraftViewDbContext` — extended `PrepareProtectedEmails` to handle Account entities (same AES+HMAC pattern as User)
+- [x] DI registration: `IAuthorRegistrationService`
+- [x] Unit tests: `AuthorRegistrationServiceTests` (8 tests)
+
+**Local phase required:**
+- [ ] Web controller: author registration form (Account/Register route) calling `IAuthorRegistrationService`
+- [ ] Wire ASP.NET Identity `UserManager` to create `IdentityUser` alongside `Account` record
+- [ ] Remove author-only seeding as required onboarding path (move to dev-only tooling)
+- [ ] Tenancy-scoped Dropbox connect flow — `DropboxConnections.TenancyId` (requires AuthorId→TenancyId rename from MT-Sprint-1 local phase)
+
+---
 
 #### MT-Sprint-2 Progress
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,5 @@
 ﻿# DraftView — Task List
-Last updated: 2026-08-19
+Last updated: 2026-08-21
 Last deployed: 2026-08-17 13:59 (commit: d51d201)
 
 ---
@@ -51,7 +51,23 @@ Last deployed: 2026-08-17 13:59 (commit: d51d201)
 ## 2. Open Minor Work
 
 ### 2(a) Bugs
-No open bugs.
+
+- [ ] **BUG-001 — `Account.Activate()` never called on email confirmation**
+
+  **Branch:** `claude/multi-tenancy-implementation-m279oe`
+  **File:** `DraftView.Web/Controllers/OnboardingController.cs` — `ConfirmEmail` action
+
+  `AuthorSelfRegistrationService` creates both a `User` (inactive) and an `Account` (inactive — `Account.Create()` sets `IsActive = false`). When the author confirms their email, `ConfirmEmail` correctly calls `domainUser.Activate()` on the `User` but never retrieves or activates the corresponding `Account`. As a result `Account.IsActive` stays `false` permanently. `Account.RecordLogin()` will throw `UnauthorisedOperationException` on any login attempt, and any future guard on `account.IsActive` will deny access.
+
+  **Fix:** after the `domainUser.Activate()` block, look up the Account by HMAC and activate it in the same `SaveChangesAsync` call:
+  ```csharp
+  var hmac    = hmacService.Compute(identityUser.Email!.Trim());
+  var account = await accountRepo.GetByEmailLookupHmacAsync(hmac, ct);
+  if (account is not null && !account.IsActive)
+      account.Activate();
+  await unitOfWork.SaveChangesAsync(ct);
+  ```
+  `IUserEmailLookupHmacService` and `IAccountRepository` are already injected into `OnboardingController`. Readers do not get `Account` records — `ReaderConfirmEmail` is unaffected.
 
 ### 2(b) Changes
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,5 @@
 ﻿# DraftView — Task List
-Last updated: 2026-08-18
+Last updated: 2026-08-19
 Last deployed: 2026-08-17 13:59 (commit: d51d201)
 
 ---
@@ -153,15 +153,39 @@ is now a near-term requirement, not a post-revenue concern.
 
 See `MultiTenancy.md` for full design, migration strategy, and sprint plan.
 
-| Sprint | Deliverable |
-|--------|-------------|
-| MT-Sprint-1 | Account / Tenancy / TenancyMembership entity split |
-| MT-Sprint-2 | Subscription enforcement, `IBillingProvider`, billing/provider rollout after go-live |
-| MT-Sprint-3 | Author self-serve registration, Dropbox connect per Tenancy |
-| MT-Sprint-4 | Reader cross-tenancy identity |
-| MT-Sprint-5 | Reader Marketplace (post-revenue) |
+| Sprint | Deliverable | Status |
+|--------|-------------|--------|
+| MT-Sprint-1 | Account / Tenancy / TenancyMembership entity split | 🟡 In progress — cloud phase complete; local phase pending |
+| MT-Sprint-2 | Subscription enforcement, `IBillingProvider`, billing/provider rollout after go-live | 🔴 Not started |
+| MT-Sprint-3 | Author self-serve registration, Dropbox connect per Tenancy | 🔴 Not started |
+| MT-Sprint-4 | Reader cross-tenancy identity | 🔴 Not started |
+| MT-Sprint-5 | Reader Marketplace (post-revenue) | ⏸ Deferred post-revenue |
 
 **Prerequisite:** Production stable before MT-Sprint-1. Billing/provider rollout is deferred until post-go-live MT-Sprint-2.
+
+#### MT-Sprint-1 Progress
+
+**Cloud phase complete (PR #claude/multi-tenancy-implementation-m279oe):**
+- [x] `TenancyRole` enum — `DraftView.Domain/Enumerations/TenancyRole.cs`
+- [x] `Account` entity with full invariants and email-protection pattern — `DraftView.Domain/Entities/Account.cs`
+- [x] `Tenancy` entity with MaxBetaReaderCount default (5) — `DraftView.Domain/Entities/Tenancy.cs`
+- [x] `TenancyMembership` entity with soft-delete and restore — `DraftView.Domain/Entities/TenancyMembership.cs`
+- [x] `IAccountRepository`, `ITenancyRepository`, `ITenancyMembershipRepository` interfaces
+- [x] `AccountRepository`, `TenancyRepository`, `TenancyMembershipRepository` implementations
+- [x] EF configurations for all three entities (`AccountConfiguration`, `TenancyConfiguration`, `TenancyMembershipConfiguration`)
+- [x] `DraftViewDbContext` — new DbSets: `Accounts`, `Tenancies`, `TenancyMemberships`
+- [x] DI registration in `ServiceCollectionExtensions`
+- [x] Unit tests: `AccountTests` (21 tests), `TenancyTests` (10 tests), `TenancyMembershipTests` (9 tests)
+
+**Local phase required (cannot be done safely without dotnet runtime):**
+- [ ] Generate EF migration: `dotnet ef migrations add AddMultiTenancyEntities --project DraftView.Infrastructure --startup-project DraftView.Web`
+- [ ] Apply migration: `dotnet ef database update --project DraftView.Infrastructure --startup-project DraftView.Web`
+- [ ] Run full test suite: `dotnet test` — confirm all new tests GREEN plus no regressions
+- [ ] `AuthorId` → `TenancyId` rename on `Projects`, `Comments`, `ReaderAccess`, `Invitations`, `AuthorNotifications`, `UserPreferences` — requires build verification
+- [ ] `DropboxConnections.UserId` → `DropboxConnections.TenancyId` rename with data migration
+- [ ] Remove/replace `IUserRepository.GetAllBetaReadersAsync()` (unscoped global query)
+- [ ] `ReaderAccess` transitional decision — keep as bridge or subsume into `TenancyMembership`
+- [ ] Data backfill: map existing `User` records to `Account` + `Tenancy` + author `TenancyMembership`
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -158,7 +158,7 @@ See `MultiTenancy.md` for full design, migration strategy, and sprint plan.
 | MT-Sprint-1 | Account / Tenancy / TenancyMembership entity split | 🟡 In progress — cloud phase complete; local phase pending |
 | MT-Sprint-2 | Subscription enforcement, `IBillingProvider`, billing/provider rollout after go-live | 🟡 In progress — cloud phase complete; local phase pending |
 | MT-Sprint-3 | Author self-serve registration, Dropbox connect per Tenancy | 🟡 In progress — cloud phase complete; local phase pending |
-| MT-Sprint-4 | Reader cross-tenancy identity | 🔴 Not started |
+| MT-Sprint-4 | Reader cross-tenancy identity | 🟡 In progress — cloud phase complete; local phase pending |
 | MT-Sprint-5 | Reader Marketplace (post-revenue) | ⏸ Deferred post-revenue |
 
 **Prerequisite:** Production stable before MT-Sprint-1. Billing/provider rollout is deferred until post-go-live MT-Sprint-2.
@@ -229,6 +229,22 @@ See `MultiTenancy.md` for full design, migration strategy, and sprint plan.
 - [ ] Run full test suite: `dotnet test` — confirm all new tests GREEN plus no regressions
 - [ ] Wire reader-count enforcement into reader access grant flow (application service layer)
 - [ ] Seed existing tenancies with a `TenancySubscription` record (Free tier) in the data backfill migration
+
+#### MT-Sprint-4 Progress
+
+**Cloud phase complete:**
+- [x] `IProjectRepository.GetAllForReaderAsync(Guid readerId)` — projects accessible via active `ReaderAccess`
+- [x] `ProjectRepository.GetAllForReaderAsync` — EF subquery joining `ReaderAccess` (active, non-revoked)
+- [x] `IReadEventRepository.GetMostRecentByUserIdAsync(Guid userId)` — ordered by `LastOpenedAt DESC`
+- [x] `ReadEventRepository.GetMostRecentByUserIdAsync` — implementation
+- [x] `IReadingProgressService.GetLastReadEventAcrossProjectsAsync(Guid userId)` — cross-project last-read
+- [x] `ReadingProgressService.GetLastReadEventAcrossProjectsAsync` — delegates to repository
+- [x] Unit tests: `ReadingProgressServiceTests` — 3 new tests for `GetLastReadEventAcrossProjectsAsync`
+
+**Local phase required:**
+- [ ] Run full test suite: `dotnet test` — confirm all new tests GREEN plus no regressions
+- [ ] Wire `GetAllForReaderAsync` into reader dashboard service (post-`AuthorId`→`TenancyId` rename)
+- [ ] Wire `GetLastReadEventAcrossProjectsAsync` into reader Continue Reading CTA (cross-project variant)
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -156,7 +156,7 @@ See `MultiTenancy.md` for full design, migration strategy, and sprint plan.
 | Sprint | Deliverable | Status |
 |--------|-------------|--------|
 | MT-Sprint-1 | Account / Tenancy / TenancyMembership entity split | 🟡 In progress — cloud phase complete; local phase pending |
-| MT-Sprint-2 | Subscription enforcement, `IBillingProvider`, billing/provider rollout after go-live | 🔴 Not started |
+| MT-Sprint-2 | Subscription enforcement, `IBillingProvider`, billing/provider rollout after go-live | 🟡 In progress — cloud phase complete; local phase pending |
 | MT-Sprint-3 | Author self-serve registration, Dropbox connect per Tenancy | 🔴 Not started |
 | MT-Sprint-4 | Reader cross-tenancy identity | 🔴 Not started |
 | MT-Sprint-5 | Reader Marketplace (post-revenue) | ⏸ Deferred post-revenue |
@@ -188,6 +188,29 @@ See `MultiTenancy.md` for full design, migration strategy, and sprint plan.
 - [ ] Remove/replace `IUserRepository.GetAllBetaReadersAsync()` (unscoped global query)
 - [ ] `ReaderAccess` transitional decision — keep as bridge or subsume into `TenancyMembership`
 - [ ] Data backfill: map existing `User` records to `Account` + `Tenancy` + author `TenancyMembership`
+
+#### MT-Sprint-2 Progress
+
+**Cloud phase complete:**
+- [x] `SubscriptionTier` enum — `DraftView.Domain/Enumerations/SubscriptionTier.cs`
+- [x] `TenancySubscription` entity with tier, provider id, deactivation — `DraftView.Domain/Entities/TenancySubscription.cs`
+- [x] `ITenancySubscriptionRepository` interface
+- [x] `TenancySubscriptionRepository` implementation
+- [x] `TenancySubscriptionConfiguration` EF config (unique index on TenancyId)
+- [x] `IBillingProvider` abstraction — `DraftView.Application/Interfaces/IBillingProvider.cs`
+- [x] `NullBillingProvider` — `DraftView.Infrastructure/Billing/NullBillingProvider.cs`
+- [x] `IReaderAccessRepository.CountActiveReadersForAuthorAsync` — additive reader count method
+- [x] `ReaderAccessRepository.CountActiveReadersForAuthorAsync` — implementation
+- [x] `DraftViewDbContext` — `DbSet<TenancySubscription>` added
+- [x] DI registration: `ITenancySubscriptionRepository`, `IBillingProvider`
+- [x] Unit tests: `TenancySubscriptionTests` (9 tests)
+
+**Local phase required:**
+- [ ] Generate EF migration: `dotnet ef migrations add AddTenancySubscription --project DraftView.Infrastructure --startup-project DraftView.Web`
+- [ ] Apply migration: `dotnet ef database update --project DraftView.Infrastructure --startup-project DraftView.Web`
+- [ ] Run full test suite: `dotnet test` — confirm all new tests GREEN plus no regressions
+- [ ] Wire reader-count enforcement into reader access grant flow (application service layer)
+- [ ] Seed existing tenancies with a `TenancySubscription` record (Free tier) in the data backfill migration
 
 ---
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -163,6 +163,8 @@ See `MultiTenancy.md` for full design, migration strategy, and sprint plan.
 
 **Prerequisite:** Production stable before MT-Sprint-1. Billing/provider rollout is deferred until post-go-live MT-Sprint-2.
 
+**Branch strategy:** All MT-Sprint work (MT-Sprint-1 through MT-Sprint-4) is developed on `claude/multi-tenancy-implementation-m279oe` and is **not merged to `main`** until the full workstream is complete and verified ready for production deployment. PR #50 remains draft until that point.
+
 #### MT-Sprint-1 Progress
 
 **Cloud phase complete (PR #claude/multi-tenancy-implementation-m279oe):**


### PR DESCRIPTION
## Summary

Implements the additive foundation of MT-Sprint-1 (Account / Tenancy / TenancyMembership entity split) for issue #49.

> ⚠️ **Branch policy:** This PR covers the entire MT-Sprint workstream (MT-Sprint-1 through MT-Sprint-4). It will **not be merged to `main`** until all sprints are complete, all tests are GREEN locally, and the implementation is verified ready for production deployment.

This is the **cloud execution phase** of MT-Sprint-1 — all changes are additive (no existing entities modified). The rename and data-migration work requiring build verification and a live database is listed below as the required local phase.

## What's in this PR

**New domain entities (with full invariant enforcement):**
- `Account` — platform identity; replaces `User` under multi-tenancy. Email protection pattern mirrors `User` (ciphertext + HMAC).
- `Tenancy` — author-owned workspace. `MaxBetaReaderCount` seeded to `5` (pre-billing operational default per `MultiTenancy.md`).
- `TenancyMembership` — Author-Tenancy 1:1 link only (Role = Author always). Supports soft-delete and restore.
- `TenancyRole` enum — `Author` only. Reader access (including authors reading other authors' projects) is granted at the project level via `ReaderAccess`, not via `TenancyMembership`.

**New repository interfaces:**
- `IAccountRepository` — lookup by id and by email HMAC.
- `ITenancyRepository` — lookup by id and by owner account.
- `ITenancyMembershipRepository` — all queries explicitly tenancy-scoped.

**New repository implementations:**
- `AccountRepository`, `TenancyRepository`, `TenancyMembershipRepository` — all LINQ queries carry explicit `IsSoftDeleted` and tenancy-scope guards.

**New EF configurations:**
- `AccountConfiguration` — `Accounts` table; unique index on `EmailLookupHmac`; `Email` property ignored (runtime-only).
- `TenancyConfiguration` — `Tenancies` table; unique index on `OwnerAccountId` (one tenancy per account).
- `TenancyMembershipConfiguration` — `TenancyMemberships` table; unique composite index on `(TenancyId, AccountId)`.

**Infrastructure wiring:**
- `DraftViewDbContext` — three new `DbSet` properties added.
- `ServiceCollectionExtensions` — three new scoped repository registrations.

**Unit tests (39 new tests — require `dotnet test` locally):**
- `AccountTests` — 21 tests covering factory invariants, activation, soft-delete, login, display name/email updates, and protected email state.
- `TenancyTests` — 10 tests covering factory invariants, default `MaxBetaReaderCount`, name update, soft-delete.
- `TenancyMembershipTests` — 8 tests covering factory invariants, role assignment, soft-delete, restore.

**`MultiTenancy.md` updated (v1.1)** — documents author-as-reader model (§ 3.1.1), resolves `ReaderAccess` open design decision (§ 9), and sharpens MT-Sprint-4 requirements.

**`TASKS.md` updated** — MT-Sprint-1 shown as in-progress with cloud/local phase breakdown and branch policy.

## Model: reader access

An author account can be invited to read another author's project. This creates a `ReaderAccess` record on the host project — it does **not** create a `TenancyMembership` in the host tenancy. The same mechanism applies to regular readers. Reader count limits (`MaxBetaReaderCount`) are enforced via `ReaderAccess` counts, not `TenancyMembership`.

## Local phase required before merge

This PR must not be merged until all sprints are complete AND the following local validation is done:

```
# Generate the EF migration (MT-Sprint-1)
dotnet ef migrations add AddMultiTenancyEntities --project DraftView.Infrastructure --startup-project DraftView.Web

# Apply to local/staging DB
dotnet ef database update --project DraftView.Infrastructure --startup-project DraftView.Web

# Confirm all new tests GREEN and no regressions
dotnet test
```

**Remaining MT-Sprint-1 work (local phase):**
- `AuthorId` → `TenancyId` rename on `Projects`, `Comments`, `Invitations`, `ReaderAccess`, `AuthorNotifications`, `UserPreferences`
- `DropboxConnections.UserId` → `DropboxConnections.TenancyId` with data-preserving migration
- Remove `IUserRepository.GetAllBetaReadersAsync()` (unscoped global query)
- Data backfill: existing `User` → `Account` + `Tenancy` + author `TenancyMembership`

**Future sprints still to implement on this branch:**
- MT-Sprint-2 — `TenancySubscription`, `IBillingProvider`, reader-count enforcement via `ReaderAccess`
- MT-Sprint-3 — Author self-serve registration, tenancy-scoped Dropbox connect
- MT-Sprint-4 — Reader cross-tenancy identity, invitation flow, Reader Dashboard queries via `ReaderAccess`

## Architecture compliance

- Domain → Application → Infrastructure → Web boundaries preserved.
- All new entities use factory methods and private setters.
- All new entities use soft-delete (no hard deletes).
- No domain logic added to repositories or controllers.
- No existing entity modified (additive-only cloud phase).