### PR TITLE
fix: wire --header-image token to site-nav and page-header--image

### DIFF
--- a/DraftView.Web/wwwroot/css/DraftView.Components.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Components.css
@@ -295,7 +295,7 @@
 }
 
 .page-header--image {
-    background-image: url('/images/DraftView.Header.web.jpg');
+    background-image: var(--header-image);
     background-size: cover;
     background-position: center 35%;
     position: relative;

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-19-1";
+    --css-version: "v2026-08-21-1";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;

--- a/DraftView.Web/wwwroot/css/DraftView.Navigation.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Navigation.css
@@ -12,7 +12,7 @@
     position: sticky;
     top: 0;
     z-index: 1000;
-    background-image: url('/images/DraftView.Header.web.jpg');
+    background-image: var(--header-image);
     background-size: cover;
     background-position: center 40%;
 }


### PR DESCRIPTION
## Summary

Fixes #54.

The sticky navbar (`.site-nav`) and page header banner (`.page-header--image`) both hardcoded `DraftView.Header.web.jpg` — a 420×280, 3:2 portrait-ratio image used as a full-width banner strip. All theme CSS files already declare `--header-image` with correctly proportioned panoramic assets (~3:1 ratio, 2200+ px wide); this change makes both components consume that token so every theme controls its own banner image.

**Changes:**
- `DraftView.Navigation.css`: `.site-nav` background-image → `var(--header-image)`
- `DraftView.Components.css`: `.page-header--image` background-image → `var(--header-image)`
- `DraftView.Core.css`: css-version bumped to `v2026-08-21-1`

**Immediate effect by theme:**

| Theme | Banner image now used | Ratio |
|-------|----------------------|-------|
| Crime | `DraftView.Theme.Crime.Header.png` | ~3.2:1 ✅ |
| Noir | `Noir.Header.png` | ~3.2:1 ✅ |
| Contemporary | `contemporary-banner.png` | ~3.2:1 ✅ |
| Historic | `Historic-Banner.png` | ~2:1 ✅ |
| Default (Adventure) | `DraftView.Header.png` | 3:2 ⚠️ |

The default theme's asset (`DraftView.Header.png`, 1536×1024) is now wired up but still has the wrong ratio — a replacement panoramic asset is tracked separately in #54 Part 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L52HgAVtkgswEti2QAmyhB)_