### PR TITLE
refactor: rename all theme images to [theme]-[role]-[dimensions] convention

### DIFF
--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-5" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-5" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-6" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-6" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-5" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-6" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Components.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Components.css
@@ -323,7 +323,7 @@
 .page-header--image {
     background-image: var(--header-image);
     background-size: cover;
-    background-position: center 35%;
+    background-position: var(--header-image-position);
     position: relative;
     border-radius: var(--radius-lg);
     overflow: hidden;

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,11 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-21-5";
+    --css-version: "v2026-08-21-6";
+    /* Banner image focal point — overridden per theme for images that are not 3.2:1 panoramic.
+       Default suits Noir / Crime / Contemporary (all correctly proportioned at ~2240x700).
+       Historic and Adventure override this until replacement panoramic banners are available. */
+    --header-image-position: center 40%;
     /* Colour palette now split into Light and Dark theme files */
     /* Typography */
     --font-ui: 'Inter', system-ui, -apple-system, sans-serif;

--- a/DraftView.Web/wwwroot/css/DraftView.Dark.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Dark.css
@@ -44,7 +44,8 @@
     --background-tile: url('/images/DraftView.Tile.Dark.web.jpg');
 
     /* Hero and error images — Adventure theme; shared across light/dark variants */
-    --header-image:       url('/images/DraftView.Header.png');
+    --header-image:       url('/images/DraftView.Header.png');         /* 1536x1024 (1.5:1) — replace with 2240x700 panoramic — see issue #54 */
+    --header-image-position: center 25%;                               /* Show top quarter: avoids worst of the portrait crop */
     --atmosphere-image:   url('/images/DraftView.Atmosphere.web.jpg');
     --hero-image:         url('/images/DraftViewReaderDash.Hero.png');          /* Second atmosphere image for hero rotation */
     --error-image-403:    url('/images/DraftView.403AccessDenied.png');

--- a/DraftView.Web/wwwroot/css/DraftView.Light.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Light.css
@@ -43,7 +43,8 @@
     --background-tile: url('/images/DraftView.Tile.web.jpg');
 
     /* Hero and error images — Adventure theme; shared across light/dark variants */
-    --header-image:       url('/images/DraftView.Header.png');
+    --header-image:       url('/images/DraftView.Header.png');         /* 1536x1024 (1.5:1) — replace with 2240x700 panoramic — see issue #54 */
+    --header-image-position: center 25%;                               /* Show top quarter: avoids worst of the portrait crop */
     --atmosphere-image:   url('/images/DraftView.Atmosphere.web.jpg');
     --hero-image:         url('/images/DraftViewReaderDash.Hero.png');          /* Second atmosphere image for hero rotation */
     --error-image-403:    url('/images/DraftView.403AccessDenied.png');

--- a/DraftView.Web/wwwroot/css/DraftView.Navigation.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Navigation.css
@@ -14,7 +14,7 @@
     z-index: 1000;
     background-image: var(--header-image);
     background-size: cover;
-    background-position: center 40%;
+    background-position: var(--header-image-position);
 }
 
     .site-nav::after {

--- a/DraftView.Web/wwwroot/css/DraftView.Settings.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Settings.css
@@ -7,7 +7,7 @@
 .site-hero.settings-hero {
     min-height: 180px;
     background-image: var(--header-image);
-    background-position: center 40%;
+    background-position: var(--header-image-position);
     margin-bottom: var(--space-8);
 }
 

--- a/DraftView.Web/wwwroot/css/DraftView.Theme.Historic.Dark.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Theme.Historic.Dark.css
@@ -50,7 +50,8 @@
     --background-tile: url('/images/Historic-Dark-Background-Tile.png');
 
     /* Hero and error images — Georgian / Napoleonic visual world; shared across light/dark variants */
-    --header-image:       url('/images/Historic-Banner.png');                        /* Header banner */
+    --header-image:       url('/images/Historic-Banner.png');                        /* Header banner — 1774x887 (2:1); replace with 2240x700 panoramic — see issue #76 */
+    --header-image-position: 72% 40%;                                                /* Shift right: avoids the DraftView logo on the left, shows ships + city */
     --atmosphere-image:   url('/images/Historic-Atmosphere.png');                   /* Letter with wax seal, gloves, fan — candlelit ballroom beyond */
     --hero-image:         url('/images/Historic-Reader-Dashboard-Hero.png');        /* Regency woman reading by ballroom window */
     --error-image-403:    url('/images/Historic-403-Access-Denied.png');            /* Redcoat soldier blocking door, 403 ACCESS DENIED plaque */

--- a/DraftView.Web/wwwroot/css/DraftView.Theme.Historic.Dark.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Theme.Historic.Dark.css
@@ -50,7 +50,7 @@
     --background-tile: url('/images/Historic-Dark-Background-Tile.png');
 
     /* Hero and error images — Georgian / Napoleonic visual world; shared across light/dark variants */
-    --header-image:       url('/images/Historic-Banner.png');                        /* Header banner — 1774x887 (2:1); replace with 2240x700 panoramic — see issue #76 */
+    --header-image:       url('/images/Historic-Banner.png');                        /* Header banner — 1774x887 (2:1); replace with 2240x700 panoramic — see issue #77 */
     --header-image-position: 72% 40%;                                                /* Shift right: avoids the DraftView logo on the left, shows ships + city */
     --atmosphere-image:   url('/images/Historic-Atmosphere.png');                   /* Letter with wax seal, gloves, fan — candlelit ballroom beyond */
     --hero-image:         url('/images/Historic-Reader-Dashboard-Hero.png');        /* Regency woman reading by ballroom window */

--- a/DraftView.Web/wwwroot/css/DraftView.Theme.Historic.Light.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Theme.Historic.Light.css
@@ -50,7 +50,8 @@
     --background-tile: url('/images/Historic-Light-Background-Tile.png');
 
     /* Hero and error images — Georgian / Napoleonic visual world; shared across light/dark variants */
-    --header-image:       url('/images/Historic-Banner.png');                        /* Header banner */
+    --header-image:       url('/images/Historic-Banner.png');                        /* Header banner — 1774x887 (2:1); replace with 2240x700 panoramic — see issue #76 */
+    --header-image-position: 72% 40%;                                                /* Shift right: avoids the DraftView logo on the left, shows ships + city */
     --atmosphere-image:   url('/images/Historic-Atmosphere.png');                   /* Letter with wax seal, gloves, fan — candlelit ballroom beyond */
     --hero-image:         url('/images/Historic-Reader-Dashboard-Hero.png');        /* Regency woman reading by ballroom window */
     --error-image-403:    url('/images/Historic-403-Access-Denied.png');            /* Redcoat soldier blocking door, 403 ACCESS DENIED plaque */

--- a/DraftView.Web/wwwroot/css/DraftView.Theme.Historic.Light.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Theme.Historic.Light.css
@@ -50,7 +50,7 @@
     --background-tile: url('/images/Historic-Light-Background-Tile.png');
 
     /* Hero and error images — Georgian / Napoleonic visual world; shared across light/dark variants */
-    --header-image:       url('/images/Historic-Banner.png');                        /* Header banner — 1774x887 (2:1); replace with 2240x700 panoramic — see issue #76 */
+    --header-image:       url('/images/Historic-Banner.png');                        /* Header banner — 1774x887 (2:1); replace with 2240x700 panoramic — see issue #77 */
     --header-image-position: 72% 40%;                                                /* Shift right: avoids the DraftView logo on the left, shows ships + city */
     --atmosphere-image:   url('/images/Historic-Atmosphere.png');                   /* Letter with wax seal, gloves, fan — candlelit ballroom beyond */
     --hero-image:         url('/images/Historic-Reader-Dashboard-Hero.png');        /* Regency woman reading by ballroom window */


### PR DESCRIPTION
## Problem

Banner images are cropped badly on Historic and Adventure themes because the images are the wrong aspect ratio. The correct ratio is **3.2:1 (~2240x700px)** — used correctly by Noir, Crime, and Contemporary. The broken images:

| Theme | Image | Ratio | Issue |
|-------|-------|-------|-------|
| Adventure | DraftView.Header.png | 1.5:1 | New image needed (#54) |
| Historic | Historic-Banner.png | 2.0:1 | New image needed (#76), also has DraftView logo baked in |

## Fix

Added `--header-image-position` CSS custom property (default `center 40%`). All three banner selectors (`site-nav`, `.page-header--image`, `.site-hero.settings-hero`) now use `var(--header-image-position)` instead of hardcoded values.

Theme-specific overrides applied as interim mitigation:
- **Adventure** (Light + Dark): `center 25%` — shows top quarter of the tall 1.5:1 image
- **Historic** (Light + Dark): `72% 40%` — shifts right to show ships/city, away from the DraftView logo on the left

Panoramic replacements are tracked in issues #54 (Adventure) and #76 (Historic).

## CSS version
Bumped to `v2026-08-21-6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)