### PR TITLE
fix: Settings activity log replaced with checkbox filter + per-type clear

### DIFF
--- a/DraftView.Web/Controllers/AccountController.cs
+++ b/DraftView.Web/Controllers/AccountController.cs
@@ -460,7 +460,7 @@ public class AccountController(
     // Settings
     // ---------------------------------------------------------------------------
     [HttpGet]
-    public async Task<IActionResult> Settings(string? type = null)
+    public async Task<IActionResult> Settings()
     {
         var user = await GetCurrentUserAsync();
         if (user is null)
@@ -473,8 +473,6 @@ public class AccountController(
             user.Id,
             DraftView.Application.Contracts.UserEmailAccessPurpose.SelfServiceSettings));
 
-        NotificationEventType? typeFilter = Enum.TryParse<NotificationEventType>(type, out var parsed) ? parsed : null;
-
         var vm = new SettingsViewModel {
             DisplayName = user.DisplayName,
             Email = resolvedEmail,
@@ -485,8 +483,7 @@ public class AccountController(
             ProseFontSize = prefs?.ProseFontSize.ToString() ?? "Medium",
             ReaderBio = prefs?.ReaderBio,
             ReaderGenreInterests = prefs?.ReaderGenreInterests,
-            ReaderPace = prefs?.ReaderPace?.ToString(),
-            ActiveTypeFilter = typeFilter
+            ReaderPace = prefs?.ReaderPace?.ToString()
         };
 
         if (vm.IsAuthor)
@@ -494,7 +491,6 @@ public class AccountController(
             var connection = await GetDropboxConnectionAsync(user.Id);
             vm.DropboxStatus = connection?.Status.ToString();
             vm.DropboxAuthorisedAt = connection?.AuthorisedAt;
-            vm.Notifications = await dashboardService.GetNotificationsAsync(user.Id, typeFilter);
         }
 
         return View(vm);

--- a/DraftView.Web/Models/AccountViewModels.cs
+++ b/DraftView.Web/Models/AccountViewModels.cs
@@ -1,6 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using DraftView.Domain.Entities;
-using DraftView.Domain.Notifications;
 
 namespace DraftView.Web.Models;
 
@@ -67,8 +65,6 @@ public class SettingsViewModel
     public string? ReaderBio { get; set; }
     public string? ReaderGenreInterests { get; set; }
     public string? ReaderPace { get; set; }
-    public IReadOnlyList<AuthorNotification> Notifications { get; set; } = [];
-    public NotificationEventType? ActiveTypeFilter { get; set; }
 }
 
 public class UpdateReaderProfileViewModel

--- a/DraftView.Web/Views/Account/Settings.cshtml
+++ b/DraftView.Web/Views/Account/Settings.cshtml
@@ -1,5 +1,4 @@
-﻿@using DraftView.Domain.Notifications
-@model DraftView.Web.Models.SettingsViewModel
+﻿@model DraftView.Web.Models.SettingsViewModel
 @{
     ViewData["Title"] = "Account Settings";
 }
@@ -217,78 +216,65 @@
 
         @if (Model.IsAuthor)
         {
-            var activeLabel   = SettingsFilterLabel(Model.ActiveTypeFilter);
-            var allClass      = SettingsChipClass(Model.ActiveTypeFilter, null);
-            var commentClass  = SettingsChipClass(Model.ActiveTypeFilter, NotificationEventType.NewComment);
-            var replyClass    = SettingsChipClass(Model.ActiveTypeFilter, NotificationEventType.ReplyToAuthor);
-            var readerClass   = SettingsChipClass(Model.ActiveTypeFilter, NotificationEventType.ReaderJoined);
-            var syncClass     = SettingsChipClass(Model.ActiveTypeFilter, NotificationEventType.SyncCompleted);
             <div class="card settings-card">
                 <div class="card__header"><span class="card__title">Activity Log</span></div>
-
-                <div class="notification-filters">
-                    <a asp-action="Settings" class="@allClass">All</a>
-                    <a asp-action="Settings" asp-route-type="@NotificationEventType.NewComment"    class="@commentClass">Comments</a>
-                    <a asp-action="Settings" asp-route-type="@NotificationEventType.ReplyToAuthor" class="@replyClass">Replies</a>
-                    <a asp-action="Settings" asp-route-type="@NotificationEventType.ReaderJoined"  class="@readerClass">Readers</a>
-                    <a asp-action="Settings" asp-route-type="@NotificationEventType.SyncCompleted" class="@syncClass">Sync</a>
-                </div>
-
-                @if (Model.Notifications.Any())
-                {
-                    <ul class="notifications-list notifications-list--settings">
-                        @foreach (var n in Model.Notifications)
-                        {
-                            <li class="notification-item">
-                                @await Html.PartialAsync("_NotificationItem", n)
-                                <form asp-controller="Author" asp-action="DismissNotification" method="post" style="display:contents">
-                                    @Html.AntiForgeryToken()
-                                    <input type="hidden" name="notificationId" value="@n.Id" />
-                                    <button type="submit" class="notification-item__dismiss" aria-label="Dismiss">&#x2715;</button>
-                                </form>
-                            </li>
-                        }
+                <div class="card__body">
+                    <ul class="activity-clear-list">
+                        <li class="activity-clear-row">
+                            <label class="activity-clear-label">
+                                <input type="checkbox" class="activity-clear-check" checked />
+                                Comments
+                            </label>
+                            <form asp-action="ClearNotifications" method="post">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="type" value="NewComment" />
+                                <button type="submit" class="btn btn--ghost btn--sm">Clear</button>
+                            </form>
+                        </li>
+                        <li class="activity-clear-row">
+                            <label class="activity-clear-label">
+                                <input type="checkbox" class="activity-clear-check" checked />
+                                Replies
+                            </label>
+                            <form asp-action="ClearNotifications" method="post">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="type" value="ReplyToAuthor" />
+                                <button type="submit" class="btn btn--ghost btn--sm">Clear</button>
+                            </form>
+                        </li>
+                        <li class="activity-clear-row">
+                            <label class="activity-clear-label">
+                                <input type="checkbox" class="activity-clear-check" checked />
+                                Readers
+                            </label>
+                            <form asp-action="ClearNotifications" method="post">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="type" value="ReaderJoined" />
+                                <button type="submit" class="btn btn--ghost btn--sm">Clear</button>
+                            </form>
+                        </li>
+                        <li class="activity-clear-row">
+                            <label class="activity-clear-label">
+                                <input type="checkbox" class="activity-clear-check" checked />
+                                Sync
+                            </label>
+                            <form asp-action="ClearNotifications" method="post">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="type" value="SyncCompleted" />
+                                <button type="submit" class="btn btn--ghost btn--sm">Clear</button>
+                            </form>
+                        </li>
                     </ul>
-
                     <div class="settings-activity-actions">
-                        @if (Model.ActiveTypeFilter.HasValue)
-                        {
-                            <form asp-action="ClearNotifications" method="post" style="display:inline">
-                                @Html.AntiForgeryToken()
-                                <input type="hidden" name="type" value="@Model.ActiveTypeFilter" />
-                                <button type="submit" class="btn btn--ghost btn--sm">Clear @activeLabel</button>
-                            </form>
-                        }
-                        else
-                        {
-                            <form asp-action="ClearNotifications" method="post" style="display:inline"
-                                  onsubmit="return confirm('Clear all activity? This cannot be undone.')">
-                                @Html.AntiForgeryToken()
-                                <button type="submit" class="btn btn--ghost btn--sm">Clear All</button>
-                            </form>
-                        }
+                        <form asp-action="ClearNotifications" method="post"
+                              onsubmit="return confirm('Clear all activity? This cannot be undone.')">
+                            @Html.AntiForgeryToken()
+                            <button type="submit" class="btn btn--ghost btn--sm">Clear All</button>
+                        </form>
                     </div>
-                }
-                else
-                {
-                    <p class="settings-hint" style="margin-top:var(--space-4);">No activity to show.</p>
-                }
+                </div>
             </div>
         }
 
     </div>
 </div>
-
-@functions {
-    static string SettingsChipClass(NotificationEventType? active, NotificationEventType? chip) =>
-        "notification-filter" + (active == chip ? " notification-filter--active" : "");
-
-    static string? SettingsFilterLabel(NotificationEventType? type) => type switch
-    {
-        NotificationEventType.NewComment    => "Comments",
-        NotificationEventType.ReplyToAuthor => "Replies",
-        NotificationEventType.ReaderJoined  => "Readers",
-        NotificationEventType.SyncCompleted => "Sync",
-        _                                   => null
-    };
-}

--- a/DraftView.Web/wwwroot/css/DraftView.Notifications.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Notifications.css
@@ -218,6 +218,40 @@ a.notification-item__title:hover {
     border-top: 1px solid var(--color-border);
 }
 
+.activity-clear-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.activity-clear-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-5);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.activity-clear-row:last-child {
+    border-bottom: none;
+}
+
+.activity-clear-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--color-text);
+    cursor: default;
+}
+
+.activity-clear-check {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--color-accent);
+    cursor: default;
+}
+
 /* --------------------------------------------------------------------------
    6. Browser Fallbacks
    -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Corrects the Settings page implementation from PR #87. The full activity log (notification list + per-item dismiss) was incorrectly placed on Settings — it belongs only on the Dashboard.

- **Settings Activity Log card** now shows a checkbox row per notification type (Comments, Replies, Readers, Sync), each with a scoped **Clear** button (no confirmation needed)
- A **Clear All** button at the bottom is guarded by `confirm()`
- The full notification list, per-item dismiss, and filter chip navigation have been removed from Settings
- `SettingsViewModel.Notifications` and `ActiveTypeFilter` removed (no longer needed)
- `AccountController.Settings` no longer loads notifications

## Test plan

- [ ] `dotnet test` — 1,293 total, 1,292 passed, 1 skipped
- [ ] Settings page shows Activity Log card with four checkbox rows and Clear buttons
- [ ] Clicking Clear next to Comments removes only comment notifications
- [ ] Clear All prompts confirm dialog before clearing
- [ ] Dashboard activity log is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)