### PR TITLE
feat: apply page-header--image banner to all author/support/privacy pages

### DIFF
--- a/Docs/TASKS.md
+++ b/Docs/TASKS.md
@@ -1,6 +1,6 @@
-# DraftView — Task List
+﻿# DraftView — Task List
 Last updated: 2026-08-21
-Last deployed: 2026-08-21 16:59 (commit: b91f74b)
+Last deployed: 2026-08-21 18:01 (commit: fea82b3)
 Last merged: 2026-08-21 — PR #58 (CHANGE-011: MT-Sprint FK constraints) merged to main
 
 ---

--- a/DraftView.Web/Views/Author/Dashboard.cshtml
+++ b/DraftView.Web/Views/Author/Dashboard.cshtml
@@ -3,12 +3,12 @@
 @model DashboardViewModel
 @{ ViewData["Title"] = "Dashboard"; }
 
-<div class="page-header">
-    <div>
-        <h1 class="page-title">Dashboard</h1>
+<div class="page-header page-header--image">
+    <div class="page-header__inner">
+        <h1 class="page-header__title">Dashboard</h1>
         @if (Model.ActiveProject is not null)
         {
-            <p class="page-subtitle">Active project: @Model.ActiveProject.Name</p>
+            <p class="page-header__subtitle">Active project: @Model.ActiveProject.Name</p>
         }
     </div>
 </div>

--- a/DraftView.Web/Views/Author/InviteReader.cshtml
+++ b/DraftView.Web/Views/Author/InviteReader.cshtml
@@ -3,9 +3,11 @@
     ViewData["Title"] = "Invite Reader";
 }
 
-<div class="page-header">
-    <h1 class="page-title">Invite a Reader</h1>
-    <p class="page-subtitle">An email will be sent with a link to create their account.</p>
+<div class="page-header page-header--image">
+    <div class="page-header__inner">
+        <h1 class="page-header__title">Invite a Reader</h1>
+        <p class="page-header__subtitle">An email will be sent with a link to create their account.</p>
+    </div>
 </div>
 
 <div class="card invite-reader-card">

--- a/DraftView.Web/Views/Author/ManageReaderAccess.cshtml
+++ b/DraftView.Web/Views/Author/ManageReaderAccess.cshtml
@@ -2,10 +2,10 @@
 @model DraftView.Web.Models.ReaderAccessViewModel
 @{ ViewData["Title"] = "Manage Project Access"; }
 
-<div class="page-header">
-    <div>
-        <h1 class="page-title">@Model.DisplayName</h1>
-        <p class="page-subtitle">
+<div class="page-header page-header--image">
+    <div class="page-header__inner">
+        <h1 class="page-header__title">@Model.DisplayName</h1>
+        <p class="page-header__subtitle">
             @switch (Model.Status)
             {
                 case DraftView.Domain.Enumerations.ReaderStatus.Active:

--- a/DraftView.Web/Views/Author/Projects.cshtml
+++ b/DraftView.Web/Views/Author/Projects.cshtml
@@ -2,10 +2,10 @@
     ViewData["Title"] = "Add Project";
 }
 
-<div class="page-header">
-    <div>
-        <h1 class="page-title">Add Project</h1>
-        <p class="page-subtitle">Scanning: /Apps/Scrivener</p>
+<div class="page-header page-header--image">
+    <div class="page-header__inner">
+        <h1 class="page-header__title">Add Project</h1>
+        <p class="page-header__subtitle">Scanning: /Apps/Scrivener</p>
     </div>
 </div>
 

--- a/DraftView.Web/Views/Author/Readers.cshtml
+++ b/DraftView.Web/Views/Author/Readers.cshtml
@@ -4,11 +4,13 @@
 @model IReadOnlyList<ReaderRowViewModel>
 @{ ViewData["Title"] = "Beta Readers"; }
 
-<div class="page-header">
-    <div>
-        <h1 class="page-title">Beta Readers</h1>
-        <p class="page-subtitle">@Model.Count reader(s)</p>
+<div class="page-header page-header--image">
+    <div class="page-header__inner">
+        <h1 class="page-header__title">Beta Readers</h1>
+        <p class="page-header__subtitle">@Model.Count reader(s)</p>
     </div>
+</div>
+<div class="page-header__actions">
     <a asp-action="InviteReader" class="btn btn--primary">Invite a Reader</a>
 </div>
 

--- a/DraftView.Web/Views/Home/Privacy.cshtml
+++ b/DraftView.Web/Views/Home/Privacy.cshtml
@@ -2,9 +2,11 @@
     ViewData["Title"] = "Privacy Notice";
 }
 
-<div class="page-header">
-    <h1 class="page-title">Privacy Notice</h1>
-    <p class="page-subtitle">How DraftView uses and protects account email addresses.</p>
+<div class="page-header page-header--image">
+    <div class="page-header__inner">
+        <h1 class="page-header__title">Privacy Notice</h1>
+        <p class="page-header__subtitle">How DraftView uses and protects account email addresses.</p>
+    </div>
 </div>
 
 <div class="settings-page">

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-4" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-4" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-5" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-4" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-5" />
         }
     }
 </head>

--- a/DraftView.Web/Views/Support/Dashboard.cshtml
+++ b/DraftView.Web/Views/Support/Dashboard.cshtml
@@ -5,10 +5,10 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
-<div class="page-header">
-    <div>
-        <h1 class="page-title">System Dashboard</h1>
-        <p class="page-subtitle">System support operations and service status</p>
+<div class="page-header page-header--image">
+    <div class="page-header__inner">
+        <h1 class="page-header__title">System Dashboard</h1>
+        <p class="page-header__subtitle">System support operations and service status</p>
     </div>
 </div>
 

--- a/DraftView.Web/Views/Support/Readers.cshtml
+++ b/DraftView.Web/Views/Support/Readers.cshtml
@@ -5,10 +5,10 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
-<div class="page-header">
-    <div>
-        <h1 class="page-title">Readers</h1>
-        <p class="page-subtitle">System support reader listing (deny-by-default email visibility).</p>
+<div class="page-header page-header--image">
+    <div class="page-header__inner">
+        <h1 class="page-header__title">Readers</h1>
+        <p class="page-header__subtitle">System support reader listing (deny-by-default email visibility).</p>
     </div>
 </div>
 

--- a/DraftView.Web/wwwroot/css/DraftView.Components.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Components.css
@@ -327,7 +327,15 @@
     position: relative;
     border-radius: var(--radius-lg);
     overflow: hidden;
-    margin-bottom: var(--space-8);
+    margin-bottom: var(--space-4);
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.page-header__actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: var(--space-6);
 }
 
     .page-header--image::after {

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-21-4";
+    --css-version: "v2026-08-21-5";
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
Closes #74

## Changes

**CSS — `DraftView.Components.css`**
- `.page-header--image` now explicitly resets `border-bottom: none` and `padding-bottom: 0` so the base `.page-header` border doesn't bleed through the image banner
- New `.page-header__actions` class for action buttons positioned below the banner

**8 views updated**

Each page gets `page-header--image` added to the class list, content wrapped in `page-header__inner`, and `page-title`/`page-subtitle` renamed to the BEM modifier classes (`page-header__title`, `page-header__subtitle`) so the white text and z-index overlay work correctly:

| View | Note |
|------|------|
| Author/Dashboard | — |
| Author/InviteReader | — |
| Author/ManageReaderAccess | Status badge inside subtitle — works as-is |
| Author/Projects | — |
| Author/Readers | 'Invite a Reader' button moved below banner into `.page-header__actions` |
| Home/Privacy | — |
| Support/Dashboard | — |
| Support/Readers | — |

CSS version bumped to `v2026-08-21-5`.

## Test plan
- [ ] All 8 pages show the configured banner image (header image, not atmosphere)
- [ ] White title/subtitle text readable over the dark overlay
- [ ] Readers page: 'Invite a Reader' button visible below the banner
- [ ] ManageReaderAccess: status badge renders correctly
- [ ] No visual regression on pages using `page-title`/`page-subtitle` outside page-header context (Sections, Publishing, ManualChapters, Discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)