### PR TITLE
fix: replace nav image background with flat themed colour

### DIFF
--- a/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
+++ b/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-7" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/EmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/EmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-7" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/FAQ.cshtml
+++ b/DraftView.Web/Views/Onboarding/FAQ.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-7" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/Join.cshtml
+++ b/DraftView.Web/Views/Onboarding/Join.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-7" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-7" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-7" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-7" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-7" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-7" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-8" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-21-7";
+    --css-version: "v2026-08-21-8";
     /* Banner image focal point — overridden per theme for images that are not 3.2:1 panoramic.
        Default suits Noir / Crime / Contemporary (all correctly proportioned at ~2240x700).
        Historic and Adventure override this until replacement panoramic banners are available. */

--- a/DraftView.Web/wwwroot/css/DraftView.Navigation.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Navigation.css
@@ -12,22 +12,11 @@
     position: sticky;
     top: 0;
     z-index: 1000;
-    background-image: var(--header-image);
-    background-size: cover;
-    background-position: var(--header-image-position);
+    background: var(--color-surface-alt);
+    border-bottom: 1px solid var(--color-border);
 }
 
-    .site-nav::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background: rgba(10, 15, 30, 0.72);
-        pointer-events: none;
-    }
-
 .site-nav__inner {
-    position: relative;
-    z-index: 1;
     max-width: var(--max-width);
     margin: 0 auto;
     padding: 0 var(--space-6);
@@ -42,14 +31,14 @@
     align-items: center;
     font-size: var(--text-lg);
     font-weight: var(--font-bold);
-    color: #ffffff;
+    color: var(--color-text);
     letter-spacing: -0.02em;
     text-decoration: none;
     flex-shrink: 0;
 }
 
     .site-nav__brand:hover {
-        color: #ffffff;
+        color: var(--color-text);
         text-decoration: none;
     }
 
@@ -149,7 +138,7 @@
     background: none;
     border: none;
     cursor: pointer;
-    color: #ffffff;
+    color: var(--color-text);
     font-size: 1.5rem;
     line-height: 1;
     padding: var(--space-2);


### PR DESCRIPTION
Closes #80

## Summary
- Removes `--header-image` and its dark overlay pseudo-element from `.site-nav`
- Replaces with `background: var(--color-surface-alt)` — uses each theme's existing light/dark surface token so the nav colour is always appropriate
- Adds `border-bottom: 1px solid var(--color-border)` for definition
- Updates hardcoded `#ffffff` text colours on `.site-nav__brand` and `.nav-toggle` to `var(--color-text)` so they read correctly on both light and dark themes
- CSS version bumped to `v2026-08-21-8`

## Test plan
- [ ] Check nav bar on each theme (Adventure, Crime, Noir, Contemporary, Historic) in both light and dark variants — should show a flat themed background, not the panoramic banner
- [ ] Confirm hero/page-header images no longer appear twice
- [ ] Check brand name and mobile toggle button are readable in all themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)