### PR TITLE
feat: add DB-level FK constraints to MT-Sprint tenancy entities

### DIFF
--- a/DraftView.Infrastructure/Persistence/Configurations/TenancyConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/TenancyConfiguration.cs
@@ -36,5 +36,10 @@ public class TenancyConfiguration : IEntityTypeConfiguration<Tenancy>
 
         builder.HasIndex(t => t.OwnerAccountId)
             .IsUnique();
+
+        builder.HasOne<Account>()
+            .WithMany()
+            .HasForeignKey(t => t.OwnerAccountId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/DraftView.Infrastructure/Persistence/Configurations/TenancyMembershipConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/TenancyMembershipConfiguration.cs
@@ -36,5 +36,15 @@ public class TenancyMembershipConfiguration : IEntityTypeConfiguration<TenancyMe
             .IsUnique();
 
         builder.HasIndex(m => m.AccountId);
+
+        builder.HasOne<Tenancy>()
+            .WithMany()
+            .HasForeignKey(m => m.TenancyId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Account>()
+            .WithMany()
+            .HasForeignKey(m => m.AccountId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/DraftView.Infrastructure/Persistence/Configurations/TenancySubscriptionConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/TenancySubscriptionConfiguration.cs
@@ -32,5 +32,10 @@ public class TenancySubscriptionConfiguration : IEntityTypeConfiguration<Tenancy
         // One subscription record per tenancy.
         builder.HasIndex(s => s.TenancyId)
             .IsUnique();
+
+        builder.HasOne<Tenancy>()
+            .WithMany()
+            .HasForeignKey(s => s.TenancyId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }

--- a/DraftView.Infrastructure/Persistence/Migrations/20260821151022_AddMTSprintForeignKeyConstraints.Designer.cs
+++ b/DraftView.Infrastructure/Persistence/Migrations/20260821151022_AddMTSprintForeignKeyConstraints.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DraftView.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DraftView.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DraftViewDbContext))]
-    partial class DraftViewDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260821151022_AddMTSprintForeignKeyConstraints")]
+    partial class AddMTSprintForeignKeyConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DraftView.Infrastructure/Persistence/Migrations/20260821151022_AddMTSprintForeignKeyConstraints.cs
+++ b/DraftView.Infrastructure/Persistence/Migrations/20260821151022_AddMTSprintForeignKeyConstraints.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DraftView.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMTSprintForeignKeyConstraints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tenancies_Accounts_OwnerAccountId",
+                table: "Tenancies",
+                column: "OwnerAccountId",
+                principalTable: "Accounts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TenancyMemberships_Accounts_AccountId",
+                table: "TenancyMemberships",
+                column: "AccountId",
+                principalTable: "Accounts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TenancyMemberships_Tenancies_TenancyId",
+                table: "TenancyMemberships",
+                column: "TenancyId",
+                principalTable: "Tenancies",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TenancySubscriptions_Tenancies_TenancyId",
+                table: "TenancySubscriptions",
+                column: "TenancyId",
+                principalTable: "Tenancies",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tenancies_Accounts_OwnerAccountId",
+                table: "Tenancies");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TenancyMemberships_Accounts_AccountId",
+                table: "TenancyMemberships");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TenancyMemberships_Tenancies_TenancyId",
+                table: "TenancyMemberships");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TenancySubscriptions_Tenancies_TenancyId",
+                table: "TenancySubscriptions");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `TenancyConfiguration`, `TenancyMembershipConfiguration`, and `TenancySubscriptionConfiguration` were missing `HasOne/WithMany/HasForeignKey` declarations
- The `AddMultiTenancySchema` migration therefore created **no foreign key constraints** in PostgreSQL for these tables — only indexes
- Database could not enforce referential integrity between `Accounts`, `Tenancies`, `TenancyMemberships`, and `TenancySubscriptions`

## Constraints added (all `ON DELETE RESTRICT`)

| FK | References |
|---|---|
| `Tenancies.OwnerAccountId` | `Accounts.Id` |
| `TenancyMemberships.TenancyId` | `Tenancies.Id` |
| `TenancyMemberships.AccountId` | `Accounts.Id` |
| `TenancySubscriptions.TenancyId` | `Tenancies.Id` |

## Migration

`AddMTSprintForeignKeyConstraints` — additive only, no data changes.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet ef database update` — migration applied cleanly
- [x] `dotnet test` — 1,283 passed, 0 failed, 1 skipped (SMTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)