### PR TITLE
fix: settings hero shows atmosphere image instead of header image

### DIFF
--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-3" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-3" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-4" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-3" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-4" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-21-3";
+    --css-version: "v2026-08-21-4";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;

--- a/DraftView.Web/wwwroot/css/DraftView.Settings.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Settings.css
@@ -1,7 +1,10 @@
 ﻿/* --------------------------------------------------------------------------
    4A. Account Settings Layout
    -------------------------------------------------------------------------- */
-.settings-hero {
+/* Compound selector beats .site-hero alone (specificity 0,2,0 vs 0,1,0).
+   Required because DraftView.Settings.css loads before DraftView.Components.css,
+   so a single-class .settings-hero rule loses to .site-hero in the cascade. */
+.site-hero.settings-hero {
     min-height: 180px;
     background-image: var(--header-image);
     background-position: center 40%;


### PR DESCRIPTION
## Problem

Account Settings (`/Account/Settings`) shows the atmosphere/theme image in the page hero instead of the configured banner image (`--header-image`).

**Root cause:** CSS load order. `DraftView.Settings.css` loads before `DraftView.Components.css` in `_Layout.cshtml`. Both `.settings-hero` and `.site-hero` are single-class selectors (specificity 0,1,0). When the same property appears in both, the later file wins — so `.site-hero { background-image: var(--atmosphere-image) }` from Components.css overrides `.settings-hero { background-image: var(--header-image) }` from Settings.css.

## Fix

Changed `.settings-hero` to `.site-hero.settings-hero` (specificity 0,2,0). This always beats `.site-hero` (0,1,0) regardless of file load order. Comment added explaining why the compound selector is required.

## Broader audit finding

The `page-header--image` CSS class (which correctly applies `var(--header-image)`) exists in Components.css but is never applied to any view. All author, support, and privacy pages use `class="page-header"` only — showing a plain text header with no banner image. This is tracked separately in issue #73.

## Test plan
- [x] Build succeeds (3 pre-existing warnings from PR #62 pending merge)
- [ ] Account Settings page visually shows header image not atmosphere image (requires deploy or local run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)