### PR TITLE
feat: hover tooltip on read count listing reader names (#91)

### DIFF
--- a/DraftView.Application.Tests/Services/SectionManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/SectionManagementServiceTests.cs
@@ -215,4 +215,30 @@ public class SectionManagementServiceTests
         Assert.True(result!.CommentAuthorNames.ContainsKey(readerId));
         Assert.Equal("Alice", result.CommentAuthorNames[readerId]);
     }
+
+    [Fact]
+    public async Task GetSectionDetailAsync_PopulatesReaderNamesFromReadEvents()
+    {
+        var project   = Project.Create("Book", "/path", Guid.NewGuid(), "root-uuid");
+        var scene     = Section.CreateDocument(project.Id, "s1", "Scene 1", null, 0, "<p>a</p>", "h1", null);
+        var authorId  = Guid.NewGuid();
+        var reader1Id = Guid.NewGuid();
+        var reader2Id = Guid.NewGuid();
+        var reader1   = User.Create("r1@example.test", "Hilary", Role.BetaReader);
+        var reader2   = User.Create("r2@example.test", "Becca",  Role.BetaReader);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
+        _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default)).ReturnsAsync([]);
+        _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
+            .ReturnsAsync([ReadEvent.Create(scene.Id, reader1Id), ReadEvent.Create(scene.Id, reader2Id)]);
+        _userRepository.Setup(r => r.GetByIdAsync(reader1Id, default)).ReturnsAsync(reader1);
+        _userRepository.Setup(r => r.GetByIdAsync(reader2Id, default)).ReturnsAsync(reader2);
+
+        var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.ReaderNames.Count);
+        Assert.Contains("Hilary", result.ReaderNames);
+        Assert.Contains("Becca",  result.ReaderNames);
+    }
 }

--- a/DraftView.Application/Services/SectionManagementService.cs
+++ b/DraftView.Application/Services/SectionManagementService.cs
@@ -129,13 +129,21 @@ public class SectionManagementService(
             nameMap[uid] = u?.DisplayName ?? "Unknown";
         }
 
+        var readerNames = new List<string>();
+        foreach (var uid in events.Select(e => e.UserId).Distinct())
+        {
+            var u = await userRepository.GetByIdAsync(uid, ct);
+            readerNames.Add(u?.DisplayName ?? "Unknown");
+        }
+
         return new SectionDetailDto
         {
             Section            = section,
             ChapterTitle       = chapterTitle,
             Comments           = comments,
             CommentAuthorNames = nameMap,
-            ReadCount          = events.Count
+            ReadCount          = events.Count,
+            ReaderNames        = readerNames
         };
     }
 

--- a/DraftView.Domain/Interfaces/Services/ISectionManagementService.cs
+++ b/DraftView.Domain/Interfaces/Services/ISectionManagementService.cs
@@ -36,6 +36,7 @@ public sealed class SectionDetailDto
     public required IReadOnlyList<Comment> Comments { get; init; }
     public required IReadOnlyDictionary<Guid, string> CommentAuthorNames { get; init; }
     public required int ReadCount { get; init; }
+    public required IReadOnlyList<string> ReaderNames { get; init; }
 }
 
 public interface ISectionManagementService

--- a/DraftView.Web/Controllers/AuthorController.cs
+++ b/DraftView.Web/Controllers/AuthorController.cs
@@ -739,7 +739,8 @@ public class AuthorController(
             ChapterTitle       = detail.ChapterTitle,
             Comments           = detail.Comments,
             ReadCount          = detail.ReadCount,
-            CommentAuthorNames = detail.CommentAuthorNames
+            CommentAuthorNames = detail.CommentAuthorNames,
+            ReaderNames        = detail.ReaderNames
         });
     }
 

--- a/DraftView.Web/Models/AuthorViewModels.cs
+++ b/DraftView.Web/Models/AuthorViewModels.cs
@@ -24,6 +24,7 @@ public class SectionViewModel
     public IReadOnlyList<Comment> Comments { get; set; } = [];
     public IReadOnlyDictionary<Guid, string> CommentAuthorNames { get; set; } = new Dictionary<Guid, string>();
     public int ReadCount { get; set; }
+    public IReadOnlyList<string> ReaderNames { get; set; } = [];
 }
 
 public class ReaderRowViewModel

--- a/DraftView.Web/Views/Author/Section.cshtml
+++ b/DraftView.Web/Views/Author/Section.cshtml
@@ -16,7 +16,7 @@
     <p class="author-section-view__meta">
         <span>@(Model.Section.ScrivenerStatus ?? "-")</span>
         <span class="author-section-view__meta-sep">|</span>
-        <span>Read by @Model.ReadCount reader(s)</span>
+        <span title="@(Model.ReaderNames.Any() ? string.Join(", ", Model.ReaderNames) : "")">Read by @Model.ReadCount reader(s)</span>
     </p>
 
     <div class="card author-section-view__content-card">


### PR DESCRIPTION
## Summary

Hovering over `Read by N reader(s)` on the Author/Section page now shows a browser native tooltip listing the display names of those readers (e.g. `Hilary, Becca`).

## Changes

- `SectionDetailDto`: new `ReaderNames` property
- `SectionManagementService.GetSectionDetailAsync`: looks up display name for each unique `UserId` in the read events (reuses the existing `userRepository` already in scope)
- `SectionViewModel`: new `ReaderNames` property
- `AuthorController.Section`: maps `ReaderNames` through
- `Section.cshtml`: adds `title="..."` attribute to the read count span

## Test plan

- [ ] `dotnet test` — 1,297 total, 1,296 passed, 1 skipped
- [ ] Open a section that has been read; hover `Read by N reader(s)` — tooltip shows reader names
- [ ] Section with 0 reads — no tooltip (empty title attribute)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)