### PR TITLE
fix: replace select[multiple] dual-list with checkbox toggle list (#99)

### DIFF
--- a/DraftView.Web/Views/Author/ManageReaderAccess.cshtml
+++ b/DraftView.Web/Views/Author/ManageReaderAccess.cshtml
@@ -1,4 +1,4 @@
-﻿@using DraftView.Web.Infrastructure
+@using DraftView.Web.Infrastructure
 @model DraftView.Web.Models.ReaderAccessViewModel
 @{ ViewData["Title"] = "Manage Project Access"; }
 
@@ -26,37 +26,32 @@
     @Html.AntiForgeryToken()
     <input type="hidden" name="readerId" value="@Model.ReaderId" />
 
-    <div class="dual-list">
-        <div class="dual-list__panel">
-            <div class="dual-list__header">No Access</div>
-            <select id="no-access" multiple class="dual-list__list" size="12">
-                @foreach (var p in Model.ProjectsWithoutAccess)
-                {
-                    <option value="@p.Id">@p.Name</option>
-                }
-            </select>
-        </div>
-
-        <div class="dual-list__controls">
-            <button type="button" class="btn btn--secondary dual-list__arrow" id="grant-btn" title="Grant access">&#8594;</button>
-            <button type="button" class="btn btn--secondary dual-list__arrow" id="revoke-btn" title="Revoke access">&#8592;</button>
-        </div>
-
-        <div class="dual-list__panel">
-            <div class="dual-list__header">Has Access</div>
-            <select id="has-access" multiple class="dual-list__list" size="12">
-                @foreach (var p in Model.ProjectsWithAccess)
-                {
-                    <option value="@p.Id">@p.Name</option>
-                }
-            </select>
-        </div>
+    <div class="access-list">
+        @foreach (var p in Model.ProjectsWithAccess)
+        {
+            <label class="access-list__item">
+                <input type="checkbox" class="access-list__checkbox" value="@p.Id" checked />
+                <span class="access-list__name">@p.Name</span>
+                <span class="badge badge--success access-list__badge">Has access</span>
+            </label>
+        }
+        @foreach (var p in Model.ProjectsWithoutAccess)
+        {
+            <label class="access-list__item">
+                <input type="checkbox" class="access-list__checkbox" value="@p.Id" />
+                <span class="access-list__name">@p.Name</span>
+            </label>
+        }
+        @if (!Model.ProjectsWithAccess.Any() && !Model.ProjectsWithoutAccess.Any())
+        {
+            <p class="access-list__empty">No projects found.</p>
+        }
     </div>
 
     <div id="grant-inputs"></div>
     <div id="revoke-inputs"></div>
 
-    <div class="dual-list__actions">
+    <div class="access-list__actions">
         <button type="submit" class="btn btn--primary">
             @Html.Raw(Icons.Save()) Save
         </button>
@@ -67,45 +62,49 @@
 </form>
 
 <style>
-.dual-list {
-    display: flex;
-    gap: var(--space-4);
-    align-items: center;
+.access-list {
     margin-top: var(--space-6);
-}
-.dual-list__panel {
-    flex: 1;
-    min-width: 0;
-}
-.dual-list__header {
-    font-size: var(--text-xs);
-    font-weight: var(--font-bold);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--color-text-muted);
-    margin-bottom: var(--space-2);
-}
-.dual-list__list {
-    width: 100%;
     border: 1px solid var(--color-border-strong);
     border-radius: var(--radius);
-    padding: var(--space-2);
-    font-size: var(--text-sm);
+    overflow: hidden;
+}
+.access-list__item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    cursor: pointer;
+    border-bottom: 1px solid var(--color-border);
     background: var(--color-surface);
-    min-height: 240px;
+    transition: background 0.15s;
+}
+.access-list__item:last-child {
+    border-bottom: none;
+}
+.access-list__item:hover {
+    background: var(--color-surface-raised);
+}
+.access-list__checkbox {
+    width: 1.1rem;
+    height: 1.1rem;
+    flex-shrink: 0;
+    accent-color: var(--color-primary);
     cursor: pointer;
 }
-.dual-list__controls {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-3);
+.access-list__name {
+    flex: 1;
+    font-size: var(--text-sm);
+}
+.access-list__badge {
+    font-size: var(--text-xs);
     flex-shrink: 0;
 }
-.dual-list__arrow {
-    font-size: var(--text-lg);
-    padding: var(--space-2) var(--space-4);
+.access-list__empty {
+    padding: var(--space-4);
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
 }
-.dual-list__actions {
+.access-list__actions {
     display: flex;
     gap: var(--space-3);
     margin-top: var(--space-6);
@@ -114,35 +113,18 @@
 </style>
 
 <script>
-document.getElementById('grant-btn').addEventListener('click', function () {
-    moveSelected('no-access', 'has-access');
-});
-document.getElementById('revoke-btn').addEventListener('click', function () {
-    moveSelected('has-access', 'no-access');
-});
-
-function moveSelected(fromId, toId) {
-    const from = document.getElementById(fromId);
-    const to   = document.getElementById(toId);
-    Array.from(from.selectedOptions).forEach(opt => to.appendChild(opt));
-}
-
 document.getElementById('access-form').addEventListener('submit', function () {
     const grantContainer  = document.getElementById('grant-inputs');
     const revokeContainer = document.getElementById('revoke-inputs');
     grantContainer.innerHTML  = '';
     revokeContainer.innerHTML = '';
 
-    Array.from(document.getElementById('has-access').options).forEach(opt => {
-        const input = document.createElement('input');
-        input.type = 'hidden'; input.name = 'grantIds'; input.value = opt.value;
-        grantContainer.appendChild(input);
-    });
-
-    Array.from(document.getElementById('no-access').options).forEach(opt => {
-        const input = document.createElement('input');
-        input.type = 'hidden'; input.name = 'revokeIds'; input.value = opt.value;
-        revokeContainer.appendChild(input);
+    document.querySelectorAll('.access-list__checkbox').forEach(function (cb) {
+        var input = document.createElement('input');
+        input.type  = 'hidden';
+        input.name  = cb.checked ? 'grantIds' : 'revokeIds';
+        input.value = cb.value;
+        (cb.checked ? grantContainer : revokeContainer).appendChild(input);
     });
 });
 </script>


### PR DESCRIPTION
## Summary

iOS Safari does not support `<select multiple>` — both panels showed \"0 Items\" on iPhone even though 2 projects exist in production. Replaced the entire dual-list widget with a checkbox toggle list that works on every platform.

**Before:** Two `<select multiple size="12">` boxes with arrow buttons — broken on iOS.

**After:** Single bordered list; each row is a `<label>` with a native checkbox. Checked = grant access, unchecked = revoke access. Submit handler collects into `grantIds`/`revokeIds` hidden inputs, preserving the existing `UpdateReaderAccess` POST contract exactly.

No controller, service, or model changes. Pure view replacement.

## Test plan

- [ ] Desktop: verify books appear, toggling grants/revokes works, Save persists correctly
- [ ] iOS Safari: verify books appear in the list and toggling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)