### PR TITLE
fix: resolve all 3 build warnings

### DIFF
--- a/DraftView.Web/Controllers/OnboardingController.cs
+++ b/DraftView.Web/Controllers/OnboardingController.cs
@@ -11,7 +11,6 @@ using System.Web;
 
 namespace DraftView.Web.Controllers;
 
-[AllowAnonymous]
 public class OnboardingController(
     IAuthorSelfRegistrationService registrationService,
     IReaderSelfRegistrationService readerRegistrationService,
@@ -31,6 +30,7 @@ public class OnboardingController(
     // ---------------------------------------------------------------------------
 
     [HttpGet("/Join")]
+    [AllowAnonymous]
     public IActionResult Join()
     {
         if (User.Identity?.IsAuthenticated == true)
@@ -44,6 +44,7 @@ public class OnboardingController(
     // ---------------------------------------------------------------------------
 
     [HttpPost("/Join")]
+    [AllowAnonymous]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Join(RegisterAuthorViewModel model, CancellationToken ct)
     {
@@ -129,6 +130,7 @@ public class OnboardingController(
     // ---------------------------------------------------------------------------
 
     [HttpGet("/Join/EmailSent")]
+    [AllowAnonymous]
     public IActionResult EmailSent() => View();
 
     // ---------------------------------------------------------------------------
@@ -136,6 +138,7 @@ public class OnboardingController(
     // ---------------------------------------------------------------------------
 
     [HttpGet("/Join/ConfirmEmail")]
+    [AllowAnonymous]
     public async Task<IActionResult> ConfirmEmail(string userId, string token, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(token))
@@ -213,6 +216,7 @@ public class OnboardingController(
     // ---------------------------------------------------------------------------
 
     [HttpGet("/Join/FAQ")]
+    [AllowAnonymous]
     public IActionResult FAQ() => View();
 
     // ===========================================================================
@@ -224,6 +228,7 @@ public class OnboardingController(
     // ---------------------------------------------------------------------------
 
     [HttpGet("/ReadersJoin")]
+    [AllowAnonymous]
     public IActionResult ReaderJoin()
     {
         if (User.Identity?.IsAuthenticated == true)
@@ -237,6 +242,7 @@ public class OnboardingController(
     // ---------------------------------------------------------------------------
 
     [HttpPost("/ReadersJoin")]
+    [AllowAnonymous]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ReaderJoin(RegisterReaderViewModel model, CancellationToken ct)
     {
@@ -317,6 +323,7 @@ public class OnboardingController(
     // ---------------------------------------------------------------------------
 
     [HttpGet("/ReadersJoin/EmailSent")]
+    [AllowAnonymous]
     public IActionResult ReaderEmailSent() => View();
 
     // ---------------------------------------------------------------------------
@@ -324,6 +331,7 @@ public class OnboardingController(
     // ---------------------------------------------------------------------------
 
     [HttpGet("/ReadersJoin/ConfirmEmail")]
+    [AllowAnonymous]
     public async Task<IActionResult> ReaderConfirmEmail(string userId, string token, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(token))

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -19,8 +19,6 @@ using System;
 using DraftView.Web.Infrastructure;
 using DraftView.Domain.Enumerations;
 using DraftView.Infrastructure.Billing;
-using DraftView.Application.Services;
-using DraftView.Domain.Interfaces.Services;
 
 namespace DraftView.Web.Extensions
 {


### PR DESCRIPTION
Closes #59

## Changes

**CS0105 x2 — duplicate `using` directives in `ServiceCollectionExtensions.cs`**
`DraftView.Application.Services` and `DraftView.Domain.Interfaces.Services` were each imported twice after the MT-Sprint merge. Removed the duplicate lines (22-23).

**ASP0026 — `[Authorize]` silently overridden in `OnboardingController`**
The class carried `[AllowAnonymous]` which shadowed the `[Authorize(Policy = "RequireAuthorPolicy")]` on the `Setup` action, making `/Join/Setup` effectively anonymous despite the intent. Fixed by:
- Removing class-level `[AllowAnonymous]`
- Adding `[AllowAnonymous]` explicitly to all 9 actions that require public access
- The `Setup` action's `[Authorize]` is now effective

## Test plan
- [x] `dotnet build DraftView.Web` - 0 warnings, 0 errors
- [x] `dotnet test` - 1,283 passed, 0 failed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)