### PR TITLE
Sync resilience: graceful blank-title handling + surface error message in UI

### DIFF
--- a/Docs/PostgreSQL.md
+++ b/Docs/PostgreSQL.md
@@ -106,6 +106,24 @@ ORDER BY "UserName";
 
 ---
 
+## Diagnosing Sync Errors
+
+When a project shows `SyncStatus = Error` in the UI, the stored error message is the first diagnostic:
+
+```bash
+sudo -u postgres psql -d draftview -c 'SELECT "Name", "SyncStatus", "SyncErrorMessage", "LastSyncedAt" FROM "Projects" ORDER BY "LastSyncedAt" DESC;'
+```
+
+The `"SyncErrorMessage"` column contains the exact exception message captured at the point of failure. Common values:
+
+| Message | Cause | Fix |
+|---------|-------|-----|
+| `Section title must not be null or whitespace.` | A document or folder in the Scrivener binder has an empty title | Give it a name in Scrivener and re-sync (since issue #84, the sync service substitutes `"Untitled"` automatically — this should no longer cause an Error) |
+| `No DraftFolder found in project.scrivx.` | The `.scrivx` manifest has no Manuscript/Draft root | Check the Scrivener project structure |
+| `Dropbox not connected.` | OAuth token has expired or been revoked | Reconnect Dropbox in Settings |
+
+---
+
 ## The Three Things That Go Wrong
 
 1. **No quotes** → `column "x" does not exist` — PostgreSQL lowercased your identifier

--- a/DraftView.Application/Services/ScrivenerSyncService.cs
+++ b/DraftView.Application/Services/ScrivenerSyncService.cs
@@ -125,12 +125,18 @@ public class ScrivenerSyncService(
     {
         seenUuids.Add(node.Uuid);
 
+        var safeTitle = string.IsNullOrWhiteSpace(node.Title) ? "Untitled" : node.Title;
+        if (safeTitle == "Untitled")
+            logger.LogWarning(
+                "Section {Uuid} in project {ProjectId} has a blank title; substituting 'Untitled'.",
+                node.Uuid, projectId);
+
         var existing = await sectionRepo.GetByScrivenerUuidAsync(projectId, node.Uuid, ct);
         var created = false;
 
         if (existing is null)
         {
-            existing = await CreateSectionAsync(node, parentId, projectId, scrivFolderPath, ct);
+            existing = await CreateSectionAsync(node, safeTitle, parentId, projectId, scrivFolderPath, ct);
             await sectionRepo.AddAsync(existing, ct);
             created = true;
             _syncHadChanges = true;
@@ -143,7 +149,7 @@ public class ScrivenerSyncService(
         }
         else
         {
-            await UpdateSectionAsync(existing, node, scrivFolderPath, ct);
+            await UpdateSectionAsync(existing, node, safeTitle, scrivFolderPath, ct);
         }
 
         foreach (var child in node.Children)
@@ -298,22 +304,22 @@ public class ScrivenerSyncService(
         cursor.Length <= 16 ? cursor : cursor[..16];
 
     private async Task<Section> CreateSectionAsync(
-        ParsedBinderNode node, Guid? parentId, Guid projectId,
+        ParsedBinderNode node, string safeTitle, Guid? parentId, Guid projectId,
         string scrivFolderPath, CancellationToken ct)
     {
         if (node.NodeType == ParsedNodeType.Folder)
-            return Section.CreateFolder(projectId, node.Uuid, node.Title, parentId, node.SortOrder);
+            return Section.CreateFolder(projectId, node.Uuid, safeTitle, parentId, node.SortOrder);
 
         var rtf = await converter.ConvertAsync(scrivFolderPath, node.Uuid, ct);
-        return Section.CreateDocument(projectId, node.Uuid, node.Title, parentId,
+        return Section.CreateDocument(projectId, node.Uuid, safeTitle, parentId,
             node.SortOrder, rtf?.Html, rtf?.Hash, node.ScrivenerStatus);
     }
 
     private async Task UpdateSectionAsync(
-        Section existing, ParsedBinderNode node,
+        Section existing, ParsedBinderNode node, string safeTitle,
         string scrivFolderPath, CancellationToken ct)
     {
-        existing.UpdateTitle(node.Title);
+        existing.UpdateTitle(safeTitle);
         existing.UpdateSortOrder(node.SortOrder);
         existing.UpdateScrivenerStatus(node.ScrivenerStatus);
 

--- a/DraftView.Web/Views/Author/Dashboard.cshtml
+++ b/DraftView.Web/Views/Author/Dashboard.cshtml
@@ -105,6 +105,10 @@
                                     else if (p.SyncStatus == SyncStatus.Error)
                                     {
                                         <span class="badge badge--danger" title="@p.SyncErrorMessage">Error</span>
+                                        @if (!string.IsNullOrWhiteSpace(p.SyncErrorMessage))
+                                        {
+                                            <div style="font-size:0.75rem; color:var(--color-danger, #c62828); margin-top:4px; max-width:200px; line-height:1.3;">@p.SyncErrorMessage</div>
+                                        }
                                     }
                                     else if (p.SyncStatus == SyncStatus.Syncing)
                                     {


### PR DESCRIPTION
Closes #84

## Summary

- **Sync service**: blank or whitespace section titles in a Scrivener project no longer abort the sync with an `Error` status. The sync service now substitutes `"Untitled"`, logs a warning, and continues — the project completes as `Healthy`.
- **Dashboard UI**: when a project is in `Error` state, `SyncErrorMessage` is now displayed as readable text beneath the Error badge, not just a hover tooltip. Authors can see exactly what failed without leaving the dashboard.
- **PostgreSQL.md**: documents the `SyncErrorMessage` diagnostic query and a table of common error messages with their causes and fixes.

## Changes

- `DraftView.Application/Services/ScrivenerSyncService.cs` — sanitize title to `"Untitled"` in `ReconcileNodeAsync` before passing to `CreateSectionAsync` / `UpdateSectionAsync`; both methods now accept a `safeTitle` parameter
- `DraftView.Web/Views/Author/Dashboard.cshtml` — inline error message beneath the Error badge
- `Docs/PostgreSQL.md` — sync error diagnostic section added

---
_Generated by [Claude Code](https://claude.ai/code/session_015k3nErQXXk2bpcntSw4JRn)_