### PR TITLE
feat: comment count pill on reader dashboard links to chapter comments (#100)

### DIFF
--- a/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
+++ b/DraftView.Web/Views/Onboarding/ConfirmEmailResult.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-30-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/EmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/EmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-30-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/FAQ.cshtml
+++ b/DraftView.Web/Views/Onboarding/FAQ.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-30-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/Join.cshtml
+++ b/DraftView.Web/Views/Onboarding/Join.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-30-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderEmailSent.cshtml
@@ -11,9 +11,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-30-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
+++ b/DraftView.Web/Views/Onboarding/ReaderJoin.cshtml
@@ -12,9 +12,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="/css/DraftView.Light.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-30-1" />
     <link rel="icon" type="image/png" href="/images/DraftView.Logo.web.png" />
     <style>
         *, *::before, *::after { box-sizing: border-box; }

--- a/DraftView.Web/Views/Reader/DesktopDashboard.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopDashboard.cshtml
@@ -126,7 +126,8 @@ else
                                                 <td class="reader-dashboard__cell reader-dashboard__cell--comments">
                                                     @if (item.ReaderCommentCount > 0)
                                                     {
-                                                        <span class="reader-dashboard__comment-count">@item.ReaderCommentCount</span>
+                                                        <a href="@Url.Action("Read", "Reader", new { id = item.Chapter.Id })#chapter-comments"
+                                                           class="reader-dashboard__comment-count">@item.ReaderCommentCount</a>
                                                     }
                                                     else
                                                     {

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-29-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-29-1" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-30-1" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-29-1" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-30-1" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-29-1";
+    --css-version: "v2026-08-30-1";
     /* Banner image focal point — overridden per theme for images that are not 3.2:1 panoramic.
        Default suits Noir / Crime / Contemporary (all correctly proportioned at ~2240x700).
        Historic and Adventure override this until replacement panoramic banners are available. */

--- a/DraftView.Web/wwwroot/css/DraftView.DesktopReader.css
+++ b/DraftView.Web/wwwroot/css/DraftView.DesktopReader.css
@@ -1101,6 +1101,7 @@
     font-size: var(--text-xs);
     font-weight: var(--font-bold);
     text-align: center;
+    text-decoration: none;
 }
 
 .reader-dashboard__comment-none {


### PR DESCRIPTION
## Summary

- The comment count pill on `/Reader/Dashboard` was a non-interactive `<span>`. Changed it to an `<a>` that links to `/Reader/Read/{chapterId}#chapter-comments`, so readers can jump directly to their comments from the dashboard.
- Added `text-decoration: none` to `.reader-dashboard__comment-count` in `DraftView.DesktopReader.css` so the pill retains its rounded badge appearance as an anchor element.
- CSS version bumped to `v2026-08-30-1`.

No controller, service, or model changes — pure view and CSS.

## Test plan

- [ ] Dashboard: verify comment count pills are clickable and scroll to `#chapter-comments` on the Read page
- [ ] Dashboard: verify zero-comment rows still show `—` (unchanged)
- [x] Full suite: 1,300 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)