### PR TITLE
fix: resolve domain user via email claim when Identity UserName is custom username (#96)

### DIFF
--- a/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
@@ -920,6 +920,78 @@ public class ReaderControllerTests
         Assert.Equal("MobileChapters", view.ViewName);
     }
 
+    /// <summary>
+    /// Verifies that Dashboard resolves the domain user via ClaimTypes.Email when
+    /// the Identity UserName is a chosen username, not the account email.
+    /// Before the fix, GetByEmailAsync("JennyMoss") returns null → Forbid().
+    /// After the fix, GetByEmailAsync uses the email claim → user found → ViewResult.
+    /// </summary>
+    [Fact]
+    public async Task Dashboard_ReaderWithChosenUsername_ResolvesUserViaEmailClaim()
+    {
+        var user = User.Create("jenny@example.test", "Jenny", Role.BetaReader);
+        user.Activate();
+
+        userRepo.Setup(r => r.GetByEmailAsync("jenny@example.test", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        readerAccessRepo.Setup(r => r.GetByReaderIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        accessRequestRepo.Setup(r => r.GetVisibleByReaderIdAsync(user.Id, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        readerDashboardService
+            .Setup(r => r.GetReaderChapterCommentCountsAsync(user.Id, It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, int>());
+        readerDashboardService
+            .Setup(r => r.GetCrossProjectResumeTargetAsync(user.Id, It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ResumeTarget?)null);
+
+        var sut = CreateSutWithChosenUsername("JennyMoss", "jenny@example.test", "Mozilla/5.0");
+
+        var result = await sut.Dashboard();
+
+        Assert.IsType<ViewResult>(result);
+    }
+
+    private ReaderController CreateSutWithChosenUsername(string username, string email, string userAgent)
+    {
+        var controller = new ReaderController(
+            projectRepo.Object,
+            sectionRepo.Object,
+            commentService.Object,
+            progressService.Object,
+            userRepo.Object,
+            prefsRepo.Object,
+            readerAccessRepo.Object,
+            sectionVersionRepo.Object,
+            readEventRepo.Object,
+            sectionDiffService.Object,
+            humanOverrideService.Object,
+            passageAnchorService.Object,
+            CommentDisplayService,
+            accessRequestRepo.Object,
+            accessRequestService.Object,
+            readerDashboardService.Object,
+            logger.Object);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(
+                    new ClaimsIdentity(
+                        [
+                            new Claim(ClaimTypes.Name, username),
+                            new Claim(ClaimTypes.Email, email)
+                        ],
+                        "TestAuth"))
+            }
+        };
+
+        controller.ControllerContext.HttpContext.Request.Headers.UserAgent = userAgent;
+
+        return controller;
+    }
+
     private ReaderController CreateSut(User user, string userAgent)
     {
         var controller = new ReaderController(

--- a/DraftView.Web/Controllers/BaseController.cs
+++ b/DraftView.Web/Controllers/BaseController.cs
@@ -24,7 +24,11 @@ public abstract class BaseController(IUserRepository userRepo) : Controller
     {
         if (UserResolved) return CurrentUser;
 
-        var email    = User.Identity?.Name;
+        // Prefer the explicit email claim (added by DraftViewUserClaimsPrincipalFactory).
+        // Fall back to Identity.Name for sessions that pre-date the factory deployment
+        // and for users whose UserName already equals their email.
+        var email = User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value
+                    ?? User.Identity?.Name;
         CurrentUser = email is null ? null : await userRepo.GetByEmailAsync(email, ct);
         UserResolved = true;
         return CurrentUser;


### PR DESCRIPTION
## Summary

- `GetCurrentUserAsync()` in `BaseController` used `User.Identity.Name` (the Identity `UserName`) as the email for HMAC lookup. Readers who chose a custom username at invitation acceptance (e.g. `JennyMoss`) had `UserName ≠ Email`, so the lookup returned `null` and every controller action returned `Forbid()` → AccessDenied.
- The default Identity `UserClaimsPrincipalFactory` already includes a `ClaimTypes.Email` claim in every sign-in cookie. The fix changes `GetCurrentUserAsync()` to prefer that claim over `User.Identity.Name`.
- All existing sessions where `UserName == Email` are unaffected: the email claim and `Identity.Name` hold the same value.

**Confirmed on production:** `AspNetUsers` shows `UserName=JennyMoss`, `Email=jennyclarke2010@hotmail.co.uk`. She has the `BetaReader` Identity role and a valid `ReaderAccess` grant for The Fractured Lattice. The only blocker was the failed domain-user lookup.

**Covers all sign-in paths automatically:** login, impersonation, and invitation acceptance all go through `CreateUserPrincipalAsync`, which calls the built-in factory that adds `ClaimTypes.Email`.

## Files changed

- `DraftView.Web/Controllers/BaseController.cs` — two-line change to `GetCurrentUserAsync()`
- `DraftView.Web.Tests/Controllers/ReaderControllerTests.cs` — regression test (RED before fix, GREEN after)

## Test plan

- [x] New test `Dashboard_ReaderWithChosenUsername_ResolvesUserViaEmailClaim` was RED before the fix and GREEN after
- [x] Full suite: 1,297 passed, 0 failed, 1 skipped (SMTP integration test, expected)
- [ ] Deploy and re-impersonate Jenny — verify she can reach the reader dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)