### PR TITLE
fix: settings hero uses --header-image not --atmosphere-image

### DIFF
--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-21-1";
+    --css-version: "v2026-08-21-2";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;

--- a/DraftView.Web/wwwroot/css/DraftView.Settings.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Settings.css
@@ -3,6 +3,8 @@
    -------------------------------------------------------------------------- */
 .settings-hero {
     min-height: 180px;
+    background-image: var(--header-image);
+    background-position: center 40%;
     margin-bottom: var(--space-8);
 }
 


### PR DESCRIPTION
## Summary

The Profile/Settings page hero strip (180px tall, full viewport width) was inheriting `--atmosphere-image` from `.site-hero`. The atmosphere image is designed for tall cinematic hero sections (Login, Reader Dashboard) — a wide banner strip needs the panoramic `--header-image` token instead.

**Changes:**
- `DraftView.Settings.css`: `.settings-hero` now sets `background-image: var(--header-image)` and `background-position: center 40%`, overriding the inherited atmosphere image
- `DraftView.Core.css`: css-version bumped to `v2026-08-21-2`

The `--header-image` token is already declared per-theme with correctly proportioned panoramic assets, wired up to the navbar and page-header banner in #55.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L52HgAVtkgswEti2QAmyhB)_