### PR TITLE
feat: Recent Activity filter chips + Settings Activity Log (#86)

### DIFF
--- a/DraftView.Application.Tests/Services/DashboardServiceTests.cs
+++ b/DraftView.Application.Tests/Services/DashboardServiceTests.cs
@@ -7,6 +7,12 @@ using DraftView.Domain.Notifications;
 
 namespace DraftView.Application.Tests.Services;
 
+/// <summary>
+/// Tests for DashboardService notification methods.
+/// Covers: get notifications (unfiltered, type-filtered, pruning), dismiss single,
+/// dismiss all, dismiss by type.
+/// Excludes: project overview, reader summary, email health (each covered separately).
+/// </summary>
 public class DashboardServiceTests
 {
     private static readonly Guid AuthorId = Guid.NewGuid();
@@ -157,6 +163,91 @@ public class DashboardServiceTests
         await sut.DismissAllNotificationsAsync(AuthorId);
 
         _notificationRepo.Verify(r => r.DeleteAllByAuthorIdAsync(AuthorId, default), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetNotificationsAsync — type filter
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetNotificationsAsync_WithTypeFilter_CallsFilteredRepoMethod()
+    {
+        var type = NotificationEventType.NewComment;
+        var n = AuthorNotification.Create(
+            AuthorId, type, "Alice commented", null, null, DateTime.UtcNow);
+        var sut = CreateSut();
+
+        _notificationRepo
+            .Setup(r => r.PruneOlderThanAsync(AuthorId, It.IsAny<DateTime>(), default))
+            .Returns(Task.CompletedTask);
+        _notificationRepo
+            .Setup(r => r.GetByAuthorIdAndTypeAsync(AuthorId, type, default))
+            .ReturnsAsync(new List<AuthorNotification> { n });
+
+        var result = await sut.GetNotificationsAsync(AuthorId, type);
+
+        Assert.Single(result);
+        _notificationRepo.Verify(r => r.GetByAuthorIdAndTypeAsync(AuthorId, type, default), Times.Once);
+        _notificationRepo.Verify(r => r.GetByAuthorIdAsync(AuthorId, default), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetNotificationsAsync_WithNullFilter_CallsUnfilteredRepoMethod()
+    {
+        var sut = CreateSut();
+
+        _notificationRepo
+            .Setup(r => r.PruneOlderThanAsync(AuthorId, It.IsAny<DateTime>(), default))
+            .Returns(Task.CompletedTask);
+        _notificationRepo
+            .Setup(r => r.GetByAuthorIdAsync(AuthorId, default))
+            .ReturnsAsync(new List<AuthorNotification>());
+
+        await sut.GetNotificationsAsync(AuthorId, null);
+
+        _notificationRepo.Verify(r => r.GetByAuthorIdAsync(AuthorId, default), Times.Once);
+        _notificationRepo.Verify(
+            r => r.GetByAuthorIdAndTypeAsync(It.IsAny<Guid>(), It.IsAny<NotificationEventType>(), default),
+            Times.Never);
+    }
+
+    // -----------------------------------------------------------------------
+    // DismissNotificationsByTypeAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task DismissNotificationsByTypeAsync_WithSpecificType_CallsDeleteByType()
+    {
+        var type = NotificationEventType.NewComment;
+        var sut = CreateSut();
+
+        _notificationRepo
+            .Setup(r => r.DeleteByAuthorIdAndTypeAsync(AuthorId, type, default))
+            .Returns(Task.CompletedTask);
+
+        await sut.DismissNotificationsByTypeAsync(AuthorId, type);
+
+        _notificationRepo.Verify(r => r.DeleteByAuthorIdAndTypeAsync(AuthorId, type, default), Times.Once);
+        _notificationRepo.Verify(r => r.DeleteAllByAuthorIdAsync(AuthorId, default), Times.Never);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task DismissNotificationsByTypeAsync_WithNullType_CallsDeleteAll()
+    {
+        var sut = CreateSut();
+
+        _notificationRepo
+            .Setup(r => r.DeleteAllByAuthorIdAsync(AuthorId, default))
+            .Returns(Task.CompletedTask);
+
+        await sut.DismissNotificationsByTypeAsync(AuthorId, null);
+
+        _notificationRepo.Verify(r => r.DeleteAllByAuthorIdAsync(AuthorId, default), Times.Once);
+        _notificationRepo.Verify(
+            r => r.DeleteByAuthorIdAndTypeAsync(It.IsAny<Guid>(), It.IsAny<NotificationEventType>(), default),
+            Times.Never);
         _unitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
     }
 }

--- a/DraftView.Application/Services/DashboardService.cs
+++ b/DraftView.Application/Services/DashboardService.cs
@@ -1,6 +1,7 @@
 using DraftView.Domain.Entities;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
+using DraftView.Domain.Notifications;
 
 namespace DraftView.Application.Services;
 
@@ -23,11 +24,17 @@ public class DashboardService(
         CancellationToken ct = default) =>
         await logRepo.GetFailedAsync(ct);
 
+    /// <summary>
+    /// Returns notifications for the author, pruning any older than 90 days first.
+    /// When typeFilter is provided, only notifications of that event type are returned.
+    /// </summary>
     public async Task<IReadOnlyList<AuthorNotification>> GetNotificationsAsync(
-        Guid authorId, CancellationToken ct = default)
+        Guid authorId, NotificationEventType? typeFilter = null, CancellationToken ct = default)
     {
         await notificationRepo.PruneOlderThanAsync(authorId, DateTime.UtcNow.AddDays(-90), ct);
-        return await notificationRepo.GetByAuthorIdAsync(authorId, ct);
+        return typeFilter.HasValue
+            ? await notificationRepo.GetByAuthorIdAndTypeAsync(authorId, typeFilter.Value, ct)
+            : await notificationRepo.GetByAuthorIdAsync(authorId, ct);
     }
 
     public async Task DismissNotificationAsync(
@@ -41,6 +48,20 @@ public class DashboardService(
         Guid authorId, CancellationToken ct = default)
     {
         await notificationRepo.DeleteAllByAuthorIdAsync(authorId, ct);
+        await unitOfWork.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Deletes notifications for the author scoped by type.
+    /// When type is null, all notifications for the author are deleted.
+    /// </summary>
+    public async Task DismissNotificationsByTypeAsync(
+        Guid authorId, NotificationEventType? type, CancellationToken ct = default)
+    {
+        if (type.HasValue)
+            await notificationRepo.DeleteByAuthorIdAndTypeAsync(authorId, type.Value, ct);
+        else
+            await notificationRepo.DeleteAllByAuthorIdAsync(authorId, ct);
         await unitOfWork.SaveChangesAsync(ct);
     }
 }

--- a/DraftView.Domain/Interfaces/Repositories/IAuthorNotificationRepository.cs
+++ b/DraftView.Domain/Interfaces/Repositories/IAuthorNotificationRepository.cs
@@ -1,4 +1,5 @@
 using DraftView.Domain.Entities;
+using DraftView.Domain.Notifications;
 
 namespace DraftView.Domain.Interfaces.Repositories;
 
@@ -6,7 +7,9 @@ public interface IAuthorNotificationRepository
 {
     Task AddAsync(AuthorNotification notification, CancellationToken ct = default);
     Task<IReadOnlyList<AuthorNotification>> GetByAuthorIdAsync(Guid authorId, CancellationToken ct = default);
+    Task<IReadOnlyList<AuthorNotification>> GetByAuthorIdAndTypeAsync(Guid authorId, NotificationEventType type, CancellationToken ct = default);
     Task DeleteAsync(Guid notificationId, CancellationToken ct = default);
     Task DeleteAllByAuthorIdAsync(Guid authorId, CancellationToken ct = default);
+    Task DeleteByAuthorIdAndTypeAsync(Guid authorId, NotificationEventType type, CancellationToken ct = default);
     Task PruneOlderThanAsync(Guid authorId, DateTime cutoff, CancellationToken ct = default);
 }

--- a/DraftView.Domain/Interfaces/Services/IDashboardService.cs
+++ b/DraftView.Domain/Interfaces/Services/IDashboardService.cs
@@ -1,4 +1,5 @@
 using DraftView.Domain.Entities;
+using DraftView.Domain.Notifications;
 
 namespace DraftView.Domain.Interfaces.Services;
 
@@ -9,11 +10,14 @@ public interface IDashboardService
     Task<IReadOnlyList<EmailDeliveryLog>> GetEmailHealthSummaryAsync(CancellationToken ct = default);
 
     Task<IReadOnlyList<AuthorNotification>> GetNotificationsAsync(
-        Guid authorId, CancellationToken ct = default);
+        Guid authorId, NotificationEventType? typeFilter = null, CancellationToken ct = default);
 
     Task DismissNotificationAsync(
         Guid notificationId, CancellationToken ct = default);
 
     Task DismissAllNotificationsAsync(
         Guid authorId, CancellationToken ct = default);
+
+    Task DismissNotificationsByTypeAsync(
+        Guid authorId, NotificationEventType? type, CancellationToken ct = default);
 }

--- a/DraftView.Infrastructure.Tests/Persistence/AuthorNotificationRepositoryTests.cs
+++ b/DraftView.Infrastructure.Tests/Persistence/AuthorNotificationRepositoryTests.cs
@@ -6,6 +6,12 @@ using DraftView.Infrastructure.Persistence.Repositories;
 
 namespace DraftView.Infrastructure.Tests.Persistence;
 
+/// <summary>
+/// Tests for AuthorNotificationRepository.
+/// Covers: add, get by author, get by author and type, delete single, delete all by author,
+/// delete by author and type, prune older than.
+/// Excludes: SaveChanges lifecycle (caller responsibility), concurrent-access scenarios.
+/// </summary>
 public class AuthorNotificationRepositoryTests : IDisposable
 {
     private static readonly Guid AuthorA = Guid.NewGuid();
@@ -29,10 +35,11 @@ public class AuthorNotificationRepositoryTests : IDisposable
     private static AuthorNotification Make(
         Guid authorId,
         DateTime? occurredAt = null,
-        string title = "Test notification") =>
+        string title = "Test notification",
+        NotificationEventType type = NotificationEventType.NewComment) =>
         AuthorNotification.Create(
             authorId,
-            NotificationEventType.NewComment,
+            type,
             title,
             null,
             null,
@@ -175,5 +182,68 @@ public class AuthorNotificationRepositoryTests : IDisposable
         var remaining = await _sut.GetByAuthorIdAsync(AuthorA);
         Assert.Single(remaining);
         Assert.Equal(cutoff.AddDays(1), remaining[0].OccurredAt);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetByAuthorIdAndTypeAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetByAuthorIdAndTypeAsync_ReturnsOnlyMatchingType()
+    {
+        await _sut.AddAsync(Make(AuthorA, type: NotificationEventType.NewComment));
+        await _sut.AddAsync(Make(AuthorA, type: NotificationEventType.ReaderJoined));
+        await _db.SaveChangesAsync();
+
+        var results = await _sut.GetByAuthorIdAndTypeAsync(AuthorA, NotificationEventType.NewComment);
+
+        Assert.Single(results);
+        Assert.Equal(NotificationEventType.NewComment, results[0].EventType);
+    }
+
+    [Fact]
+    public async Task GetByAuthorIdAndTypeAsync_ExcludesOtherAuthors()
+    {
+        await _sut.AddAsync(Make(AuthorA, type: NotificationEventType.NewComment));
+        await _sut.AddAsync(Make(AuthorB, type: NotificationEventType.NewComment));
+        await _db.SaveChangesAsync();
+
+        var results = await _sut.GetByAuthorIdAndTypeAsync(AuthorA, NotificationEventType.NewComment);
+
+        Assert.Single(results);
+        Assert.Equal(AuthorA, results[0].AuthorId);
+    }
+
+    // -----------------------------------------------------------------------
+    // DeleteByAuthorIdAndTypeAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task DeleteByAuthorIdAndTypeAsync_RemovesOnlyMatchingType()
+    {
+        await _sut.AddAsync(Make(AuthorA, type: NotificationEventType.NewComment));
+        await _sut.AddAsync(Make(AuthorA, type: NotificationEventType.ReaderJoined));
+        await _db.SaveChangesAsync();
+
+        await _sut.DeleteByAuthorIdAndTypeAsync(AuthorA, NotificationEventType.NewComment);
+        await _db.SaveChangesAsync();
+
+        var remaining = await _sut.GetByAuthorIdAsync(AuthorA);
+        Assert.Single(remaining);
+        Assert.Equal(NotificationEventType.ReaderJoined, remaining[0].EventType);
+    }
+
+    [Fact]
+    public async Task DeleteByAuthorIdAndTypeAsync_LeavesOtherAuthorsIntact()
+    {
+        await _sut.AddAsync(Make(AuthorA, type: NotificationEventType.NewComment));
+        await _sut.AddAsync(Make(AuthorB, type: NotificationEventType.NewComment));
+        await _db.SaveChangesAsync();
+
+        await _sut.DeleteByAuthorIdAndTypeAsync(AuthorA, NotificationEventType.NewComment);
+        await _db.SaveChangesAsync();
+
+        var bRemaining = await _sut.GetByAuthorIdAsync(AuthorB);
+        Assert.Single(bRemaining);
     }
 }

--- a/DraftView.Infrastructure/Persistence/Repositories/AuthorNotificationRepository.cs
+++ b/DraftView.Infrastructure/Persistence/Repositories/AuthorNotificationRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using DraftView.Domain.Entities;
 using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Notifications;
 
 namespace DraftView.Infrastructure.Persistence.Repositories;
 
@@ -13,6 +14,17 @@ public class AuthorNotificationRepository(DraftViewDbContext db) : IAuthorNotifi
         Guid authorId, CancellationToken ct = default) =>
         await db.AuthorNotifications
             .Where(n => n.AuthorId == authorId)
+            .OrderByDescending(n => n.OccurredAt)
+            .ToListAsync(ct);
+
+    /// <summary>
+    /// Returns all notifications for the given author with the specified event type,
+    /// ordered by most recent first.
+    /// </summary>
+    public async Task<IReadOnlyList<AuthorNotification>> GetByAuthorIdAndTypeAsync(
+        Guid authorId, NotificationEventType type, CancellationToken ct = default) =>
+        await db.AuthorNotifications
+            .Where(n => n.AuthorId == authorId && n.EventType == type)
             .OrderByDescending(n => n.OccurredAt)
             .ToListAsync(ct);
 
@@ -29,6 +41,19 @@ public class AuthorNotificationRepository(DraftViewDbContext db) : IAuthorNotifi
             .Where(n => n.AuthorId == authorId)
             .ToListAsync(ct);
         db.AuthorNotifications.RemoveRange(all);
+    }
+
+    /// <summary>
+    /// Removes all notifications for the given author matching the specified event type.
+    /// Does not call SaveChanges — the caller is responsible for the unit of work.
+    /// </summary>
+    public async Task DeleteByAuthorIdAndTypeAsync(
+        Guid authorId, NotificationEventType type, CancellationToken ct = default)
+    {
+        var items = await db.AuthorNotifications
+            .Where(n => n.AuthorId == authorId && n.EventType == type)
+            .ToListAsync(ct);
+        db.AuthorNotifications.RemoveRange(items);
     }
 
     public async Task PruneOlderThanAsync(Guid authorId, DateTime cutoff, CancellationToken ct = default)

--- a/DraftView.Web.Tests/Controllers/AccountControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/AccountControllerTests.cs
@@ -27,6 +27,7 @@ public class AccountControllerTests
     private readonly Mock<IUserPreferencesRepository> prefsRepo = new();
     private readonly Mock<IControlledUserEmailService> controlledUserEmailService = new();
     private readonly Mock<IEmailSender> emailSender = new();
+    private readonly Mock<IDashboardService> dashboardService = new();
     private readonly Mock<ILogger<AccountController>> logger = new();
     private readonly Mock<IUserEmailEncryptionService> emailEncryptionService = new();
     private readonly Mock<IUserEmailLookupHmacService> emailLookupHmacService = new();
@@ -79,6 +80,7 @@ public class AccountControllerTests
             prefsRepo.Object,
             controlledUserEmailService.Object,
             emailSender.Object,
+            dashboardService.Object,
             logger.Object
         );
 

--- a/DraftView.Web.Tests/EmailExposure/GoverningRenderedEmailExposureTests.cs
+++ b/DraftView.Web.Tests/EmailExposure/GoverningRenderedEmailExposureTests.cs
@@ -164,7 +164,7 @@ public class GoverningRenderedEmailExposureTests :
                 var dashboardService = new Mock<IDashboardService>();
                 dashboardService.Setup(s => s.GetEmailHealthSummaryAsync(It.IsAny<CancellationToken>()))
                     .ReturnsAsync(Array.Empty<EmailDeliveryLog>());
-                dashboardService.Setup(s => s.GetNotificationsAsync(authorUser.Id, It.IsAny<CancellationToken>()))
+                dashboardService.Setup(s => s.GetNotificationsAsync(authorUser.Id, It.IsAny<NotificationEventType?>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(Array.Empty<AuthorNotification>());
 
                 var publicationService = new Mock<IPublicationService>();

--- a/DraftView.Web/Controllers/AccountController.cs
+++ b/DraftView.Web/Controllers/AccountController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
+using DraftView.Domain.Notifications;
 using Microsoft.EntityFrameworkCore;
 using DraftView.Infrastructure.Persistence;
 using DraftView.Web.Models;
@@ -22,6 +23,7 @@ public class AccountController(
     IUserPreferencesRepository prefsRepo,
     DraftView.Application.Interfaces.IControlledUserEmailService controlledUserEmailService,
     IEmailSender emailSender,
+    IDashboardService dashboardService,
     ILogger<AccountController> logger) : BaseController(userRepo)
 {
     // ---------------------------------------------------------------------------
@@ -458,7 +460,7 @@ public class AccountController(
     // Settings
     // ---------------------------------------------------------------------------
     [HttpGet]
-    public async Task<IActionResult> Settings()
+    public async Task<IActionResult> Settings(string? type = null)
     {
         var user = await GetCurrentUserAsync();
         if (user is null)
@@ -471,6 +473,8 @@ public class AccountController(
             user.Id,
             DraftView.Application.Contracts.UserEmailAccessPurpose.SelfServiceSettings));
 
+        NotificationEventType? typeFilter = Enum.TryParse<NotificationEventType>(type, out var parsed) ? parsed : null;
+
         var vm = new SettingsViewModel {
             DisplayName = user.DisplayName,
             Email = resolvedEmail,
@@ -481,7 +485,8 @@ public class AccountController(
             ProseFontSize = prefs?.ProseFontSize.ToString() ?? "Medium",
             ReaderBio = prefs?.ReaderBio,
             ReaderGenreInterests = prefs?.ReaderGenreInterests,
-            ReaderPace = prefs?.ReaderPace?.ToString()
+            ReaderPace = prefs?.ReaderPace?.ToString(),
+            ActiveTypeFilter = typeFilter
         };
 
         if (vm.IsAuthor)
@@ -489,9 +494,25 @@ public class AccountController(
             var connection = await GetDropboxConnectionAsync(user.Id);
             vm.DropboxStatus = connection?.Status.ToString();
             vm.DropboxAuthorisedAt = connection?.AuthorisedAt;
+            vm.Notifications = await dashboardService.GetNotificationsAsync(user.Id, typeFilter);
         }
 
         return View(vm);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ClearNotifications(string? type = null)
+    {
+        var (author, error) = await RequireCurrentAuthorAsync();
+        if (error is not null || author is null) return error ?? Forbid();
+
+        NotificationEventType? typeFilter = Enum.TryParse<NotificationEventType>(type, out var parsed) ? parsed : null;
+        await dashboardService.DismissNotificationsByTypeAsync(author.Id, typeFilter);
+
+        return typeFilter.HasValue
+            ? RedirectToAction("Settings", new { type })
+            : RedirectToAction("Settings");
     }
 
     [HttpPost]

--- a/DraftView.Web/Controllers/AuthorController.cs
+++ b/DraftView.Web/Controllers/AuthorController.cs
@@ -1,6 +1,7 @@
 ﻿using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Enumerations;
 using DraftView.Domain.Exceptions;
+using DraftView.Domain.Notifications;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using DraftView.Domain.Entities;
@@ -43,11 +44,13 @@ public class AuthorController(
     // ---------------------------------------------------------------------------
     // Dashboard
     // ---------------------------------------------------------------------------
-    public async Task<IActionResult> Dashboard()
+    public async Task<IActionResult> Dashboard(string? type = null)
     {
         var author = await TryGetCurrentAuthorAsync();
         if (author is null)
             return RedirectToAction("Index", "Reader");
+
+        NotificationEventType? typeFilter = Enum.TryParse<NotificationEventType>(type, out var parsed) ? parsed : null;
 
         var projects          = await projectRepo.GetAllAsync();
         var active            = await projectRepo.GetReaderActiveProjectAsync();
@@ -55,7 +58,7 @@ public class AuthorController(
             ? await publicationService.GetPublishedChaptersAsync(active.Id) : [];
         var failures      = await dashboardService.GetEmailHealthSummaryAsync();
         var readers       = await userRepo.GetAllBetaReadersAsync();
-        var notifications = await dashboardService.GetNotificationsAsync(author.Id);
+        var notifications = await dashboardService.GetNotificationsAsync(author.Id, typeFilter);
 
         return View(new DashboardViewModel
         {
@@ -64,7 +67,8 @@ public class AuthorController(
             PublishedSections = publishedChapters,
             EmailFailures     = failures,
             ActiveReaderCount = readers.Count(r => r.IsActive && !r.IsSoftDeleted),
-            Notifications     = notifications
+            Notifications     = notifications,
+            ActiveTypeFilter  = typeFilter
         });
     }
 
@@ -76,17 +80,6 @@ public class AuthorController(
     public async Task<IActionResult> DismissNotification(Guid notificationId)
     {
         await dashboardService.DismissNotificationAsync(notificationId);
-        return RedirectToAction("Dashboard");
-    }
-
-    [HttpPost]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> ClearAllNotifications()
-    {
-        var (author, error) = await RequireCurrentAuthorAsync();
-        if (error is not null || author is null) return error ?? Forbid();
-        
-        await dashboardService.DismissAllNotificationsAsync(author.Id);
         return RedirectToAction("Dashboard");
     }
 

--- a/DraftView.Web/Models/AccountViewModels.cs
+++ b/DraftView.Web/Models/AccountViewModels.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Notifications;
 
 namespace DraftView.Web.Models;
 
@@ -65,6 +67,8 @@ public class SettingsViewModel
     public string? ReaderBio { get; set; }
     public string? ReaderGenreInterests { get; set; }
     public string? ReaderPace { get; set; }
+    public IReadOnlyList<AuthorNotification> Notifications { get; set; } = [];
+    public NotificationEventType? ActiveTypeFilter { get; set; }
 }
 
 public class UpdateReaderProfileViewModel

--- a/DraftView.Web/Models/AuthorViewModels.cs
+++ b/DraftView.Web/Models/AuthorViewModels.cs
@@ -14,6 +14,7 @@ public class DashboardViewModel
     public IReadOnlyList<EmailDeliveryLog> EmailFailures { get; set; } = [];
     public int ActiveReaderCount { get; set; }
     public IReadOnlyList<AuthorNotification> Notifications { get; set; } = [];
+    public NotificationEventType? ActiveTypeFilter { get; set; }
 }
 
 public class SectionViewModel

--- a/DraftView.Web/Views/Account/Settings.cshtml
+++ b/DraftView.Web/Views/Account/Settings.cshtml
@@ -1,4 +1,5 @@
-﻿@model DraftView.Web.Models.SettingsViewModel
+﻿@using DraftView.Domain.Notifications
+@model DraftView.Web.Models.SettingsViewModel
 @{
     ViewData["Title"] = "Account Settings";
 }
@@ -213,5 +214,81 @@
                 </div>
             }
         </div>
+
+        @if (Model.IsAuthor)
+        {
+            var activeLabel   = SettingsFilterLabel(Model.ActiveTypeFilter);
+            var allClass      = SettingsChipClass(Model.ActiveTypeFilter, null);
+            var commentClass  = SettingsChipClass(Model.ActiveTypeFilter, NotificationEventType.NewComment);
+            var replyClass    = SettingsChipClass(Model.ActiveTypeFilter, NotificationEventType.ReplyToAuthor);
+            var readerClass   = SettingsChipClass(Model.ActiveTypeFilter, NotificationEventType.ReaderJoined);
+            var syncClass     = SettingsChipClass(Model.ActiveTypeFilter, NotificationEventType.SyncCompleted);
+            <div class="card settings-card">
+                <div class="card__header"><span class="card__title">Activity Log</span></div>
+
+                <div class="notification-filters">
+                    <a asp-action="Settings" class="@allClass">All</a>
+                    <a asp-action="Settings" asp-route-type="@NotificationEventType.NewComment"    class="@commentClass">Comments</a>
+                    <a asp-action="Settings" asp-route-type="@NotificationEventType.ReplyToAuthor" class="@replyClass">Replies</a>
+                    <a asp-action="Settings" asp-route-type="@NotificationEventType.ReaderJoined"  class="@readerClass">Readers</a>
+                    <a asp-action="Settings" asp-route-type="@NotificationEventType.SyncCompleted" class="@syncClass">Sync</a>
+                </div>
+
+                @if (Model.Notifications.Any())
+                {
+                    <ul class="notifications-list notifications-list--settings">
+                        @foreach (var n in Model.Notifications)
+                        {
+                            <li class="notification-item">
+                                @await Html.PartialAsync("_NotificationItem", n)
+                                <form asp-controller="Author" asp-action="DismissNotification" method="post" style="display:contents">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="notificationId" value="@n.Id" />
+                                    <button type="submit" class="notification-item__dismiss" aria-label="Dismiss">&#x2715;</button>
+                                </form>
+                            </li>
+                        }
+                    </ul>
+
+                    <div class="settings-activity-actions">
+                        @if (Model.ActiveTypeFilter.HasValue)
+                        {
+                            <form asp-action="ClearNotifications" method="post" style="display:inline">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="type" value="@Model.ActiveTypeFilter" />
+                                <button type="submit" class="btn btn--ghost btn--sm">Clear @activeLabel</button>
+                            </form>
+                        }
+                        else
+                        {
+                            <form asp-action="ClearNotifications" method="post" style="display:inline"
+                                  onsubmit="return confirm('Clear all activity? This cannot be undone.')">
+                                @Html.AntiForgeryToken()
+                                <button type="submit" class="btn btn--ghost btn--sm">Clear All</button>
+                            </form>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <p class="settings-hint" style="margin-top:var(--space-4);">No activity to show.</p>
+                }
+            </div>
+        }
+
     </div>
 </div>
+
+@functions {
+    static string SettingsChipClass(NotificationEventType? active, NotificationEventType? chip) =>
+        "notification-filter" + (active == chip ? " notification-filter--active" : "");
+
+    static string? SettingsFilterLabel(NotificationEventType? type) => type switch
+    {
+        NotificationEventType.NewComment    => "Comments",
+        NotificationEventType.ReplyToAuthor => "Replies",
+        NotificationEventType.ReaderJoined  => "Readers",
+        NotificationEventType.SyncCompleted => "Sync",
+        _                                   => null
+    };
+}

--- a/DraftView.Web/Views/Author/Dashboard.cshtml
+++ b/DraftView.Web/Views/Author/Dashboard.cshtml
@@ -1,5 +1,4 @@
-﻿@using DraftView.Domain.Notifications
-@using DraftView.Domain.Enumerations
+﻿@using DraftView.Domain.Enumerations
 @model DashboardViewModel
 @{ ViewData["Title"] = "Dashboard"; }
 
@@ -300,29 +299,7 @@
                     @foreach (var n in Model.Notifications)
                     {
                         <li class="notification-item">
-                            <span class="notification-item__icon notification-item__icon--@NotificationIconClass(n.EventType)"
-                                  aria-hidden="true">
-                                @Html.Raw(NotificationSvgIcon(n.EventType))
-                            </span>
-                            <div class="notification-item__body">
-                                @if (n.LinkUrl is not null)
-                                {
-                                    <a href="@n.LinkUrl" class="notification-item__title">@n.Title</a>
-                                }
-                                else
-                                {
-                                    <span class="notification-item__title">@n.Title</span>
-                                }
-                                @if (!string.IsNullOrEmpty(n.Detail))
-                                {
-                                    <p class="notification-item__detail">@n.Detail</p>
-                                }
-                                <time class="notification-item__time"
-                                      datetime="@n.OccurredAt.ToString("o")"
-                                      title="@n.OccurredAt.ToString("dd MMM yyyy HH:mm") UTC">
-                                    @RelativeTime(n.OccurredAt)
-                                </time>
-                            </div>
+                            <partial name="_NotificationItem" model="@n" />
                             <form asp-action="DismissNotification" method="post" style="display:contents">
                                 @Html.AntiForgeryToken()
                                 <input type="hidden" name="notificationId" value="@n.Id" />
@@ -338,43 +315,6 @@
 </div><!-- /dashboard-body -->
 
 
-@functions {
-    static string NotificationIconClass(NotificationEventType t) => t switch
-    {
-        NotificationEventType.NewComment    => "comment",
-        NotificationEventType.ReplyToAuthor => "reply",
-        NotificationEventType.ReaderJoined  => "reader",
-        NotificationEventType.SyncCompleted => "sync",
-        _                                   => "comment"
-    };
-
-    static string NotificationSvgIcon(NotificationEventType t) => t switch
-    {
-        NotificationEventType.NewComment =>
-            """<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>""",
-
-        NotificationEventType.ReplyToAuthor =>
-            """<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg>""",
-
-        NotificationEventType.ReaderJoined =>
-            """<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>""",
-
-        NotificationEventType.SyncCompleted =>
-            """<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>""",
-
-        _ => ""
-    };
-
-    static string RelativeTime(DateTime utc)
-    {
-        var diff = DateTime.UtcNow - utc;
-        if (diff.TotalMinutes < 2)   return "just now";
-        if (diff.TotalMinutes < 60)  return $"{(int)diff.TotalMinutes}m ago";
-        if (diff.TotalHours   < 24)  return $"{(int)diff.TotalHours}h ago";
-        if (diff.TotalDays    < 7)   return $"{(int)diff.TotalDays}d ago";
-        return utc.ToString("dd MMM");
-    }
-}
 
 
 @if (Model.AllProjects.Any(p => p.SyncStatus == SyncStatus.Syncing))

--- a/DraftView.Web/Views/Author/Dashboard.cshtml
+++ b/DraftView.Web/Views/Author/Dashboard.cshtml
@@ -1,4 +1,5 @@
 ﻿@using DraftView.Domain.Enumerations
+@using DraftView.Domain.Notifications
 @model DashboardViewModel
 @{ ViewData["Title"] = "Dashboard"; }
 
@@ -61,7 +62,7 @@
 <!-- Two-column lower layout: main content left, notifications right -->
 <div class="dashboard-body">
 
-    <!-- â”€â”€ LEFT COLUMN â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ -->
+    <!-- â"€â"€ LEFT COLUMN â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€ -->
     <div class="dashboard-main">
 
         <!-- Projects -->
@@ -256,7 +257,7 @@
 
     </div><!-- /dashboard-main -->
 
-    <!-- â”€â”€ RIGHT COLUMN: NOTIFICATIONS â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ -->
+    <!-- â"€â"€ RIGHT COLUMN: NOTIFICATIONS â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€â"€ -->
     <aside class="dashboard-sidebar">
         <div class="card notifications-panel">
             <div class="card__header">
@@ -269,13 +270,25 @@
                         </span>
                     }
                 </span>
-                @if (Model.Notifications.Any())
+                @if (Model.ActiveTypeFilter.HasValue)
                 {
-                    <form asp-action="ClearAllNotifications" method="post" style="display:inline">
-                        @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn--ghost btn--sm">Clear all</button>
-                    </form>
+                    <a asp-action="Dashboard" class="btn btn--ghost btn--sm">All</a>
                 }
+            </div>
+
+            @{
+                var allClass      = FilterChipClass(Model.ActiveTypeFilter, null);
+                var commentClass  = FilterChipClass(Model.ActiveTypeFilter, NotificationEventType.NewComment);
+                var replyClass    = FilterChipClass(Model.ActiveTypeFilter, NotificationEventType.ReplyToAuthor);
+                var readerClass   = FilterChipClass(Model.ActiveTypeFilter, NotificationEventType.ReaderJoined);
+                var syncClass     = FilterChipClass(Model.ActiveTypeFilter, NotificationEventType.SyncCompleted);
+            }
+            <div class="notification-filters">
+                <a asp-action="Dashboard" class="@allClass">All</a>
+                <a asp-action="Dashboard" asp-route-type="@NotificationEventType.NewComment"    class="@commentClass">Comments</a>
+                <a asp-action="Dashboard" asp-route-type="@NotificationEventType.ReplyToAuthor" class="@replyClass">Replies</a>
+                <a asp-action="Dashboard" asp-route-type="@NotificationEventType.ReaderJoined"  class="@readerClass">Readers</a>
+                <a asp-action="Dashboard" asp-route-type="@NotificationEventType.SyncCompleted" class="@syncClass">Sync</a>
             </div>
 
             @if (!Model.Notifications.Any())
@@ -299,7 +312,7 @@
                     @foreach (var n in Model.Notifications)
                     {
                         <li class="notification-item">
-                            <partial name="_NotificationItem" model="@n" />
+                            @await Html.PartialAsync("_NotificationItem", n)
                             <form asp-action="DismissNotification" method="post" style="display:contents">
                                 @Html.AntiForgeryToken()
                                 <input type="hidden" name="notificationId" value="@n.Id" />
@@ -314,8 +327,10 @@
 
 </div><!-- /dashboard-body -->
 
-
-
+@functions {
+    static string FilterChipClass(NotificationEventType? active, NotificationEventType? chip) =>
+        "notification-filter" + (active == chip ? " notification-filter--active" : "");
+}
 
 @if (Model.AllProjects.Any(p => p.SyncStatus == SyncStatus.Syncing))
 {

--- a/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
+++ b/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/EmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/EmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/FAQ.cshtml
+++ b/DraftView.Web/Views/Onboarding/FAQ.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/Join.cshtml
+++ b/DraftView.Web/Views/Onboarding/Join.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-21-8" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-21-8" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-21-8" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-29-1" />
         }
     }
 </head>

--- a/DraftView.Web/Views/Shared/_NotificationItem.cshtml
+++ b/DraftView.Web/Views/Shared/_NotificationItem.cshtml
@@ -1,0 +1,66 @@
+@using DraftView.Domain.Notifications
+@model DraftView.Domain.Entities.AuthorNotification
+@{
+    var n = Model;
+}
+<span class="notification-item__icon notification-item__icon--@NotificationIconClass(n.EventType)"
+      aria-hidden="true">
+    @Html.Raw(NotificationSvgIcon(n.EventType))
+</span>
+<div class="notification-item__body">
+    @if (n.LinkUrl is not null)
+    {
+        <a href="@n.LinkUrl" class="notification-item__title">@n.Title</a>
+    }
+    else
+    {
+        <span class="notification-item__title">@n.Title</span>
+    }
+    @if (!string.IsNullOrEmpty(n.Detail))
+    {
+        <p class="notification-item__detail">@n.Detail</p>
+    }
+    <time class="notification-item__time"
+          datetime="@n.OccurredAt.ToString("o")"
+          title="@n.OccurredAt.ToString("dd MMM yyyy HH:mm") UTC">
+        @RelativeTime(n.OccurredAt)
+    </time>
+</div>
+
+@functions {
+    static string NotificationIconClass(NotificationEventType t) => t switch
+    {
+        NotificationEventType.NewComment    => "comment",
+        NotificationEventType.ReplyToAuthor => "reply",
+        NotificationEventType.ReaderJoined  => "reader",
+        NotificationEventType.SyncCompleted => "sync",
+        _                                   => "comment"
+    };
+
+    static string NotificationSvgIcon(NotificationEventType t) => t switch
+    {
+        NotificationEventType.NewComment =>
+            """<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>""",
+
+        NotificationEventType.ReplyToAuthor =>
+            """<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg>""",
+
+        NotificationEventType.ReaderJoined =>
+            """<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>""",
+
+        NotificationEventType.SyncCompleted =>
+            """<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>""",
+
+        _ => ""
+    };
+
+    static string RelativeTime(DateTime utc)
+    {
+        var diff = DateTime.UtcNow - utc;
+        if (diff.TotalMinutes < 2)   return "just now";
+        if (diff.TotalMinutes < 60)  return $"{(int)diff.TotalMinutes}m ago";
+        if (diff.TotalHours   < 24)  return $"{(int)diff.TotalHours}h ago";
+        if (diff.TotalDays    < 7)   return $"{(int)diff.TotalDays}d ago";
+        return utc.ToString("dd MMM");
+    }
+}

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-21-8";
+    --css-version: "v2026-08-29-1";
     /* Banner image focal point — overridden per theme for images that are not 3.2:1 panoramic.
        Default suits Noir / Crime / Contemporary (all correctly proportioned at ~2240x700).
        Historic and Adventure override this until replacement panoramic banners are available. */

--- a/DraftView.Web/wwwroot/css/DraftView.Notifications.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Notifications.css
@@ -165,7 +165,61 @@ a.notification-item__title:hover {
 }
 
 /* --------------------------------------------------------------------------
-   5. Browser Fallbacks
+   5. Notification Filters (Dashboard chips and Settings Activity Log pills)
+   -------------------------------------------------------------------------- */
+.notification-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+    padding: var(--space-3) var(--space-5);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.notification-filter {
+    padding: 2px var(--space-3);
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    background: none;
+    color: var(--color-ink-muted);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background 0.1s ease, color 0.1s ease, border-color 0.1s ease;
+    line-height: 1.6;
+}
+
+.notification-filter:hover {
+    background: var(--color-surface-alt, rgba(0,0,0,0.04));
+    color: var(--color-text);
+    border-color: var(--color-ink-muted);
+}
+
+.notification-filter--active {
+    background: var(--color-accent);
+    color: #fff;
+    border-color: var(--color-accent);
+}
+
+.notification-filter--active:hover {
+    background: var(--color-accent);
+    color: #fff;
+    border-color: var(--color-accent);
+}
+
+/* Settings-context overrides: no sticky/max-height constraints */
+.notifications-list--settings {
+    max-height: none;
+    overflow-y: visible;
+}
+
+.settings-activity-actions {
+    padding: var(--space-3) var(--space-5);
+    border-top: 1px solid var(--color-border);
+}
+
+/* --------------------------------------------------------------------------
+   6. Browser Fallbacks
    -------------------------------------------------------------------------- */
 @supports not (color: color-mix(in srgb, red 10%, transparent)) {
     .notification-item__icon--comment {


### PR DESCRIPTION
## Summary

- **Dashboard**: server-side filter chips (All / Comments / Replies / Readers / Sync) reload with `?type=X`; active chip highlighted; "Clear All" button removed from Dashboard entirely
- **Account/Settings**: new Activity Log card at bottom with identical filter pills; "Clear [Type]" (no confirm) when a filter is active; "Clear All" guarded by `confirm()` dialog when no filter; per-item dismiss works from both pages
- **CSS**: `.notification-filter` / `.notification-filter--active` pill styles and `.settings-activity-actions` footer strip added to `DraftView.Notifications.css`; version bumped to `v2026-08-29-1`

## Changes by layer

- **Infrastructure** (TDD): `GetByAuthorIdAndTypeAsync` + `DeleteByAuthorIdAndTypeAsync` on `IAuthorNotificationRepository` / `AuthorNotificationRepository` — 4 new tests
- **Application** (TDD): `GetNotificationsAsync(typeFilter?)` + `DismissNotificationsByTypeAsync` on `IDashboardService` / `DashboardService` — 4 new tests
- **Web** (wiring): `AuthorController.Dashboard(type?)`, `AccountController.Settings(type?)` + new `ClearNotifications` action; `IDashboardService` injected into `AccountController`
- **Refactor** (separate commit): `_NotificationItem.cshtml` partial extracted before feature work

## Test plan

- [ ] Build green: `dotnet build`
- [ ] Tests green: `dotnet test` — 1,293 total, 1,292 passed, 1 skipped
- [ ] Dashboard: filter chips visible; clicking a chip reloads filtered list; "All" clears filter; "Clear All" button absent
- [ ] Account/Settings: Activity Log card visible for author; filter pills work; "Clear Comments" removes only comments; "Clear All" requires confirm dialog
- [ ] Reader/Settings: Activity Log card not visible for reader accounts

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)