### PR TITLE
CHANGE-024: Reader version diff -- What's Changed

### DIFF
--- a/DraftView.Application.Tests/Services/ChangeClassificationServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ChangeClassificationServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using DraftView.Application.Services;
+using DraftView.Application.Services;
 using DraftView.Domain.Diff;
 using DraftView.Domain.Enumerations;
 
@@ -6,12 +6,18 @@ namespace DraftView.Application.Tests.Services;
 
 /// <summary>
 /// Tests for ChangeClassificationService.Classify.
-/// Covers threshold-based classification from paragraph diffs.
-/// Excludes: diff generation itself (covered in HtmlDiffService tests), persistence wiring, and UI rendering.
+/// Covers word-level threshold classification: Trivial, Polish, Revision, Rewrite.
+/// Trivial threshold: wordsChanged less than max(5, ceil(totalWords * 0.01)).
+/// Polish: 1-10%. Revision: 10-40%. Rewrite: greater than 40%.
+/// Excludes: diff generation (HtmlDiffServiceTests), persistence, UI rendering.
 /// </summary>
 public class ChangeClassificationServiceTests
 {
     private readonly ChangeClassificationService _sut = new();
+
+    // ---------------------------------------------------------------------------
+    // Null / empty
+    // ---------------------------------------------------------------------------
 
     [Fact]
     public void Classify_WithNullParagraphs_ReturnsNull()
@@ -30,82 +36,202 @@ public class ChangeClassificationServiceTests
     }
 
     [Fact]
-    public void Classify_WithNoChanges_ReturnsNull()
+    public void Classify_WithNoWordChanges_ReturnsNull()
     {
-        var result = _sut.Classify(CreateParagraphs(unchanged: 10, added: 0, removed: 0));
+        // 200-word scene, nothing changed
+        var paragraphs = new[]
+        {
+            Unchanged(totalWords: 200)
+        };
+
+        var result = _sut.Classify(paragraphs);
 
         Assert.Null(result);
     }
 
+    // ---------------------------------------------------------------------------
+    // Trivial
+    // ---------------------------------------------------------------------------
+
     [Fact]
-    public void Classify_WithMinorChanges_ReturnsPolish()
+    public void Classify_WithFourWordsChanged_SmallScene_ReturnsTrivial()
     {
-        var result = _sut.Classify(CreateParagraphs(unchanged: 9, added: 1, removed: 0));
+        // Scene: 200 words. Threshold: max(5, ceil(2)) = 5. Changed: 4 < 5 -> Trivial.
+        var paragraphs = new[]
+        {
+            Unchanged(totalWords: 196),
+            Modified(wordsAdded: 2, wordsRemoved: 2, totalWords: 198)
+        };
+
+        var result = _sut.Classify(paragraphs);
+
+        Assert.Equal(ChangeClassification.Trivial, result);
+    }
+
+    [Fact]
+    public void Classify_WithEightWordsChanged_LargeScene_ReturnsTrivial()
+    {
+        // Scene: 1000 words. Threshold: max(5, ceil(10)) = 10. Changed: 8 < 10 -> Trivial.
+        var paragraphs = new[]
+        {
+            Unchanged(totalWords: 996),
+            Modified(wordsAdded: 4, wordsRemoved: 4, totalWords: 1000)
+        };
+
+        var result = _sut.Classify(paragraphs);
+
+        Assert.Equal(ChangeClassification.Trivial, result);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Polish (1% to less than 10%)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Classify_WithPolishChanges_ReturnsPolish()
+    {
+        // Scene: 200 words. Changed: 10 words = 5%. 5% is in [1%, 10%) -> Polish.
+        var paragraphs = new[]
+        {
+            Unchanged(totalWords: 190),
+            Modified(wordsAdded: 5, wordsRemoved: 5, totalWords: 200)
+        };
+
+        var result = _sut.Classify(paragraphs);
 
         Assert.Equal(ChangeClassification.Polish, result);
     }
 
     [Fact]
-    public void Classify_WithModerateChanges_ReturnsRevision()
+    public void Classify_WithFiveWordsChanged_SmallScene_ReturnsPolish()
     {
-        var result = _sut.Classify(CreateParagraphs(unchanged: 7, added: 2, removed: 1));
+        // Scene: 200 words. Trivial threshold = max(5, 2) = 5. Changed: 5 = exactly at threshold -> Polish (not Trivial).
+        var paragraphs = new[]
+        {
+            Unchanged(totalWords: 195),
+            Modified(wordsAdded: 2, wordsRemoved: 3, totalWords: 200)
+        };
+
+        var result = _sut.Classify(paragraphs);
+
+        Assert.Equal(ChangeClassification.Polish, result);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Revision (10% to less than 40%)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Classify_WithRevisionChanges_ReturnsRevision()
+    {
+        // Scene: 200 words. Changed: 50 words = 25% -> Revision.
+        var paragraphs = new[]
+        {
+            Unchanged(totalWords: 150),
+            Modified(wordsAdded: 25, wordsRemoved: 25, totalWords: 200)
+        };
+
+        var result = _sut.Classify(paragraphs);
 
         Assert.Equal(ChangeClassification.Revision, result);
     }
 
     [Fact]
-    public void Classify_WithMajorChanges_ReturnsRewrite()
+    public void Classify_AtPolishRevisionBoundary_ReturnsRevision()
     {
-        var result = _sut.Classify(CreateParagraphs(unchanged: 3, added: 4, removed: 3));
+        // Scene: 100 words total. Changed: 10 words = exactly 10% -> Revision.
+        // No Unchanged paragraph so total = Modified.TotalWords only.
+        var paragraphs = new[]
+        {
+            Modified(wordsAdded: 5, wordsRemoved: 5, totalWords: 100)
+        };
+
+        var result = _sut.Classify(paragraphs);
+
+        Assert.Equal(ChangeClassification.Revision, result);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Rewrite (40% or more)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Classify_WithRewriteChanges_ReturnsRewrite()
+    {
+        // Scene: 200 words. Changed: 120 words = 60% -> Rewrite.
+        var paragraphs = new[]
+        {
+            Unchanged(totalWords: 80),
+            Modified(wordsAdded: 60, wordsRemoved: 60, totalWords: 200)
+        };
+
+        var result = _sut.Classify(paragraphs);
 
         Assert.Equal(ChangeClassification.Rewrite, result);
     }
 
     [Fact]
-    public void Classify_AtExactRevisionThreshold_ReturnsRevision()
+    public void Classify_AtRevisionRewriteBoundary_ReturnsRewrite()
     {
-        var result = _sut.Classify(CreateParagraphs(unchanged: 8, added: 2, removed: 0));
+        // Scene: 100 words total. Changed: 40 words = exactly 40% -> Rewrite.
+        // No Unchanged paragraph so total = Modified.TotalWords only.
+        var paragraphs = new[]
+        {
+            Modified(wordsAdded: 20, wordsRemoved: 20, totalWords: 100)
+        };
 
-        Assert.Equal(ChangeClassification.Revision, result);
-    }
-
-    [Fact]
-    public void Classify_AtExactRewriteThreshold_ReturnsRewrite()
-    {
-        var result = _sut.Classify(CreateParagraphs(unchanged: 4, added: 6, removed: 0));
+        var result = _sut.Classify(paragraphs);
 
         Assert.Equal(ChangeClassification.Rewrite, result);
     }
 
     [Fact]
-    public void Classify_WithOnlyAdditions_ClassifiesCorrectly()
+    public void Classify_WithOnlyAddedParagraphs_ClassifiesFromWordCount()
     {
-        var result = _sut.Classify(CreateParagraphs(unchanged: 8, added: 2, removed: 0));
+        // Entire new paragraph added: 50 words added to a 200-word scene = 25% -> Revision.
+        var paragraphs = new[]
+        {
+            Unchanged(totalWords: 200),
+            Added(wordsAdded: 50)
+        };
+
+        var result = _sut.Classify(paragraphs);
 
         Assert.Equal(ChangeClassification.Revision, result);
     }
 
     [Fact]
-    public void Classify_WithOnlyRemovals_ClassifiesCorrectly()
+    public void Classify_WithOnlyRemovedParagraphs_ClassifiesFromWordCount()
     {
-        var result = _sut.Classify(CreateParagraphs(unchanged: 8, added: 0, removed: 2));
+        // 80 words removed from a 200-word scene (now 120 words). 80/120 = 67% -> Rewrite.
+        var paragraphs = new[]
+        {
+            Unchanged(totalWords: 120),
+            Removed(wordsRemoved: 80)
+        };
 
-        Assert.Equal(ChangeClassification.Revision, result);
+        var result = _sut.Classify(paragraphs);
+
+        Assert.Equal(ChangeClassification.Rewrite, result);
     }
 
-    private static IReadOnlyList<ParagraphDiffResult> CreateParagraphs(int unchanged, int added, int removed)
-    {
-        var paragraphs = new List<ParagraphDiffResult>();
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
 
-        for (var i = 0; i < unchanged; i++)
-            paragraphs.Add(new ParagraphDiffResult($"unchanged-{i}", $"<p>unchanged-{i}</p>", DiffResultType.Unchanged));
+    private static ParagraphDiffResult Unchanged(int totalWords)
+        => new("unchanged", "<p>unchanged</p>", DiffResultType.Unchanged,
+               wordsAdded: 0, wordsRemoved: 0, totalWords: totalWords);
 
-        for (var i = 0; i < added; i++)
-            paragraphs.Add(new ParagraphDiffResult($"added-{i}", $"<p>added-{i}</p>", DiffResultType.Added));
+    private static ParagraphDiffResult Modified(int wordsAdded, int wordsRemoved, int totalWords)
+        => new("modified", "<p>modified</p>", DiffResultType.Modified,
+               wordsAdded: wordsAdded, wordsRemoved: wordsRemoved, totalWords: totalWords);
 
-        for (var i = 0; i < removed; i++)
-            paragraphs.Add(new ParagraphDiffResult($"removed-{i}", $"<p>removed-{i}</p>", DiffResultType.Removed));
+    private static ParagraphDiffResult Added(int wordsAdded)
+        => new("added", "<p>added</p>", DiffResultType.Added,
+               wordsAdded: wordsAdded, wordsRemoved: 0, totalWords: wordsAdded);
 
-        return paragraphs;
-    }
+    private static ParagraphDiffResult Removed(int wordsRemoved)
+        => new("removed", "<p>removed</p>", DiffResultType.Removed,
+               wordsAdded: 0, wordsRemoved: wordsRemoved, totalWords: 0);
 }

--- a/DraftView.Application.Tests/Services/HtmlDiffServiceTests.cs
+++ b/DraftView.Application.Tests/Services/HtmlDiffServiceTests.cs
@@ -99,37 +99,131 @@ public class HtmlDiffServiceTests
     }
 
     [Fact]
-    public void Compute_ChangedParagraph_DetectsRemovalAndAddition()
+    public void Compute_SingleChangedParagraph_ProducesModified()
     {
-        var from = "<p>Hello</p>";
-        var to = "<p>World</p>";
+        var from = "<p>Hello world</p>";
+        var to = "<p>Hello earth</p>";
 
         var result = _sut.Compute(from, to);
 
-        Assert.Equal(2, result.Count);
-        Assert.Equal(DiffResultType.Removed, result[0].Type);
-        Assert.Equal("Hello", result[0].Text);
-        Assert.Equal(DiffResultType.Added, result[1].Type);
-        Assert.Equal("World", result[1].Text);
+        Assert.Single(result);
+        Assert.Equal(DiffResultType.Modified, result[0].Type);
+    }
+
+    [Fact]
+    public void Compute_ModifiedParagraph_HtmlContainsDelForRemovedWord()
+    {
+        var from = "<p>Hello world</p>";
+        var to = "<p>Hello earth</p>";
+
+        var result = _sut.Compute(from, to);
+
+        Assert.Contains("<del>world</del>", result[0].Html);
+    }
+
+    [Fact]
+    public void Compute_ModifiedParagraph_HtmlContainsInsForInsertedWord()
+    {
+        var from = "<p>Hello world</p>";
+        var to = "<p>Hello earth</p>";
+
+        var result = _sut.Compute(from, to);
+
+        Assert.Contains("<ins>earth</ins>", result[0].Html);
+    }
+
+    [Fact]
+    public void Compute_ModifiedParagraph_PopulatesWordCounts()
+    {
+        var from = "<p>Hello world</p>";
+        var to = "<p>Hello earth</p>";
+
+        var result = _sut.Compute(from, to);
+
+        Assert.Equal(1, result[0].WordsAdded);
+        Assert.Equal(1, result[0].WordsRemoved);
+    }
+
+    [Fact]
+    public void Compute_UnchangedParagraph_HasZeroWordChanges()
+    {
+        var from = "<p>Hello world</p>";
+        var to = "<p>Hello world</p>";
+
+        var result = _sut.Compute(from, to);
+
+        Assert.Equal(0, result[0].WordsAdded);
+        Assert.Equal(0, result[0].WordsRemoved);
+    }
+
+    [Fact]
+    public void Compute_UnchangedParagraph_HasTotalWordsPopulated()
+    {
+        var from = "<p>Hello world today</p>";
+        var to = "<p>Hello world today</p>";
+
+        var result = _sut.Compute(from, to);
+
+        Assert.Equal(3, result[0].TotalWords);
+    }
+
+    [Fact]
+    public void Compute_AddedParagraph_HasWordsAddedEqualToWordCount()
+    {
+        var from = "<p>Hello</p>";
+        var to = "<p>Hello</p><p>Brand new paragraph</p>";
+
+        var result = _sut.Compute(from, to);
+
+        var added = result.Single(r => r.Type == DiffResultType.Added);
+        Assert.Equal(3, added.WordsAdded);
+        Assert.Equal(0, added.WordsRemoved);
+        Assert.Equal(3, added.TotalWords);
+    }
+
+    [Fact]
+    public void Compute_RemovedParagraph_HasWordsRemovedEqualToWordCount()
+    {
+        var from = "<p>Hello</p><p>Gone forever now</p>";
+        var to = "<p>Hello</p>";
+
+        var result = _sut.Compute(from, to);
+
+        var removed = result.Single(r => r.Type == DiffResultType.Removed);
+        Assert.Equal(3, removed.WordsRemoved);
+        Assert.Equal(0, removed.WordsAdded);
+        Assert.Equal(0, removed.TotalWords);
+    }
+
+    [Fact]
+    public void Compute_MismatchedChangedParagraphCounts_KeepsSeparateRemovedAndAdded()
+    {
+        // 2 removed, 1 added — cannot pair 1:1, keep as separate Removed/Added
+        var from = "<p>Para one</p><p>Para two</p>";
+        var to = "<p>Para three</p>";
+
+        var result = _sut.Compute(from, to);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(2, result.Count(r => r.Type == DiffResultType.Removed));
+        Assert.Equal(1, result.Count(r => r.Type == DiffResultType.Added));
     }
 
     [Fact]
     public void Compute_MultiParagraph_CorrectSequence()
     {
+        // B replaced by D: 1 Removed + 1 Added -> merged to Modified
         var from = "<p>A</p><p>B</p><p>C</p>";
         var to = "<p>A</p><p>D</p><p>C</p>";
 
         var result = _sut.Compute(from, to);
 
-        Assert.Equal(4, result.Count);
+        Assert.Equal(3, result.Count);
         Assert.Equal(DiffResultType.Unchanged, result[0].Type);
         Assert.Equal("A", result[0].Text);
-        Assert.Equal(DiffResultType.Removed, result[1].Type);
-        Assert.Equal("B", result[1].Text);
-        Assert.Equal(DiffResultType.Added, result[2].Type);
-        Assert.Equal("D", result[2].Text);
-        Assert.Equal(DiffResultType.Unchanged, result[3].Type);
-        Assert.Equal("C", result[3].Text);
+        Assert.Equal(DiffResultType.Modified, result[1].Type);
+        Assert.Equal(DiffResultType.Unchanged, result[2].Type);
+        Assert.Equal("C", result[2].Text);
     }
 
     [Fact]
@@ -146,15 +240,30 @@ public class HtmlDiffServiceTests
     }
 
     [Fact]
-    public void Compute_PreservesOriginalHtml_InResult()
+    public void Compute_PurelyAddedParagraph_PreservesOriginalHtml()
     {
+        // A second paragraph added with no removed counterpart preserves its original HTML.
+        var from = "<p>Hello</p>";
+        var to = "<p>Hello</p><p><em>World</em></p>";
+
+        var result = _sut.Compute(from, to);
+
+        var added = result.Single(r => r.Type == DiffResultType.Added);
+        Assert.Contains("<em>World</em>", added.Html);
+    }
+
+    [Fact]
+    public void Compute_ModifiedParagraph_HtmlContainsDiffSpansNotOriginalInlineTags()
+    {
+        // A modified paragraph produces diff HTML (del/ins), not the original inline markup.
         var from = "<p><strong>Hello</strong></p>";
         var to = "<p><em>World</em></p>";
 
         var result = _sut.Compute(from, to);
 
-        Assert.Equal(2, result.Count);
-        Assert.Contains("<strong>Hello</strong>", result[0].Html);
-        Assert.Contains("<em>World</em>", result[1].Html);
+        Assert.Single(result);
+        Assert.Equal(DiffResultType.Modified, result[0].Type);
+        Assert.Contains("<del>", result[0].Html);
+        Assert.Contains("<ins>", result[0].Html);
     }
 }

--- a/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
@@ -12,14 +12,18 @@ public class ReaderDashboardServiceTests
     private static readonly Guid UserId    = Guid.NewGuid();
     private static readonly Guid ProjectId = Guid.NewGuid();
 
-    private readonly Mock<IReadingProgressService> _progressService = new();
-    private readonly Mock<ISectionRepository>      _sectionRepo     = new();
-    private readonly Mock<ICommentRepository>      _commentRepo     = new();
+    private readonly Mock<IReadingProgressService>   _progressService    = new();
+    private readonly Mock<ISectionRepository>        _sectionRepo        = new();
+    private readonly Mock<ICommentRepository>        _commentRepo        = new();
+    private readonly Mock<IReadEventRepository>      _readEventRepo      = new();
+    private readonly Mock<ISectionVersionRepository> _sectionVersionRepo = new();
 
     private ReaderDashboardService CreateSut() => new(
         _progressService.Object,
         _sectionRepo.Object,
-        _commentRepo.Object);
+        _commentRepo.Object,
+        _readEventRepo.Object,
+        _sectionVersionRepo.Object);
 
     // -----------------------------------------------------------------------
     // GetCrossProjectResumeTargetAsync
@@ -270,5 +274,158 @@ public class ReaderDashboardServiceTests
 
         Assert.Equal(2, result[ch1Id]);
         Assert.Equal(1, result[ch2Id]);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetChapterChangeStatusesAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ChapterChangeStatuses_EmptyChapterIds_ReturnsEmptyDictionary()
+    {
+        var result = await CreateSut().GetChapterChangeStatusesAsync(
+            UserId, [], ReadingStyle.StoryReader);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ChapterChangeStatuses_WhenReaderIsUpToDate_ReturnsNullClassification()
+    {
+        var chapterId = Guid.NewGuid();
+        var scene = CreateScene(chapterId);
+        var readEvent = ReadEvent.Create(scene.Id, UserId);
+        readEvent.MarkAsRead(1);
+
+        var version = CreateVersion(scene, 1, ChangeClassification.Polish);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([scene]);
+        _readEventRepo.Setup(r => r.GetAsync(scene.Id, UserId, default))
+            .ReturnsAsync(readEvent);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(scene.Id, default))
+            .ReturnsAsync(version);
+
+        var result = await CreateSut().GetChapterChangeStatusesAsync(
+            UserId, [chapterId], ReadingStyle.StoryReader);
+
+        Assert.Null(result[chapterId]);
+    }
+
+    [Fact]
+    public async Task ChapterChangeStatuses_WhenSceneUpdated_ReturnsMaxClassification()
+    {
+        var chapterId = Guid.NewGuid();
+        var scene = CreateScene(chapterId);
+        var readEvent = ReadEvent.Create(scene.Id, UserId);
+        readEvent.MarkAsRead(1);
+
+        var version = CreateVersion(scene, 2, ChangeClassification.Revision);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([scene]);
+        _readEventRepo.Setup(r => r.GetAsync(scene.Id, UserId, default))
+            .ReturnsAsync(readEvent);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(scene.Id, default))
+            .ReturnsAsync(version);
+
+        var result = await CreateSut().GetChapterChangeStatusesAsync(
+            UserId, [chapterId], ReadingStyle.StoryReader);
+
+        Assert.Equal(ChangeClassification.Revision, result[chapterId]);
+    }
+
+    [Fact]
+    public async Task ChapterChangeStatuses_WhenClassificationBelowThreshold_ReturnsNull()
+    {
+        var chapterId = Guid.NewGuid();
+        var scene = CreateScene(chapterId);
+        var readEvent = ReadEvent.Create(scene.Id, UserId);
+        readEvent.MarkAsRead(1);
+
+        // Latest version has Trivial changes — below StoryReader threshold (Polish+)
+        var version = CreateVersion(scene, 2, ChangeClassification.Trivial);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([scene]);
+        _readEventRepo.Setup(r => r.GetAsync(scene.Id, UserId, default))
+            .ReturnsAsync(readEvent);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(scene.Id, default))
+            .ReturnsAsync(version);
+
+        var result = await CreateSut().GetChapterChangeStatusesAsync(
+            UserId, [chapterId], ReadingStyle.StoryReader);
+
+        Assert.Null(result[chapterId]);
+    }
+
+    [Fact]
+    public async Task ChapterChangeStatuses_WhenNoReadEvent_ReturnsNullClassification()
+    {
+        var chapterId = Guid.NewGuid();
+        var scene = CreateScene(chapterId);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([scene]);
+        _readEventRepo.Setup(r => r.GetAsync(scene.Id, UserId, default))
+            .ReturnsAsync((ReadEvent?)null);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(scene.Id, default))
+            .ReturnsAsync(CreateVersion(scene, 1, ChangeClassification.Polish));
+
+        var result = await CreateSut().GetChapterChangeStatusesAsync(
+            UserId, [chapterId], ReadingStyle.StoryReader);
+
+        // No read event = never read = "New" state, not "Updated" — no classification
+        Assert.Null(result[chapterId]);
+    }
+
+    [Fact]
+    public async Task ChapterChangeStatuses_MultipleScenes_ReturnsMaxAcrossScenes()
+    {
+        var chapterId = Guid.NewGuid();
+        var scene1    = CreateScene(chapterId);
+        var scene2    = CreateScene(chapterId);
+
+        var readEvent1 = ReadEvent.Create(scene1.Id, UserId);
+        readEvent1.MarkAsRead(1);
+        var readEvent2 = ReadEvent.Create(scene2.Id, UserId);
+        readEvent2.MarkAsRead(1);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([scene1, scene2]);
+        _readEventRepo.Setup(r => r.GetAsync(scene1.Id, UserId, default))
+            .ReturnsAsync(readEvent1);
+        _readEventRepo.Setup(r => r.GetAsync(scene2.Id, UserId, default))
+            .ReturnsAsync(readEvent2);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(scene1.Id, default))
+            .ReturnsAsync(CreateVersion(scene1, 2, ChangeClassification.Polish));
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(scene2.Id, default))
+            .ReturnsAsync(CreateVersion(scene2, 2, ChangeClassification.Rewrite));
+
+        var result = await CreateSut().GetChapterChangeStatusesAsync(
+            UserId, [chapterId], ReadingStyle.StoryReader);
+
+        Assert.Equal(ChangeClassification.Rewrite, result[chapterId]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static Section CreateScene(Guid chapterId)
+    {
+        var scene = Section.CreateDocument(
+            Guid.NewGuid(), Guid.NewGuid().ToString(), "Scene",
+            chapterId, 1, "<p>content</p>", "hash", "First Draft");
+        scene.PublishAsPartOfChapter("hash");
+        return scene;
+    }
+
+    private static SectionVersion CreateVersion(Section section, int versionNumber, ChangeClassification classification)
+    {
+        section.UpdateContent("<p>content</p>", "hash");
+        var version = SectionVersion.Create(section, Guid.NewGuid(), versionNumber, 1, 0);
+        version.SetChangeClassification(classification);
+        return version;
     }
 }

--- a/DraftView.Application.Tests/Services/ReaderDiffServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderDiffServiceTests.cs
@@ -1,0 +1,240 @@
+using DraftView.Application.Services;
+using DraftView.Domain.Contracts;
+using DraftView.Domain.Diff;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+using Moq;
+
+namespace DraftView.Application.Tests.Services;
+
+/// <summary>
+/// Tests for ReaderDiffService.
+/// Covers: GetDiffAsync preference gating, MarkAsReadAsync, MarkAsUnreadAsync.
+/// Excludes: diff computation logic (SectionDiffServiceTests), classification (ChangeClassificationServiceTests).
+/// </summary>
+public class ReaderDiffServiceTests
+{
+    private static readonly Guid UserId    = Guid.NewGuid();
+    private static readonly Guid SectionId = Guid.NewGuid();
+
+    private readonly Mock<IReadEventRepository>       _readEventRepo        = new();
+    private readonly Mock<IUserPreferencesRepository> _userPreferencesRepo  = new();
+    private readonly Mock<ISectionVersionRepository>  _sectionVersionRepo   = new();
+    private readonly Mock<ISectionDiffService>        _sectionDiffService   = new();
+    private readonly Mock<IUnitOfWork>                _unitOfWork           = new();
+
+    private ReaderDiffService CreateSut() => new(
+        _readEventRepo.Object,
+        _userPreferencesRepo.Object,
+        _sectionVersionRepo.Object,
+        _sectionDiffService.Object,
+        _unitOfWork.Object);
+
+    // ---------------------------------------------------------------------------
+    // GetDiffAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetDiffAsync_WhenNoPreferences_ReturnsNull()
+    {
+        _userPreferencesRepo.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserPreferences?)null);
+
+        var result = await CreateSut().GetDiffAsync(SectionId, UserId);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetDiffAsync_WhenShowDiffOnRevisitIsFalse_ReturnsNull()
+    {
+        var prefs = UserPreferences.CreateForBetaReader(UserId);
+        // ShowDiffOnRevisit defaults to false
+
+        _userPreferencesRepo.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prefs);
+
+        var result = await CreateSut().GetDiffAsync(SectionId, UserId);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetDiffAsync_WhenShowDiffOnRevisitIsTrue_CallsDiffServiceWithPreferences()
+    {
+        var prefs = UserPreferences.CreateForBetaReader(UserId);
+        prefs.UpdateDiffPreferences(showDiffOnRevisit: true, ReadingStyle.StoryReader, diffCooldownHours: 24);
+
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+        readEvent.MarkAsRead(3);
+
+        _userPreferencesRepo.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prefs);
+        _readEventRepo.Setup(r => r.GetAsync(SectionId, UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(readEvent);
+        _sectionDiffService.Setup(s => s.GetDiffForReaderAsync(
+                SectionId,
+                readEvent.LastReadVersionNumber,
+                readEvent.LastMarkedReadAt,
+                24,
+                ReadingStyle.StoryReader,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SectionDiffResult?)null);
+
+        await CreateSut().GetDiffAsync(SectionId, UserId);
+
+        _sectionDiffService.Verify(s => s.GetDiffForReaderAsync(
+            SectionId,
+            readEvent.LastReadVersionNumber,
+            readEvent.LastMarkedReadAt,
+            24,
+            ReadingStyle.StoryReader,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetDiffAsync_WhenNoReadEvent_PassesNullVersionAndTimestamp()
+    {
+        var prefs = UserPreferences.CreateForBetaReader(UserId);
+        prefs.UpdateDiffPreferences(showDiffOnRevisit: true, ReadingStyle.BetaReader, diffCooldownHours: 1);
+
+        _userPreferencesRepo.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prefs);
+        _readEventRepo.Setup(r => r.GetAsync(SectionId, UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ReadEvent?)null);
+        _sectionDiffService.Setup(s => s.GetDiffForReaderAsync(
+                SectionId, null, null, 1, ReadingStyle.BetaReader, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SectionDiffResult?)null);
+
+        await CreateSut().GetDiffAsync(SectionId, UserId);
+
+        _sectionDiffService.Verify(s => s.GetDiffForReaderAsync(
+            SectionId, null, null, 1, ReadingStyle.BetaReader,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetDiffAsync_ReturnsResultFromDiffService()
+    {
+        var prefs = UserPreferences.CreateForBetaReader(UserId);
+        prefs.UpdateDiffPreferences(showDiffOnRevisit: true, ReadingStyle.BetaReader, diffCooldownHours: 1);
+
+        var expectedResult = new SectionDiffResult
+        {
+            FromVersionNumber    = 1,
+            CurrentVersionNumber = 2,
+            HasChanges           = true,
+            Paragraphs           = Array.Empty<ParagraphDiffResult>(),
+            Classification       = ChangeClassification.Polish
+        };
+
+        _userPreferencesRepo.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prefs);
+        _readEventRepo.Setup(r => r.GetAsync(SectionId, UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ReadEvent?)null);
+        _sectionDiffService.Setup(s => s.GetDiffForReaderAsync(
+                It.IsAny<Guid>(), It.IsAny<int?>(), It.IsAny<DateTimeOffset?>(),
+                It.IsAny<int>(), It.IsAny<ReadingStyle>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResult);
+
+        var result = await CreateSut().GetDiffAsync(SectionId, UserId);
+
+        Assert.Same(expectedResult, result);
+    }
+
+    // ---------------------------------------------------------------------------
+    // MarkAsReadAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task MarkAsReadAsync_WhenReadEventAndVersionExist_CallsMarkAsReadAndSaves()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+        var section   = CreateSection();
+        var version   = CreateVersion(section, 5);
+
+        _readEventRepo.Setup(r => r.GetAsync(SectionId, UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(readEvent);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(SectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(version);
+
+        await CreateSut().MarkAsReadAsync(SectionId, UserId);
+
+        Assert.Equal(5, readEvent.LastReadVersionNumber);
+        Assert.NotNull(readEvent.LastMarkedReadAt);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task MarkAsReadAsync_WhenNoReadEvent_DoesNotSave()
+    {
+        _readEventRepo.Setup(r => r.GetAsync(SectionId, UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ReadEvent?)null);
+
+        await CreateSut().MarkAsReadAsync(SectionId, UserId);
+
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MarkAsReadAsync_WhenNoVersion_DoesNotSave()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+
+        _readEventRepo.Setup(r => r.GetAsync(SectionId, UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(readEvent);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(SectionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SectionVersion?)null);
+
+        await CreateSut().MarkAsReadAsync(SectionId, UserId);
+
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---------------------------------------------------------------------------
+    // MarkAsUnreadAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task MarkAsUnreadAsync_WhenReadEventExists_RestoresPreviousVersionAndSaves()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+        readEvent.MarkAsRead(3);
+        readEvent.MarkAsRead(5);
+
+        _readEventRepo.Setup(r => r.GetAsync(SectionId, UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(readEvent);
+
+        await CreateSut().MarkAsUnreadAsync(SectionId, UserId);
+
+        Assert.Equal(3, readEvent.LastReadVersionNumber);
+        Assert.Null(readEvent.LastMarkedReadAt);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task MarkAsUnreadAsync_WhenNoReadEvent_DoesNotSave()
+    {
+        _readEventRepo.Setup(r => r.GetAsync(SectionId, UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ReadEvent?)null);
+
+        await CreateSut().MarkAsUnreadAsync(SectionId, UserId);
+
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static Section CreateSection()
+        => Section.CreateDocumentForUpload(Guid.NewGuid(), "Test", null, 1);
+
+    private static SectionVersion CreateVersion(Section section, int versionNumber)
+    {
+        section.UpdateContent("<p>Content</p>", "hash-" + versionNumber);
+        return SectionVersion.Create(section, Guid.NewGuid(), versionNumber, 1, 0);
+    }
+}

--- a/DraftView.Application.Tests/Services/SectionDiffServiceTests.cs
+++ b/DraftView.Application.Tests/Services/SectionDiffServiceTests.cs
@@ -12,14 +12,16 @@ namespace DraftView.Application.Tests.Services;
 
 /// <summary>
 /// Tests for SectionDiffService.GetDiffForReaderAsync.
-/// Covers: version lookup, reader state handling, diff computation coordination.
-/// Excludes: HTML diff logic (covered in HtmlDiffServiceTests), UI rendering (Web layer).
+/// Covers: version lookup, reader state handling, diff computation coordination,
+/// cooldown gate, ReadingStyle threshold filtering, classification in result.
+/// Excludes: HTML diff logic (HtmlDiffServiceTests), UI rendering (Web layer).
 /// </summary>
 public class SectionDiffServiceTests
 {
     private readonly Mock<ISectionVersionRepository> versionRepo = new();
     private readonly Mock<IHtmlDiffService> htmlDiffService = new();
-    private SectionDiffService Sut => new(versionRepo.Object, htmlDiffService.Object);
+    private readonly Mock<IChangeClassificationService> classificationService = new();
+    private SectionDiffService Sut => new(versionRepo.Object, htmlDiffService.Object, classificationService.Object);
 
     [Fact]
     public async Task GetDiffForReaderAsync_WhenNoVersionExists_ReturnsNull()
@@ -90,6 +92,9 @@ public class SectionDiffServiceTests
                 new("New", "<p>New</p>", DiffResultType.Added)
             });
 
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Polish);
+
         var result = await Sut.GetDiffForReaderAsync(sectionId, lastReadVersionNumber: 1);
 
         Assert.NotNull(result);
@@ -115,6 +120,9 @@ public class SectionDiffServiceTests
         htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
             .Returns(new List<ParagraphDiffResult>());
 
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Polish);
+
         var result = await Sut.GetDiffForReaderAsync(sectionId, lastReadVersionNumber: 5);
 
         Assert.NotNull(result);
@@ -138,6 +146,9 @@ public class SectionDiffServiceTests
         htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
             .Returns(new List<ParagraphDiffResult>());
 
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Polish);
+
         await Sut.GetDiffForReaderAsync(sectionId, lastReadVersionNumber: 1);
 
         htmlDiffService.Verify(s => s.Compute("<p>From</p>", "<p>To</p>"), Times.Once);
@@ -159,6 +170,9 @@ public class SectionDiffServiceTests
 
         htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
             .Returns(new List<ParagraphDiffResult>());
+
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Polish);
 
         await Sut.GetDiffForReaderAsync(section.Id, lastReadVersionNumber: 1);
 
@@ -186,6 +200,255 @@ public class SectionDiffServiceTests
         Assert.Equal(5, result.CurrentVersionNumber);
         Assert.Empty(result.Paragraphs);
     }
+
+    // ---------------------------------------------------------------------------
+    // Cooldown gate (new overload)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetDiffForReaderAsync_WhenCooldownActive_ReturnsNull()
+    {
+        var section = CreateSection();
+        var fromVersion = CreateVersionForSection(section, 1, "<p>Old</p>");
+        var latestVersion = CreateVersionForSection(section, 2, "<p>New</p>");
+
+        versionRepo.Setup(r => r.GetLatestAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+        versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SectionVersion> { fromVersion, latestVersion });
+
+        htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new List<ParagraphDiffResult>());
+
+        // Marked as read 12 hours ago, cooldown is 24 hours -> still in cooldown
+        var lastMarkedReadAt = DateTimeOffset.UtcNow.AddHours(-12);
+
+        var result = await Sut.GetDiffForReaderAsync(
+            section.Id, lastReadVersionNumber: 1,
+            lastMarkedReadAt: lastMarkedReadAt,
+            diffCooldownHours: 24,
+            readingStyle: ReadingStyle.BetaReader);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetDiffForReaderAsync_WhenCooldownExpired_ReturnsDiff()
+    {
+        var section = CreateSection();
+        var fromVersion = CreateVersionForSection(section, 1, "<p>Old</p>");
+        var latestVersion = CreateVersionForSection(section, 2, "<p>New</p>");
+
+        versionRepo.Setup(r => r.GetLatestAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+        versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SectionVersion> { fromVersion, latestVersion });
+
+        htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new List<ParagraphDiffResult>());
+
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Polish);
+
+        // Marked as read 48 hours ago, cooldown is 24 hours -> cooldown expired
+        var lastMarkedReadAt = DateTimeOffset.UtcNow.AddHours(-48);
+
+        var result = await Sut.GetDiffForReaderAsync(
+            section.Id, lastReadVersionNumber: 1,
+            lastMarkedReadAt: lastMarkedReadAt,
+            diffCooldownHours: 24,
+            readingStyle: ReadingStyle.BetaReader);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetDiffForReaderAsync_WhenLastMarkedReadAtIsNull_NoCooldownApplied()
+    {
+        var section = CreateSection();
+        var fromVersion = CreateVersionForSection(section, 1, "<p>Old</p>");
+        var latestVersion = CreateVersionForSection(section, 2, "<p>New</p>");
+
+        versionRepo.Setup(r => r.GetLatestAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+        versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SectionVersion> { fromVersion, latestVersion });
+
+        htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new List<ParagraphDiffResult>());
+
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Polish);
+
+        var result = await Sut.GetDiffForReaderAsync(
+            section.Id, lastReadVersionNumber: 1,
+            lastMarkedReadAt: null,
+            diffCooldownHours: 168,
+            readingStyle: ReadingStyle.BetaReader);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetDiffForReaderAsync_SystemFloor_CooldownZeroTreatedAsOneHour()
+    {
+        var section = CreateSection();
+        var fromVersion = CreateVersionForSection(section, 1, "<p>Old</p>");
+        var latestVersion = CreateVersionForSection(section, 2, "<p>New</p>");
+
+        versionRepo.Setup(r => r.GetLatestAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+
+        // Marked as read 30 minutes ago; cooldown=0 is floored to 1 hour -> still in cooldown
+        var lastMarkedReadAt = DateTimeOffset.UtcNow.AddMinutes(-30);
+
+        var result = await Sut.GetDiffForReaderAsync(
+            section.Id, lastReadVersionNumber: 1,
+            lastMarkedReadAt: lastMarkedReadAt,
+            diffCooldownHours: 0,
+            readingStyle: ReadingStyle.BetaReader);
+
+        Assert.Null(result);
+    }
+
+    // ---------------------------------------------------------------------------
+    // ReadingStyle threshold (new overload)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetDiffForReaderAsync_WhenTrivialAndStoryReader_ReturnsNull()
+    {
+        var section = CreateSection();
+        var fromVersion = CreateVersionForSection(section, 1, "<p>Old</p>");
+        var latestVersion = CreateVersionForSection(section, 2, "<p>New</p>");
+
+        versionRepo.Setup(r => r.GetLatestAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+        versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SectionVersion> { fromVersion, latestVersion });
+
+        htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new List<ParagraphDiffResult>());
+
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Trivial);
+
+        var result = await Sut.GetDiffForReaderAsync(
+            section.Id, lastReadVersionNumber: 1,
+            lastMarkedReadAt: null, diffCooldownHours: 1,
+            readingStyle: ReadingStyle.StoryReader);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetDiffForReaderAsync_WhenTrivialAndBetaReader_ReturnsDiff()
+    {
+        var section = CreateSection();
+        var fromVersion = CreateVersionForSection(section, 1, "<p>Old</p>");
+        var latestVersion = CreateVersionForSection(section, 2, "<p>New</p>");
+
+        versionRepo.Setup(r => r.GetLatestAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+        versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SectionVersion> { fromVersion, latestVersion });
+
+        htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new List<ParagraphDiffResult>());
+
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Trivial);
+
+        var result = await Sut.GetDiffForReaderAsync(
+            section.Id, lastReadVersionNumber: 1,
+            lastMarkedReadAt: null, diffCooldownHours: 1,
+            readingStyle: ReadingStyle.BetaReader);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetDiffForReaderAsync_WhenAlphaReaderAndPolishChanges_ReturnsNull()
+    {
+        var section = CreateSection();
+        var fromVersion = CreateVersionForSection(section, 1, "<p>Old</p>");
+        var latestVersion = CreateVersionForSection(section, 2, "<p>New</p>");
+
+        versionRepo.Setup(r => r.GetLatestAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+        versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SectionVersion> { fromVersion, latestVersion });
+
+        htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new List<ParagraphDiffResult>());
+
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Polish);
+
+        var result = await Sut.GetDiffForReaderAsync(
+            section.Id, lastReadVersionNumber: 1,
+            lastMarkedReadAt: null, diffCooldownHours: 1,
+            readingStyle: ReadingStyle.AlphaReader);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetDiffForReaderAsync_WhenRewriteAndStructureOnly_ReturnsDiff()
+    {
+        var section = CreateSection();
+        var fromVersion = CreateVersionForSection(section, 1, "<p>Old</p>");
+        var latestVersion = CreateVersionForSection(section, 2, "<p>New</p>");
+
+        versionRepo.Setup(r => r.GetLatestAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+        versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SectionVersion> { fromVersion, latestVersion });
+
+        htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new List<ParagraphDiffResult>());
+
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Rewrite);
+
+        var result = await Sut.GetDiffForReaderAsync(
+            section.Id, lastReadVersionNumber: 1,
+            lastMarkedReadAt: null, diffCooldownHours: 1,
+            readingStyle: ReadingStyle.StructureOnly);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetDiffForReaderAsync_ResultIncludesClassification()
+    {
+        var section = CreateSection();
+        var fromVersion = CreateVersionForSection(section, 1, "<p>Old</p>");
+        var latestVersion = CreateVersionForSection(section, 2, "<p>New</p>");
+
+        versionRepo.Setup(r => r.GetLatestAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(latestVersion);
+        versionRepo.Setup(r => r.GetAllBySectionIdAsync(section.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SectionVersion> { fromVersion, latestVersion });
+
+        htmlDiffService.Setup(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new List<ParagraphDiffResult>());
+
+        classificationService.Setup(s => s.Classify(It.IsAny<IReadOnlyList<ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Revision);
+
+        var result = await Sut.GetDiffForReaderAsync(
+            section.Id, lastReadVersionNumber: 1,
+            lastMarkedReadAt: null, diffCooldownHours: 1,
+            readingStyle: ReadingStyle.BetaReader);
+
+        Assert.NotNull(result);
+        Assert.Equal(ChangeClassification.Revision, result.Classification);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
 
     private static Section CreateSection()
     {

--- a/DraftView.Application.Tests/Services/UserServiceTests.cs
+++ b/DraftView.Application.Tests/Services/UserServiceTests.cs
@@ -319,4 +319,36 @@ public class UserServiceTests
         Assert.Null(prefs.ReaderPace);
         UnitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
     }
+
+    [Fact]
+    public async Task UpdateDiffPreferencesAsync_ValidUser_UpdatesPrefsAndSaves()
+    {
+        var user = User.Create("reader@example.com", "Reader", Role.BetaReader);
+        var prefs = UserPreferences.CreateForBetaReader(user.Id);
+        var sut = CreateSut();
+
+        PrefsRepo.Setup(r => r.GetByUserIdAsync(user.Id, default))
+            .ReturnsAsync(prefs);
+
+        await sut.UpdateDiffPreferencesAsync(user.Id, true, ReadingStyle.AlphaReader, 72);
+
+        Assert.True(prefs.ShowDiffOnRevisit);
+        Assert.Equal(ReadingStyle.AlphaReader, prefs.ReadingStyle);
+        Assert.Equal(72, prefs.DiffCooldownHours);
+        UnitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateDiffPreferencesAsync_WhenNoPreferences_DoesNotSave()
+    {
+        var user = User.Create("reader@example.com", "Reader", Role.BetaReader);
+        var sut = CreateSut();
+
+        PrefsRepo.Setup(r => r.GetByUserIdAsync(user.Id, default))
+            .ReturnsAsync((UserPreferences?)null);
+
+        await sut.UpdateDiffPreferencesAsync(user.Id, true, ReadingStyle.StoryReader, 24);
+
+        UnitOfWork.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
 }

--- a/DraftView.Application/Services/ChangeClassificationService.cs
+++ b/DraftView.Application/Services/ChangeClassificationService.cs
@@ -5,38 +5,49 @@ using DraftView.Domain.Interfaces.Services;
 namespace DraftView.Application.Services;
 
 /// <summary>
-/// Classifies the nature of content changes from paragraph-level diff results.
+/// Classifies the nature of content changes from word-level diff results.
+/// Uses total word count and changed word count to assign Trivial, Polish, Revision, or Rewrite.
 /// </summary>
 public class ChangeClassificationService : IChangeClassificationService
 {
-    private const double RewriteThreshold = 0.6;
-    private const double RevisionThreshold = 0.2;
+    private const double PolishRevisionBoundary = 0.10;
+    private const double RevisionRewriteBoundary = 0.40;
+    private const double TrivialPercentageThreshold = 0.01;
+    private const int TrivialAbsoluteFloor = 5;
 
     /// <summary>
-    /// Classifies changes based on a paragraph-level diff result.
-    /// Returns null when no diff exists (no previous version).
+    /// Classifies changes based on word-level diff results.
+    /// Returns null when no changes exist (wordsChanged == 0 or no paragraphs).
+    /// Trivial threshold: wordsChanged less than max(5, ceil(totalWords * 1%)).
+    /// Polish: 1-10%. Revision: 10-40%. Rewrite: 40%+.
     /// </summary>
     public ChangeClassification? Classify(IReadOnlyList<ParagraphDiffResult> diffParagraphs)
     {
         if (diffParagraphs is null || diffParagraphs.Count == 0)
             return null;
 
-        var total = diffParagraphs.Count;
-        var added = diffParagraphs.Count(p => p.Type == DiffResultType.Added);
-        var removed = diffParagraphs.Count(p => p.Type == DiffResultType.Removed);
-        var changed = added + removed;
+        int totalWords   = diffParagraphs.Sum(p => p.TotalWords);
+        int wordsChanged = diffParagraphs.Sum(p => p.WordsAdded + p.WordsRemoved);
 
-        var changedRatio = (double)changed / total;
+        if (wordsChanged == 0 || totalWords == 0)
+            return null;
 
-        if (changedRatio >= RewriteThreshold)
-            return ChangeClassification.Rewrite;
+        int trivialThreshold = TrivialThreshold(totalWords);
 
-        if (changedRatio >= RevisionThreshold)
-            return ChangeClassification.Revision;
+        if (wordsChanged < trivialThreshold)
+            return ChangeClassification.Trivial;
 
-        if (changedRatio > 0)
+        double ratio = (double)wordsChanged / totalWords;
+
+        if (ratio < PolishRevisionBoundary)
             return ChangeClassification.Polish;
 
-        return null;
+        if (ratio < RevisionRewriteBoundary)
+            return ChangeClassification.Revision;
+
+        return ChangeClassification.Rewrite;
     }
+
+    private static int TrivialThreshold(int totalWords)
+        => Math.Max(TrivialAbsoluteFloor, (int)Math.Ceiling(totalWords * TrivialPercentageThreshold));
 }

--- a/DraftView.Application/Services/HtmlDiffService.cs
+++ b/DraftView.Application/Services/HtmlDiffService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+using System.Text;
+using System.Text.RegularExpressions;
 using DraftView.Domain.Diff;
 using DraftView.Domain.Enumerations;
 using DraftView.Domain.Interfaces.Services;
@@ -6,16 +7,18 @@ using DraftView.Domain.Interfaces.Services;
 namespace DraftView.Application.Services;
 
 /// <summary>
-/// Computes a paragraph-level diff between two HTML content strings.
-/// Uses a Longest Common Subsequence approach comparing stripped paragraph text.
+/// Computes a word-level diff between two HTML content strings.
+/// Paragraphs are first matched using LCS. Matched pairs with word-level changes
+/// produce a Modified result with inline del/ins spans. Purely added or removed
+/// paragraphs retain their Added/Removed type. All results carry word count data
+/// for use by IChangeClassificationService.
 /// </summary>
 public class HtmlDiffService : IHtmlDiffService
 {
     /// <summary>
-    /// Computes a paragraph-level diff between the from and to HTML strings.
-    /// Returns a list of ParagraphDiffResult ordered as they appear in the
-    /// combined sequence (removed paragraphs from `from`, added paragraphs
-    /// from `to`, unchanged paragraphs preserved in position).
+    /// Computes a word-level diff between the from and to HTML strings.
+    /// Returns an ordered list of ParagraphDiffResult. Modified paragraphs carry
+    /// inline del/ins HTML spans showing removed and inserted words.
     /// </summary>
     public IReadOnlyList<ParagraphDiffResult> Compute(string? from, string? to)
     {
@@ -23,27 +26,78 @@ public class HtmlDiffService : IHtmlDiffService
             return Array.Empty<ParagraphDiffResult>();
 
         var fromParagraphs = ExtractParagraphs(from ?? string.Empty);
-        var toParagraphs = ExtractParagraphs(to ?? string.Empty);
+        var toParagraphs   = ExtractParagraphs(to   ?? string.Empty);
 
         if (fromParagraphs.Count == 0 && toParagraphs.Count > 0)
-            return toParagraphs.Select(p => new ParagraphDiffResult(p.Text, p.Html, DiffResultType.Added)).ToList();
+            return toParagraphs.Select(p => AddedParagraph(p)).ToList();
 
         if (toParagraphs.Count == 0 && fromParagraphs.Count > 0)
-            return fromParagraphs.Select(p => new ParagraphDiffResult(p.Text, p.Html, DiffResultType.Removed)).ToList();
+            return fromParagraphs.Select(p => RemovedParagraph(p)).ToList();
 
         return ComputeDiff(fromParagraphs, toParagraphs);
     }
 
-    private static List<ParagraphDiffResult> ComputeDiff(
+    private static IReadOnlyList<ParagraphDiffResult> ComputeDiff(
         List<(string Text, string Html)> from,
         List<(string Text, string Html)> to)
     {
-        var lcs = ComputeLcs(from.Select(p => p.Text).ToList(), to.Select(p => p.Text).ToList());
-        var result = new List<ParagraphDiffResult>();
+        var lcs    = ComputeParagraphLcs(from.Select(p => p.Text).ToList(), to.Select(p => p.Text).ToList());
+        var rawDiff = BuildRawDiff(from, to, lcs);
+        return MergeModifiedParagraphs(rawDiff);
+    }
 
-        int fromIndex = 0;
-        int toIndex = 0;
-        int lcsIndex = 0;
+    /// <summary>
+    /// Walks the paragraph LCS to produce an initial Removed/Added/Unchanged list,
+    /// then merges consecutive equal-count Removed+Added pairs into Modified.
+    /// </summary>
+    private static IReadOnlyList<ParagraphDiffResult> MergeModifiedParagraphs(
+        List<(string Text, string Html, DiffResultType Type)> raw)
+    {
+        var result = new List<ParagraphDiffResult>();
+        int i = 0;
+
+        while (i < raw.Count)
+        {
+            if (raw[i].Type == DiffResultType.Unchanged)
+            {
+                var p = raw[i++];
+                result.Add(UnchangedParagraph((p.Text, p.Html)));
+                continue;
+            }
+
+            var removedBatch = new List<(string Text, string Html)>();
+            while (i < raw.Count && raw[i].Type == DiffResultType.Removed)
+                removedBatch.Add((raw[i].Text, raw[i++].Html));
+
+            var addedBatch = new List<(string Text, string Html)>();
+            while (i < raw.Count && raw[i].Type == DiffResultType.Added)
+                addedBatch.Add((raw[i].Text, raw[i++].Html));
+
+            if (removedBatch.Count > 0 && addedBatch.Count > 0
+                && removedBatch.Count == addedBatch.Count)
+            {
+                for (int k = 0; k < removedBatch.Count; k++)
+                    result.Add(ApplyWordLevelDiff(removedBatch[k].Text, addedBatch[k].Text));
+            }
+            else
+            {
+                foreach (var p in removedBatch)
+                    result.Add(RemovedParagraph(p));
+                foreach (var p in addedBatch)
+                    result.Add(AddedParagraph(p));
+            }
+        }
+
+        return result;
+    }
+
+    private static List<(string Text, string Html, DiffResultType Type)> BuildRawDiff(
+        List<(string Text, string Html)> from,
+        List<(string Text, string Html)> to,
+        List<string> lcs)
+    {
+        var result   = new List<(string, string, DiffResultType)>();
+        int fromIndex = 0, toIndex = 0, lcsIndex = 0;
 
         while (fromIndex < from.Count || toIndex < to.Count)
         {
@@ -52,76 +106,153 @@ public class HtmlDiffService : IHtmlDiffService
                 var lcsText = lcs[lcsIndex];
 
                 while (fromIndex < from.Count && from[fromIndex].Text != lcsText)
-                {
-                    result.Add(new ParagraphDiffResult(from[fromIndex].Text, from[fromIndex].Html, DiffResultType.Removed));
-                    fromIndex++;
-                }
+                    result.Add((from[fromIndex].Text, from[fromIndex++].Html, DiffResultType.Removed));
 
                 while (toIndex < to.Count && to[toIndex].Text != lcsText)
-                {
-                    result.Add(new ParagraphDiffResult(to[toIndex].Text, to[toIndex].Html, DiffResultType.Added));
-                    toIndex++;
-                }
+                    result.Add((to[toIndex].Text, to[toIndex++].Html, DiffResultType.Added));
 
                 if (fromIndex < from.Count && toIndex < to.Count)
                 {
-                    result.Add(new ParagraphDiffResult(to[toIndex].Text, to[toIndex].Html, DiffResultType.Unchanged));
-                    fromIndex++;
-                    toIndex++;
-                    lcsIndex++;
+                    result.Add((to[toIndex].Text, to[toIndex].Html, DiffResultType.Unchanged));
+                    fromIndex++; toIndex++; lcsIndex++;
                 }
             }
             else
             {
                 while (fromIndex < from.Count)
-                {
-                    result.Add(new ParagraphDiffResult(from[fromIndex].Text, from[fromIndex].Html, DiffResultType.Removed));
-                    fromIndex++;
-                }
+                    result.Add((from[fromIndex].Text, from[fromIndex++].Html, DiffResultType.Removed));
 
                 while (toIndex < to.Count)
-                {
-                    result.Add(new ParagraphDiffResult(to[toIndex].Text, to[toIndex].Html, DiffResultType.Added));
-                    toIndex++;
-                }
+                    result.Add((to[toIndex].Text, to[toIndex++].Html, DiffResultType.Added));
             }
         }
 
         return result;
     }
 
-    private static List<string> ComputeLcs(List<string> from, List<string> to)
+    /// <summary>
+    /// Applies word-level LCS diff between two paragraph texts.
+    /// Produces a Modified ParagraphDiffResult with del/ins spans in the HTML.
+    /// </summary>
+    private static ParagraphDiffResult ApplyWordLevelDiff(string fromText, string toText)
     {
-        int m = from.Count;
-        int n = to.Count;
+        var fromWords = Tokenize(fromText);
+        var toWords   = Tokenize(toText);
+        var lcs       = ComputeWordLcs(fromWords, toWords);
+
+        var sb = new StringBuilder("<p>");
+        int fi = 0, ti = 0, li = 0;
+        int wordsAdded = 0, wordsRemoved = 0;
+
+        while (fi < fromWords.Length || ti < toWords.Length)
+        {
+            if (li < lcs.Count)
+            {
+                var lcsWord = lcs[li];
+
+                while (fi < fromWords.Length && fromWords[fi] != lcsWord)
+                {
+                    sb.Append("<del>").Append(HtmlEncode(fromWords[fi++])).Append("</del> ");
+                    wordsRemoved++;
+                }
+
+                while (ti < toWords.Length && toWords[ti] != lcsWord)
+                {
+                    sb.Append("<ins>").Append(HtmlEncode(toWords[ti++])).Append("</ins> ");
+                    wordsAdded++;
+                }
+
+                if (fi < fromWords.Length && ti < toWords.Length)
+                {
+                    sb.Append(HtmlEncode(fromWords[fi++])).Append(' ');
+                    ti++; li++;
+                }
+            }
+            else
+            {
+                while (fi < fromWords.Length)
+                {
+                    sb.Append("<del>").Append(HtmlEncode(fromWords[fi++])).Append("</del> ");
+                    wordsRemoved++;
+                }
+
+                while (ti < toWords.Length)
+                {
+                    sb.Append("<ins>").Append(HtmlEncode(toWords[ti++])).Append("</ins> ");
+                    wordsAdded++;
+                }
+            }
+        }
+
+        var diffHtml = sb.ToString().TrimEnd() + "</p>";
+        return new ParagraphDiffResult(toText, diffHtml, DiffResultType.Modified,
+            wordsAdded: wordsAdded, wordsRemoved: wordsRemoved, totalWords: toWords.Length);
+    }
+
+    private static ParagraphDiffResult UnchangedParagraph((string Text, string Html) p)
+    {
+        var wordCount = CountWords(p.Text);
+        return new ParagraphDiffResult(p.Text, p.Html, DiffResultType.Unchanged,
+            wordsAdded: 0, wordsRemoved: 0, totalWords: wordCount);
+    }
+
+    private static ParagraphDiffResult AddedParagraph((string Text, string Html) p)
+    {
+        var wordCount = CountWords(p.Text);
+        return new ParagraphDiffResult(p.Text, p.Html, DiffResultType.Added,
+            wordsAdded: wordCount, wordsRemoved: 0, totalWords: wordCount);
+    }
+
+    private static ParagraphDiffResult RemovedParagraph((string Text, string Html) p)
+    {
+        var wordCount = CountWords(p.Text);
+        return new ParagraphDiffResult(p.Text, p.Html, DiffResultType.Removed,
+            wordsAdded: 0, wordsRemoved: wordCount, totalWords: 0);
+    }
+
+    private static List<string> ComputeParagraphLcs(List<string> from, List<string> to)
+    {
+        int m = from.Count, n = to.Count;
         var dp = new int[m + 1, n + 1];
 
         for (int i = 1; i <= m; i++)
-        {
             for (int j = 1; j <= n; j++)
-            {
-                if (from[i - 1] == to[j - 1])
-                    dp[i, j] = dp[i - 1, j - 1] + 1;
-                else
-                    dp[i, j] = Math.Max(dp[i - 1, j], dp[i, j - 1]);
-            }
-        }
+                dp[i, j] = from[i - 1] == to[j - 1]
+                    ? dp[i - 1, j - 1] + 1
+                    : Math.Max(dp[i - 1, j], dp[i, j - 1]);
 
         var lcs = new List<string>();
         int fi = m, ti = n;
 
         while (fi > 0 && ti > 0)
         {
-            if (from[fi - 1] == to[ti - 1])
-            {
-                lcs.Insert(0, from[fi - 1]);
-                fi--;
-                ti--;
-            }
-            else if (dp[fi - 1, ti] > dp[fi, ti - 1])
-                fi--;
-            else
-                ti--;
+            if (from[fi - 1] == to[ti - 1]) { lcs.Insert(0, from[fi - 1]); fi--; ti--; }
+            else if (dp[fi - 1, ti] > dp[fi, ti - 1]) fi--;
+            else ti--;
+        }
+
+        return lcs;
+    }
+
+    private static List<string> ComputeWordLcs(string[] from, string[] to)
+    {
+        int m = from.Length, n = to.Length;
+        var dp = new int[m + 1, n + 1];
+
+        for (int i = 1; i <= m; i++)
+            for (int j = 1; j <= n; j++)
+                dp[i, j] = from[i - 1] == to[j - 1]
+                    ? dp[i - 1, j - 1] + 1
+                    : Math.Max(dp[i - 1, j], dp[i, j - 1]);
+
+        var lcs = new List<string>();
+        int fi = m, ti = n;
+
+        while (fi > 0 && ti > 0)
+        {
+            if (from[fi - 1] == to[ti - 1]) { lcs.Insert(0, from[fi - 1]); fi--; ti--; }
+            else if (dp[fi - 1, ti] > dp[fi, ti - 1]) fi--;
+            else ti--;
         }
 
         return lcs;
@@ -133,8 +264,8 @@ public class HtmlDiffService : IHtmlDiffService
             return new List<(string, string)>();
 
         var paragraphs = new List<(string Text, string Html)>();
-        var pattern = @"<p[^>]*>(.*?)</p>";
-        var matches = Regex.Matches(html, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        var matches    = Regex.Matches(html, @"<p[^>]*>(.*?)</p>",
+                             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         if (matches.Count == 0)
         {
@@ -146,8 +277,7 @@ public class HtmlDiffService : IHtmlDiffService
         {
             foreach (Match match in matches)
             {
-                var innerHtml = match.Groups[1].Value;
-                var stripped = StripTags(innerHtml);
+                var stripped = StripTags(match.Groups[1].Value);
                 if (!string.IsNullOrWhiteSpace(stripped))
                     paragraphs.Add((stripped, match.Value));
             }
@@ -156,8 +286,17 @@ public class HtmlDiffService : IHtmlDiffService
         return paragraphs;
     }
 
+    private static string[] Tokenize(string text)
+        => text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+    private static int CountWords(string text)
+        => string.IsNullOrWhiteSpace(text) ? 0 : Tokenize(text).Length;
+
     private static string StripTags(string html)
         => Regex.Replace(html, "<[^>]+>", string.Empty).Trim();
+
+    private static string HtmlEncode(string word)
+        => word.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
 
     private static bool IsNullOrEmpty(string? value)
         => string.IsNullOrWhiteSpace(value);

--- a/DraftView.Application/Services/ReaderDashboardService.cs
+++ b/DraftView.Application/Services/ReaderDashboardService.cs
@@ -8,7 +8,9 @@ namespace DraftView.Application.Services;
 public class ReaderDashboardService(
     IReadingProgressService progressService,
     ISectionRepository sectionRepo,
-    ICommentRepository commentRepo) : IReaderDashboardService
+    ICommentRepository commentRepo,
+    IReadEventRepository readEventRepo,
+    ISectionVersionRepository sectionVersionRepo) : IReaderDashboardService
 {
     public async Task<ResumeTarget?> GetCrossProjectResumeTargetAsync(
         Guid userId, IReadOnlyList<Guid> projectIds, CancellationToken ct = default)
@@ -74,4 +76,66 @@ public class ReaderDashboardService(
 
         return result;
     }
+
+    /// <summary>
+    /// Returns the highest ChangeClassification across all Document scenes in each chapter
+    /// that have been updated since the reader's last read version, filtered by ReadingStyle.
+    /// Uses the latest SectionVersion.ChangeClassification as an approximation.
+    /// Returns null for a chapter when the reader is up to date at their threshold level.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<Guid, ChangeClassification?>> GetChapterChangeStatusesAsync(
+        Guid userId, IReadOnlyList<Guid> chapterIds, ReadingStyle readingStyle, CancellationToken ct = default)
+    {
+        var result = new Dictionary<Guid, ChangeClassification?>();
+
+        if (chapterIds.Count == 0)
+            return result;
+
+        var minimumTier = MinimumTier(readingStyle);
+
+        foreach (var chapterId in chapterIds)
+        {
+            if (result.ContainsKey(chapterId))
+                continue;
+
+            var scenes = await sectionRepo.GetAllDescendantsAsync(chapterId, ct);
+            var documents = scenes.Where(s => s.NodeType == NodeType.Document && s.IsPublished && !s.IsSoftDeleted);
+
+            ChangeClassification? chapterMax = null;
+
+            foreach (var scene in documents)
+            {
+                var readEvent = await readEventRepo.GetAsync(scene.Id, userId, ct);
+                if (readEvent?.LastReadVersionNumber is null)
+                    continue;
+
+                var latestVersion = await sectionVersionRepo.GetLatestAsync(scene.Id, ct);
+                if (latestVersion is null)
+                    continue;
+
+                if (latestVersion.VersionNumber <= readEvent.LastReadVersionNumber)
+                    continue;
+
+                var classification = latestVersion.ChangeClassification;
+                if (classification is null || classification < minimumTier)
+                    continue;
+
+                if (chapterMax is null || classification > chapterMax)
+                    chapterMax = classification;
+            }
+
+            result[chapterId] = chapterMax;
+        }
+
+        return result;
+    }
+
+    private static ChangeClassification MinimumTier(ReadingStyle style) => style switch
+    {
+        ReadingStyle.BetaReader    => ChangeClassification.Trivial,
+        ReadingStyle.StoryReader   => ChangeClassification.Polish,
+        ReadingStyle.AlphaReader   => ChangeClassification.Revision,
+        ReadingStyle.StructureOnly => ChangeClassification.Rewrite,
+        _                          => ChangeClassification.Polish
+    };
 }

--- a/DraftView.Application/Services/ReaderDiffService.cs
+++ b/DraftView.Application/Services/ReaderDiffService.cs
@@ -1,0 +1,71 @@
+using DraftView.Domain.Contracts;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Services;
+
+/// <summary>
+/// Orchestrates reader-facing diff operations: get diff with preference filtering,
+/// mark as read at the current version, and mark as unread to restore the prior baseline.
+/// </summary>
+public class ReaderDiffService(
+    IReadEventRepository readEventRepo,
+    IUserPreferencesRepository userPreferencesRepo,
+    ISectionVersionRepository sectionVersionRepo,
+    ISectionDiffService sectionDiffService,
+    IUnitOfWork unitOfWork) : IReaderDiffService
+{
+    /// <summary>
+    /// Returns the diff for the section, applying the reader's ShowDiffOnRevisit preference,
+    /// cooldown, and ReadingStyle threshold. Returns null when the feature is off or suppressed.
+    /// </summary>
+    public async Task<SectionDiffResult?> GetDiffAsync(
+        Guid sectionId, Guid userId, CancellationToken ct = default)
+    {
+        var prefs = await userPreferencesRepo.GetByUserIdAsync(userId, ct);
+
+        if (prefs is null || !prefs.ShowDiffOnRevisit)
+            return null;
+
+        var readEvent = await readEventRepo.GetAsync(sectionId, userId, ct);
+
+        return await sectionDiffService.GetDiffForReaderAsync(
+            sectionId,
+            readEvent?.LastReadVersionNumber,
+            readEvent?.LastMarkedReadAt,
+            prefs.DiffCooldownHours,
+            prefs.ReadingStyle,
+            ct);
+    }
+
+    /// <summary>
+    /// Marks the section as read at the current latest published version.
+    /// No-op when no ReadEvent or no published version exists for the section.
+    /// </summary>
+    public async Task MarkAsReadAsync(
+        Guid sectionId, Guid userId, CancellationToken ct = default)
+    {
+        var readEvent = await readEventRepo.GetAsync(sectionId, userId, ct);
+        if (readEvent is null) return;
+
+        var latestVersion = await sectionVersionRepo.GetLatestAsync(sectionId, ct);
+        if (latestVersion is null) return;
+
+        readEvent.MarkAsRead(latestVersion.VersionNumber);
+        await unitOfWork.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Reverses the last MarkAsRead, restoring the previous diff baseline.
+    /// No-op when no ReadEvent exists.
+    /// </summary>
+    public async Task MarkAsUnreadAsync(
+        Guid sectionId, Guid userId, CancellationToken ct = default)
+    {
+        var readEvent = await readEventRepo.GetAsync(sectionId, userId, ct);
+        if (readEvent is null) return;
+
+        readEvent.MarkAsUnread();
+        await unitOfWork.SaveChangesAsync(ct);
+    }
+}

--- a/DraftView.Application/Services/SectionDiffService.cs
+++ b/DraftView.Application/Services/SectionDiffService.cs
@@ -1,5 +1,6 @@
 using DraftView.Domain.Contracts;
 using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
 
@@ -7,22 +8,46 @@ namespace DraftView.Application.Services;
 
 /// <summary>
 /// Computes the diff between what a reader last read and the current version.
-/// Coordinates version lookup and HTML diff computation.
+/// Coordinates version lookup, HTML diff computation, classification, and
+/// reader preference filtering (cooldown and ReadingStyle threshold).
 /// </summary>
 public class SectionDiffService(
     ISectionVersionRepository versionRepo,
-    IHtmlDiffService htmlDiffService) : ISectionDiffService
+    IHtmlDiffService htmlDiffService,
+    IChangeClassificationService classificationService) : ISectionDiffService
 {
+    private const int SystemCooldownFloorHours = 1;
+
     /// <summary>
-    /// Returns the diff for a section from the reader's last read version
-    /// to the current latest version. Returns null if no current version exists.
-    /// Returns a result with HasChanges = false if the reader is on the latest version.
+    /// Legacy overload — no cooldown or threshold filtering.
+    /// Uses BetaReader threshold (all classifications pass). Delegates to the full overload.
+    /// </summary>
+    public Task<SectionDiffResult?> GetDiffForReaderAsync(
+        Guid sectionId,
+        int? lastReadVersionNumber,
+        CancellationToken ct = default)
+        => GetDiffForReaderAsync(
+            sectionId, lastReadVersionNumber,
+            lastMarkedReadAt: null,
+            diffCooldownHours: SystemCooldownFloorHours,
+            readingStyle: ReadingStyle.BetaReader,
+            ct);
+
+    /// <summary>
+    /// Returns the diff filtered by the reader's cooldown and ReadingStyle threshold.
+    /// Returns null when: no version exists, cooldown is active, or classification is below threshold.
     /// </summary>
     public async Task<SectionDiffResult?> GetDiffForReaderAsync(
         Guid sectionId,
         int? lastReadVersionNumber,
+        DateTimeOffset? lastMarkedReadAt,
+        int diffCooldownHours,
+        ReadingStyle readingStyle,
         CancellationToken ct = default)
     {
+        if (IsCooldownActive(lastMarkedReadAt, diffCooldownHours))
+            return null;
+
         var latestVersion = await versionRepo.GetLatestAsync(sectionId, ct);
 
         if (latestVersion is null)
@@ -40,49 +65,63 @@ public class SectionDiffService(
         if (fromVersion is null)
             return CreateHasChangesResultWithoutDiff(lastReadVersionNumber.Value, latestVersion.VersionNumber);
 
-        var diffParagraphs = htmlDiffService.Compute(
-            fromVersion.HtmlContent,
-            latestVersion.HtmlContent);
+        var diffParagraphs = htmlDiffService.Compute(fromVersion.HtmlContent, latestVersion.HtmlContent);
+        var classification  = classificationService.Classify(diffParagraphs);
 
-        return CreateHasChangesResultWithDiff(
-            lastReadVersionNumber.Value,
-            latestVersion.VersionNumber,
-            diffParagraphs);
+        if (!MeetsThreshold(classification, readingStyle))
+            return null;
+
+        return new SectionDiffResult
+        {
+            FromVersionNumber    = lastReadVersionNumber.Value,
+            CurrentVersionNumber = latestVersion.VersionNumber,
+            HasChanges           = true,
+            Paragraphs           = diffParagraphs,
+            Classification       = classification
+        };
+    }
+
+    private static bool IsCooldownActive(DateTimeOffset? lastMarkedReadAt, int diffCooldownHours)
+    {
+        if (lastMarkedReadAt is null)
+            return false;
+
+        var effectiveCooldown = Math.Max(SystemCooldownFloorHours, diffCooldownHours);
+        return DateTimeOffset.UtcNow < lastMarkedReadAt.Value.AddHours(effectiveCooldown);
+    }
+
+    private static bool MeetsThreshold(ChangeClassification? classification, ReadingStyle readingStyle)
+    {
+        if (classification is null)
+            return false;
+
+        var minimum = readingStyle switch
+        {
+            ReadingStyle.BetaReader    => ChangeClassification.Trivial,
+            ReadingStyle.StoryReader   => ChangeClassification.Polish,
+            ReadingStyle.AlphaReader   => ChangeClassification.Revision,
+            ReadingStyle.StructureOnly => ChangeClassification.Rewrite,
+            _                          => ChangeClassification.Polish
+        };
+
+        return classification >= minimum;
     }
 
     private static SectionDiffResult CreateNoChangesResult(int? fromVersionNumber, int currentVersionNumber)
-    {
-        return new SectionDiffResult
+        => new()
         {
-            FromVersionNumber = fromVersionNumber,
+            FromVersionNumber    = fromVersionNumber,
             CurrentVersionNumber = currentVersionNumber,
-            HasChanges = false,
-            Paragraphs = Array.Empty<Domain.Diff.ParagraphDiffResult>()
+            HasChanges           = false,
+            Paragraphs           = Array.Empty<Domain.Diff.ParagraphDiffResult>()
         };
-    }
 
     private static SectionDiffResult CreateHasChangesResultWithoutDiff(int fromVersionNumber, int currentVersionNumber)
-    {
-        return new SectionDiffResult
+        => new()
         {
-            FromVersionNumber = fromVersionNumber,
+            FromVersionNumber    = fromVersionNumber,
             CurrentVersionNumber = currentVersionNumber,
-            HasChanges = true,
-            Paragraphs = Array.Empty<Domain.Diff.ParagraphDiffResult>()
+            HasChanges           = true,
+            Paragraphs           = Array.Empty<Domain.Diff.ParagraphDiffResult>()
         };
-    }
-
-    private static SectionDiffResult CreateHasChangesResultWithDiff(
-        int fromVersionNumber,
-        int currentVersionNumber,
-        IReadOnlyList<Domain.Diff.ParagraphDiffResult> paragraphs)
-    {
-        return new SectionDiffResult
-        {
-            FromVersionNumber = fromVersionNumber,
-            CurrentVersionNumber = currentVersionNumber,
-            HasChanges = true,
-            Paragraphs = paragraphs
-        };
-    }
 }

--- a/DraftView.Application/Services/UserService.cs
+++ b/DraftView.Application/Services/UserService.cs
@@ -235,6 +235,15 @@ public class UserService(
         await unitOfWork.SaveChangesAsync(ct);
     }
 
+    public async Task UpdateDiffPreferencesAsync(Guid userId, bool showDiffOnRevisit, ReadingStyle readingStyle, int diffCooldownHours, CancellationToken ct = default)
+    {
+        var prefs = await prefsRepo.GetByUserIdAsync(userId, ct);
+        if (prefs is null) return;
+
+        prefs.UpdateDiffPreferences(showDiffOnRevisit, readingStyle, diffCooldownHours);
+        await unitOfWork.SaveChangesAsync(ct);
+    }
+
     public async Task UpdateReaderProfileAsync(Guid userId, string? bio, string? genreInterests, ReaderPace? pace, CancellationToken ct = default)
     {
         var prefs = await prefsRepo.GetByUserIdAsync(userId, ct)

--- a/DraftView.Domain.Tests/Entities/ReadEventTests.cs
+++ b/DraftView.Domain.Tests/Entities/ReadEventTests.cs
@@ -234,4 +234,126 @@ public class ReadEventTests
 
         Assert.Null(readEvent.BannerDismissedAtVersion);
     }
+
+    // ---------------------------------------------------------------------------
+    // MarkAsRead
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Create_PreviousReadVersionNumberIsNull()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+
+        Assert.Null(readEvent.PreviousReadVersionNumber);
+    }
+
+    [Fact]
+    public void Create_LastMarkedReadAtIsNull()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+
+        Assert.Null(readEvent.LastMarkedReadAt);
+    }
+
+    [Fact]
+    public void MarkAsRead_SetsLastReadVersionNumber()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+
+        readEvent.MarkAsRead(5);
+
+        Assert.Equal(5, readEvent.LastReadVersionNumber);
+    }
+
+    [Fact]
+    public void MarkAsRead_StoresPreviousLastReadVersionNumber()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+        readEvent.MarkAsRead(3);
+
+        readEvent.MarkAsRead(5);
+
+        Assert.Equal(3, readEvent.PreviousReadVersionNumber);
+    }
+
+    [Fact]
+    public void MarkAsRead_WhenLastReadIsNull_SetsPreviousToNull()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+
+        readEvent.MarkAsRead(5);
+
+        Assert.Null(readEvent.PreviousReadVersionNumber);
+    }
+
+    [Fact]
+    public void MarkAsRead_SetsLastMarkedReadAt()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+
+        readEvent.MarkAsRead(1);
+
+        Assert.NotNull(readEvent.LastMarkedReadAt);
+        Assert.True(readEvent.LastMarkedReadAt >= before);
+    }
+
+    [Fact]
+    public void MarkAsRead_WithVersionZero_ThrowsInvariantViolation()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+
+        var ex = Assert.Throws<InvariantViolationException>(() => readEvent.MarkAsRead(0));
+
+        Assert.Equal("I-READ-MARK", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void MarkAsRead_WithNegativeVersion_ThrowsInvariantViolation()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+
+        var ex = Assert.Throws<InvariantViolationException>(() => readEvent.MarkAsRead(-1));
+
+        Assert.Equal("I-READ-MARK", ex.InvariantCode);
+    }
+
+    // ---------------------------------------------------------------------------
+    // MarkAsUnread
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void MarkAsUnread_SwapsLastAndPreviousVersionNumbers()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+        readEvent.MarkAsRead(3);
+        readEvent.MarkAsRead(5);
+
+        readEvent.MarkAsUnread();
+
+        Assert.Equal(3, readEvent.LastReadVersionNumber);
+        Assert.Equal(5, readEvent.PreviousReadVersionNumber);
+    }
+
+    [Fact]
+    public void MarkAsUnread_ClearsLastMarkedReadAt()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+        readEvent.MarkAsRead(5);
+
+        readEvent.MarkAsUnread();
+
+        Assert.Null(readEvent.LastMarkedReadAt);
+    }
+
+    [Fact]
+    public void MarkAsUnread_WhenPreviousIsNull_SetsLastToNull()
+    {
+        var readEvent = ReadEvent.Create(SectionId, UserId);
+        readEvent.MarkAsRead(5);
+
+        readEvent.MarkAsUnread();
+
+        Assert.Null(readEvent.LastReadVersionNumber);
+    }
 }

--- a/DraftView.Domain.Tests/Entities/UserPreferencesTests.cs
+++ b/DraftView.Domain.Tests/Entities/UserPreferencesTests.cs
@@ -254,4 +254,70 @@ public class UserPreferencesTests
 
         Assert.Equal(theme, prefs.DisplayTheme);
     }
+
+    // ---------------------------------------------------------------------------
+    // Diff preferences defaults
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void CreateForBetaReader_DiffPreferencesDefaultToOff()
+    {
+        var prefs = UserPreferences.CreateForBetaReader(UserId);
+
+        Assert.False(prefs.ShowDiffOnRevisit);
+        Assert.Equal(ReadingStyle.StoryReader, prefs.ReadingStyle);
+        Assert.Equal(24, prefs.DiffCooldownHours);
+    }
+
+    // ---------------------------------------------------------------------------
+    // UpdateDiffPreferences
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void UpdateDiffPreferences_SetsAllFields()
+    {
+        var prefs = UserPreferences.CreateForBetaReader(UserId);
+
+        prefs.UpdateDiffPreferences(true, ReadingStyle.BetaReader, 72);
+
+        Assert.True(prefs.ShowDiffOnRevisit);
+        Assert.Equal(ReadingStyle.BetaReader, prefs.ReadingStyle);
+        Assert.Equal(72, prefs.DiffCooldownHours);
+    }
+
+    [Fact]
+    public void UpdateDiffPreferences_WithCooldownZero_ThrowsInvariantViolation()
+    {
+        var prefs = UserPreferences.CreateForBetaReader(UserId);
+
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => prefs.UpdateDiffPreferences(true, ReadingStyle.StoryReader, 0));
+
+        Assert.Equal("I-PREF-COOLDOWN", ex.InvariantCode);
+    }
+
+    [Fact]
+    public void UpdateDiffPreferences_WithNegativeCooldown_ThrowsInvariantViolation()
+    {
+        var prefs = UserPreferences.CreateForBetaReader(UserId);
+
+        var ex = Assert.Throws<InvariantViolationException>(
+            () => prefs.UpdateDiffPreferences(true, ReadingStyle.StoryReader, -1));
+
+        Assert.Equal("I-PREF-COOLDOWN", ex.InvariantCode);
+    }
+
+    [Theory]
+    [InlineData(ReadingStyle.BetaReader)]
+    [InlineData(ReadingStyle.StoryReader)]
+    [InlineData(ReadingStyle.AlphaReader)]
+    [InlineData(ReadingStyle.StructureOnly)]
+    public void UpdateDiffPreferences_CanSetEveryReadingStyleValue(ReadingStyle style)
+    {
+        var prefs = UserPreferences.CreateForBetaReader(UserId);
+
+        prefs.UpdateDiffPreferences(false, style, 24);
+
+        Assert.Equal(style, prefs.ReadingStyle);
+    }
 }

--- a/DraftView.Domain/Contracts/SectionDiffResult.cs
+++ b/DraftView.Domain/Contracts/SectionDiffResult.cs
@@ -1,4 +1,5 @@
 using DraftView.Domain.Diff;
+using DraftView.Domain.Enumerations;
 
 namespace DraftView.Domain.Contracts;
 
@@ -20,4 +21,10 @@ public sealed class SectionDiffResult
     /// <summary>Paragraph-level diff results. Empty when no changes or no prior version.</summary>
     public IReadOnlyList<ParagraphDiffResult> Paragraphs { get; init; }
         = Array.Empty<ParagraphDiffResult>();
+
+    /// <summary>
+    /// The classification of changes in this diff, computed from word-level counts.
+    /// Null when HasChanges is false or paragraphs could not be classified.
+    /// </summary>
+    public ChangeClassification? Classification { get; init; }
 }

--- a/DraftView.Domain/Diff/ParagraphDiffResult.cs
+++ b/DraftView.Domain/Diff/ParagraphDiffResult.cs
@@ -17,10 +17,28 @@ public sealed class ParagraphDiffResult
     /// <summary>Whether this paragraph was added, removed, or unchanged.</summary>
     public DiffResultType Type { get; }
 
-    public ParagraphDiffResult(string text, string html, DiffResultType type)
+    /// <summary>Words inserted in this paragraph relative to the previous version. Zero for Unchanged/Removed.</summary>
+    public int WordsAdded { get; }
+
+    /// <summary>Words deleted in this paragraph relative to the previous version. Zero for Unchanged/Added.</summary>
+    public int WordsRemoved { get; }
+
+    /// <summary>Total words in the current version of this paragraph. Zero for Removed paragraphs.</summary>
+    public int TotalWords { get; }
+
+    public ParagraphDiffResult(
+        string text,
+        string html,
+        DiffResultType type,
+        int wordsAdded = 0,
+        int wordsRemoved = 0,
+        int totalWords = 0)
     {
-        Text = text;
-        Html = html;
-        Type = type;
+        Text         = text;
+        Html         = html;
+        Type         = type;
+        WordsAdded   = wordsAdded;
+        WordsRemoved = wordsRemoved;
+        TotalWords   = totalWords;
     }
 }

--- a/DraftView.Domain/Entities/ReadEvent.cs
+++ b/DraftView.Domain/Entities/ReadEvent.cs
@@ -15,6 +15,19 @@ public sealed class ReadEvent
     public DateTime LastOpenedAt { get; private set; }
     public int OpenCount { get; private set; }
     public int? LastReadVersionNumber { get; private set; }
+
+    /// <summary>
+    /// The version number read immediately before the current LastReadVersionNumber.
+    /// Stored so that MarkAsUnread can restore the previous diff baseline.
+    /// </summary>
+    public int? PreviousReadVersionNumber { get; private set; }
+
+    /// <summary>
+    /// The timestamp at which the reader last marked this section as read.
+    /// Null until first mark-as-read. Used to enforce the reader's diff cooldown setting.
+    /// </summary>
+    public DateTimeOffset? LastMarkedReadAt { get; private set; }
+
     public Guid? ResumeAnchorId { get; private set; }
 
     /// <summary>
@@ -107,5 +120,32 @@ public sealed class ReadEvent
     public void ClearResumeAnchor()
     {
         ResumeAnchorId = null;
+    }
+
+    /// <summary>
+    /// Records that the reader has read the section at the given version.
+    /// Stores the previous LastReadVersionNumber so MarkAsUnread can restore it.
+    /// </summary>
+    /// <param name="versionNumber">The version number being marked as read (must be >= 1).</param>
+    /// <exception cref="InvariantViolationException">Thrown when version number is less than 1.</exception>
+    public void MarkAsRead(int versionNumber)
+    {
+        if (versionNumber < 1)
+            throw new InvariantViolationException("I-READ-MARK",
+                "Version number must be 1 or greater.");
+
+        PreviousReadVersionNumber = LastReadVersionNumber;
+        LastReadVersionNumber     = versionNumber;
+        LastMarkedReadAt          = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Reverses the last MarkAsRead, restoring the previous diff baseline.
+    /// Clears LastMarkedReadAt so the cooldown does not suppress the diff.
+    /// </summary>
+    public void MarkAsUnread()
+    {
+        (LastReadVersionNumber, PreviousReadVersionNumber) = (PreviousReadVersionNumber, LastReadVersionNumber);
+        LastMarkedReadAt = null;
     }
 }

--- a/DraftView.Domain/Entities/UserPreferences.cs
+++ b/DraftView.Domain/Entities/UserPreferences.cs
@@ -34,6 +34,11 @@ public sealed class UserPreferences
     public string? ReaderGenreInterests{get; private set;}
     public ReaderPace? ReaderPace{get; private set;}
 
+    // Reader diff preferences
+    public bool ShowDiffOnRevisit{get; private set;}
+    public ReadingStyle ReadingStyle{get; private set;}
+    public int DiffCooldownHours{get; private set;}
+
 
 
     // ---------------------------------------------------------------------------
@@ -59,7 +64,10 @@ public sealed class UserPreferences
             AuthorTimezone = null,
             DisplayTheme = DisplayTheme.Light,
             ProseFont = ProseFont.SystemSerif,
-            ProseFontSize = ProseFontSize.Medium
+            ProseFontSize = ProseFontSize.Medium,
+            ShowDiffOnRevisit = false,
+            ReadingStyle = ReadingStyle.StoryReader,
+            DiffCooldownHours = 24
         };
     }
 
@@ -82,7 +90,10 @@ public sealed class UserPreferences
             AuthorTimezone = timezone,
             DisplayTheme = DisplayTheme.Light,
             ProseFont = ProseFont.SystemSerif,
-            ProseFontSize = ProseFontSize.Medium
+            ProseFontSize = ProseFontSize.Medium,
+            ShowDiffOnRevisit = false,
+            ReadingStyle = ReadingStyle.StoryReader,
+            DiffCooldownHours = 24
         };
     }
 
@@ -128,6 +139,24 @@ public sealed class UserPreferences
         ReaderBio            = bio;
         ReaderGenreInterests = genreInterests;
         ReaderPace           = pace;
+    }
+
+    /// <summary>
+    /// Updates the reader's diff-on-revisit preferences.
+    /// </summary>
+    /// <param name="showDiffOnRevisit">Whether to show a diff when revisiting an updated chapter.</param>
+    /// <param name="readingStyle">The minimum change classification the reader wants to see.</param>
+    /// <param name="diffCooldownHours">Hours to wait after marking as read before showing new diffs. Must be >= 1.</param>
+    /// <exception cref="InvariantViolationException">Thrown when diffCooldownHours is less than 1.</exception>
+    public void UpdateDiffPreferences(bool showDiffOnRevisit, ReadingStyle readingStyle, int diffCooldownHours)
+    {
+        if (diffCooldownHours < 1)
+            throw new InvariantViolationException("I-PREF-COOLDOWN",
+                "Diff cooldown must be at least 1 hour.");
+
+        ShowDiffOnRevisit = showDiffOnRevisit;
+        ReadingStyle      = readingStyle;
+        DiffCooldownHours = diffCooldownHours;
     }
 
     // ---------------------------------------------------------------------------

--- a/DraftView.Domain/Enumerations/ChangeClassification.cs
+++ b/DraftView.Domain/Enumerations/ChangeClassification.cs
@@ -2,11 +2,13 @@ namespace DraftView.Domain.Enumerations;
 
 /// <summary>
 /// Classifies the nature of changes between two SectionVersion snapshots.
-/// Populated by IChangeClassificationService in V-Sprint 4.
+/// Ordinal order is significant: Trivial &lt; Polish &lt; Revision &lt; Rewrite.
+/// Populated by IChangeClassificationService.
 /// </summary>
 public enum ChangeClassification
 {
-    Polish = 0,
-    Revision = 1,
-    Rewrite = 2
+    Trivial  = -1,  // < max(5, totalWords * 0.01) words changed — micro-fixes only
+    Polish   =  0,  // 1–10% of words changed — light surface improvement
+    Revision =  1,  // 10–40% of words changed — noticeable reworking
+    Rewrite  =  2   // > 40% of words changed — major restructuring
 }

--- a/DraftView.Domain/Enumerations/DiffResultType.cs
+++ b/DraftView.Domain/Enumerations/DiffResultType.cs
@@ -7,5 +7,6 @@ public enum DiffResultType
 {
     Unchanged = 0,
     Added     = 1,
-    Removed   = 2
+    Removed   = 2,
+    Modified  = 3  // Paragraph exists in both versions but with word-level changes
 }

--- a/DraftView.Domain/Enumerations/ReadingStyle.cs
+++ b/DraftView.Domain/Enumerations/ReadingStyle.cs
@@ -1,0 +1,13 @@
+namespace DraftView.Domain.Enumerations;
+
+/// <summary>
+/// Controls the minimum change classification a reader sees when revisiting a chapter.
+/// Maps to the reader's self-described reading purpose.
+/// </summary>
+public enum ReadingStyle
+{
+    BetaReader    = 0,  // Show everything, including typos (Trivial and above)
+    StoryReader   = 1,  // Minor edits and above (Polish and above) — default
+    AlphaReader   = 2,  // Meaningful revisions and above (Revision and above)
+    StructureOnly = 3   // Major rewrites only (Rewrite)
+}

--- a/DraftView.Domain/Interfaces/Services/IReaderDashboardService.cs
+++ b/DraftView.Domain/Interfaces/Services/IReaderDashboardService.cs
@@ -1,3 +1,5 @@
+using DraftView.Domain.Enumerations;
+
 namespace DraftView.Domain.Interfaces.Services;
 
 public record ResumeTarget(Guid ChapterId, Guid? SceneId);
@@ -20,4 +22,13 @@ public interface IReaderDashboardService
     /// </summary>
     Task<IReadOnlyDictionary<Guid, int>> GetReaderChapterCommentCountsAsync(
         Guid userId, IReadOnlyList<Guid> chapterIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the highest ChangeClassification across all scenes updated since
+    /// the reader last read them, filtered by the reader's ReadingStyle threshold.
+    /// Null means the reader is up to date (or has never read) at their threshold level.
+    /// Every requested chapterId appears as a key.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, ChangeClassification?>> GetChapterChangeStatusesAsync(
+        Guid userId, IReadOnlyList<Guid> chapterIds, ReadingStyle readingStyle, CancellationToken ct = default);
 }

--- a/DraftView.Domain/Interfaces/Services/IReaderDiffService.cs
+++ b/DraftView.Domain/Interfaces/Services/IReaderDiffService.cs
@@ -1,0 +1,30 @@
+using DraftView.Domain.Contracts;
+
+namespace DraftView.Domain.Interfaces.Services;
+
+/// <summary>
+/// Orchestrates reader-facing diff operations: retrieving the diff for display,
+/// marking a section as read, and marking it as unread.
+/// </summary>
+public interface IReaderDiffService
+{
+    /// <summary>
+    /// Returns the diff for a section for the given reader, applying their
+    /// ShowDiffOnRevisit preference, cooldown, and ReadingStyle threshold.
+    /// Returns null when: preferences not found, ShowDiffOnRevisit is false,
+    /// cooldown is active, or the classification is below the reader's threshold.
+    /// </summary>
+    Task<SectionDiffResult?> GetDiffAsync(Guid sectionId, Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks the section as read at the current latest version for the given reader.
+    /// No-op if no ReadEvent or no published version exists.
+    /// </summary>
+    Task MarkAsReadAsync(Guid sectionId, Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Reverses the last MarkAsRead for the section, restoring the previous diff baseline.
+    /// No-op if no ReadEvent exists.
+    /// </summary>
+    Task MarkAsUnreadAsync(Guid sectionId, Guid userId, CancellationToken ct = default);
+}

--- a/DraftView.Domain/Interfaces/Services/ISectionDiffService.cs
+++ b/DraftView.Domain/Interfaces/Services/ISectionDiffService.cs
@@ -1,4 +1,5 @@
 using DraftView.Domain.Contracts;
+using DraftView.Domain.Enumerations;
 
 namespace DraftView.Domain.Interfaces.Services;
 
@@ -11,9 +12,22 @@ public interface ISectionDiffService
     /// Returns the diff for a section from the reader's last read version
     /// to the current latest version. Returns null if no current version exists.
     /// Returns a result with HasChanges = false if the reader is on the latest version.
+    /// Uses BetaReader threshold and no cooldown — for legacy callers.
     /// </summary>
     Task<SectionDiffResult?> GetDiffForReaderAsync(
         Guid sectionId,
         int? lastReadVersionNumber,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the diff filtered by the reader's cooldown and ReadingStyle threshold.
+    /// Returns null when: no version exists, cooldown is active, or classification is below threshold.
+    /// </summary>
+    Task<SectionDiffResult?> GetDiffForReaderAsync(
+        Guid sectionId,
+        int? lastReadVersionNumber,
+        DateTimeOffset? lastMarkedReadAt,
+        int diffCooldownHours,
+        ReadingStyle readingStyle,
         CancellationToken ct = default);
 }

--- a/DraftView.Domain/Interfaces/Services/IUserService.cs
+++ b/DraftView.Domain/Interfaces/Services/IUserService.cs
@@ -14,6 +14,7 @@ public interface IUserService
     Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default);
     Task UpdateDisplayThemeAsync(Guid userId, DisplayTheme displayTheme, CancellationToken ct = default);
     Task UpdateProseFontPreferencesAsync(Guid userId, ProseFont proseFont, ProseFontSize proseFontSize, CancellationToken ct = default);
+    Task UpdateDiffPreferencesAsync(Guid userId, bool showDiffOnRevisit, ReadingStyle readingStyle, int diffCooldownHours, CancellationToken ct = default);
     Task UpdateEmailAsync(Guid userId, string email, CancellationToken ct = default);
     Task UpdateReaderProfileAsync(Guid userId, string? bio, string? genreInterests, DraftView.Domain.Enumerations.ReaderPace? pace, CancellationToken ct = default);
     Task ResendInvitationAsync(Guid userId, Guid authorId, CancellationToken ct = default);

--- a/DraftView.Infrastructure/Persistence/Configurations/ReadEventConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/ReadEventConfiguration.cs
@@ -29,6 +29,12 @@ public class ReadEventConfiguration : IEntityTypeConfiguration<ReadEvent>
             .HasColumnName("BannerDismissedAtVersion")
             .IsRequired(false);
 
+        builder.Property(e => e.PreviousReadVersionNumber)
+            .IsRequired(false);
+
+        builder.Property(e => e.LastMarkedReadAt)
+            .IsRequired(false);
+
         builder.HasOne<PassageAnchor>()
             .WithMany()
             .HasForeignKey(r => r.ResumeAnchorId)

--- a/DraftView.Infrastructure/Persistence/Configurations/UserPreferencesConfiguration.cs
+++ b/DraftView.Infrastructure/Persistence/Configurations/UserPreferencesConfiguration.cs
@@ -47,5 +47,18 @@ public class UserPreferencesConfiguration : IEntityTypeConfiguration<UserPrefere
         builder.Property(p => p.ReaderPace)
             .IsRequired(false)
             .HasConversion<string>();
+
+        builder.Property(p => p.ShowDiffOnRevisit)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(p => p.ReadingStyle)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasDefaultValue(ReadingStyle.StoryReader);
+
+        builder.Property(p => p.DiffCooldownHours)
+            .IsRequired()
+            .HasDefaultValue(24);
     }
 }

--- a/DraftView.Infrastructure/Persistence/Migrations/20260831101155_AddReaderDiffPreferences.Designer.cs
+++ b/DraftView.Infrastructure/Persistence/Migrations/20260831101155_AddReaderDiffPreferences.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DraftView.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DraftView.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(DraftViewDbContext))]
-    partial class DraftViewDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260831101155_AddReaderDiffPreferences")]
+    partial class AddReaderDiffPreferences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DraftView.Infrastructure/Persistence/Migrations/20260831101155_AddReaderDiffPreferences.cs
+++ b/DraftView.Infrastructure/Persistence/Migrations/20260831101155_AddReaderDiffPreferences.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DraftView.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReaderDiffPreferences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DiffCooldownHours",
+                table: "UserPreferences",
+                type: "integer",
+                nullable: false,
+                defaultValue: 24);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReadingStyle",
+                table: "UserPreferences",
+                type: "text",
+                nullable: false,
+                defaultValue: "StoryReader");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowDiffOnRevisit",
+                table: "UserPreferences",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "LastMarkedReadAt",
+                table: "ReadEvents",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PreviousReadVersionNumber",
+                table: "ReadEvents",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DiffCooldownHours",
+                table: "UserPreferences");
+
+            migrationBuilder.DropColumn(
+                name: "ReadingStyle",
+                table: "UserPreferences");
+
+            migrationBuilder.DropColumn(
+                name: "ShowDiffOnRevisit",
+                table: "UserPreferences");
+
+            migrationBuilder.DropColumn(
+                name: "LastMarkedReadAt",
+                table: "ReadEvents");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousReadVersionNumber",
+                table: "ReadEvents");
+        }
+    }
+}

--- a/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
@@ -45,6 +45,7 @@ public class ReaderControllerTests
     private readonly Mock<IAccessRequestRepository> accessRequestRepo = new();
     private readonly Mock<IAccessRequestService> accessRequestService = new();
     private readonly Mock<IReaderDashboardService> readerDashboardService = new();
+    private readonly Mock<IReaderDiffService> readerDiffService = new();
     private readonly Mock<ILogger<ReaderController>> logger = new();
     private ICommentDisplayService CommentDisplayService =>
         new DraftView.Application.Services.CommentDisplayService(userRepo.Object, passageAnchorService.Object);
@@ -1070,6 +1071,7 @@ public class ReaderControllerTests
             accessRequestRepo.Object,
             accessRequestService.Object,
             readerDashboardService.Object,
+            readerDiffService.Object,
             logger.Object);
 
         controller.ControllerContext = new ControllerContext
@@ -1110,6 +1112,7 @@ public class ReaderControllerTests
             accessRequestRepo.Object,
             accessRequestService.Object,
             readerDashboardService.Object,
+            readerDiffService.Object,
             logger.Object);
 
         controller.ControllerContext = new ControllerContext

--- a/DraftView.Web/Controllers/AccountController.cs
+++ b/DraftView.Web/Controllers/AccountController.cs
@@ -483,7 +483,10 @@ public class AccountController(
             ProseFontSize = prefs?.ProseFontSize.ToString() ?? "Medium",
             ReaderBio = prefs?.ReaderBio,
             ReaderGenreInterests = prefs?.ReaderGenreInterests,
-            ReaderPace = prefs?.ReaderPace?.ToString()
+            ReaderPace = prefs?.ReaderPace?.ToString(),
+            ShowDiffOnRevisit = prefs?.ShowDiffOnRevisit ?? false,
+            ReadingStyle = prefs?.ReadingStyle.ToString() ?? "StoryReader",
+            DiffCooldownHours = prefs?.DiffCooldownHours ?? 24
         };
 
         if (vm.IsAuthor)
@@ -569,6 +572,35 @@ public class AccountController(
         {
             await userService.UpdateProseFontPreferencesAsync(user.Id, proseFont, proseFontSize);
             TempData["Success"] = "Reading preferences updated.";
+        }
+        catch (Exception ex)
+        {
+            TempData["Error"] = ex.Message;
+        }
+
+        return RedirectToAction("Settings");
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ChangeDiffPreferences(ChangeDiffPreferencesViewModel model)
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null)
+            return RedirectToAction("Login");
+
+        if (!Enum.TryParse<DraftView.Domain.Enumerations.ReadingStyle>(model.ReadingStyle, true, out var readingStyle))
+        {
+            TempData["Error"] = "Invalid reading style.";
+            return RedirectToAction("Settings");
+        }
+
+        var cooldownHours = model.DiffCooldownHours > 0 ? model.DiffCooldownHours : 1;
+
+        try
+        {
+            await userService.UpdateDiffPreferencesAsync(user.Id, model.ShowDiffOnRevisit, readingStyle, cooldownHours);
+            TempData["Success"] = "Change notification preferences updated.";
         }
         catch (Exception ex)
         {

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -457,15 +457,27 @@ public class ReaderController(
             });
         }
 
-        // Populate comment counts via application service
+        // Populate comment counts and chapter change statuses via application service
         var allChapterIds = viewModel.Projects
             .SelectMany(p => p.PublishedChapters.Select(c => c.Chapter.Id))
             .ToList();
-        var commentCounts = await _readerDashboardService.GetReaderChapterCommentCountsAsync(user.Id, allChapterIds);
+
+        var dashboardPrefs = await _userPreferencesRepo.GetByUserIdAsync(user.Id);
+        var readingStyle   = dashboardPrefs?.ReadingStyle ?? ReadingStyle.StoryReader;
+
+        var commentCounts   = await _readerDashboardService.GetReaderChapterCommentCountsAsync(user.Id, allChapterIds);
+        var changeStatuses  = await _readerDashboardService.GetChapterChangeStatusesAsync(user.Id, allChapterIds, readingStyle);
+
         foreach (var proj in viewModel.Projects)
+        {
             foreach (var ch in proj.PublishedChapters)
+            {
                 if (commentCounts.TryGetValue(ch.Chapter.Id, out var count))
                     ch.ReaderCommentCount = count;
+                if (changeStatuses.TryGetValue(ch.Chapter.Id, out var status))
+                    ch.ChapterChangeClassification = status;
+            }
+        }
 
         // Resolve resume target via application service
         var resumeTarget = await _readerDashboardService.GetCrossProjectResumeTargetAsync(user.Id, projectIds);
@@ -584,14 +596,14 @@ public class ReaderController(
             .OrderBy(s => s.SortOrder)
             .ToList();
 
+        var preferences = await _userPreferencesRepo.GetByUserIdAsync(user.Id);
+        var showDiffOnRevisit = preferences?.ShowDiffOnRevisit ?? false;
+
         var scenesWithComments = new List<SceneWithComments>();
         foreach (var scene in scenes)
         {
             var sceneWithComments = await BuildSceneWithCommentsAsync(
-                scene,
-                user,
-                project?.AuthorId ?? Guid.Empty,
-                isModerator);
+                scene, user, project?.AuthorId ?? Guid.Empty, isModerator, showDiffOnRevisit);
             scenesWithComments.Add(sceneWithComments);
         }
 
@@ -599,7 +611,7 @@ public class ReaderController(
         if (!scenesWithComments.Any())
         {
             var leafContent = await BuildSceneWithCommentsAsync(
-                chapter, user, project?.AuthorId ?? Guid.Empty, isModerator);
+                chapter, user, project?.AuthorId ?? Guid.Empty, isModerator, showDiffOnRevisit);
             scenesWithComments.Add(leafContent);
         }
 
@@ -607,7 +619,6 @@ public class ReaderController(
         var chapterComments    = await BuildCommentDisplayModelsAsync(chapterCommentsRaw, user.Id, project?.AuthorId ?? Guid.Empty, isModerator);
         var breadcrumb         = BuildBreadcrumb(chapter, allSections);
         var topAncestor        = GetTopLevelAncestor(chapter, allSections);
-        var preferences        = await _userPreferencesRepo.GetByUserIdAsync(user.Id);
 
         DesktopSectionContentsViewModel? bookContents = null;
         if (topAncestor is not null)
@@ -681,8 +692,11 @@ public class ReaderController(
 
         await ProgressService.RecordOpenAsync(id, user.Id);
 
-        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner) =
-            await ResolveSceneContentAndDiffAsync(scene, user.Id);
+        var preferences       = await _userPreferencesRepo.GetByUserIdAsync(user.Id);
+        var showDiffMobile    = preferences?.ShowDiffOnRevisit ?? false;
+
+        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, _, updatedSinceLastRead, showUpdateBanner, _, _) =
+            await ResolveSceneContentAndDiffAsync(scene, user.Id, showDiffMobile);
 
         var (prevSceneId, nextSceneId) = section.NodeType == NodeType.Document
             ? GetPrevNextSceneIds(scene.Id, chapter.Id, allSections)
@@ -690,7 +704,6 @@ public class ReaderController(
 
         var commentsRaw       = await CommentService.GetThreadsForSectionAsync(id, user.Id);
         var sceneCommentCount = commentsRaw.Count(c => !c.IsSoftDeleted);
-        var preferences       = await _userPreferencesRepo.GetByUserIdAsync(user.Id);
 
         return View("MobileRead", new MobileReadViewModel {
             Scene                    = scene,
@@ -727,46 +740,56 @@ public class ReaderController(
         Domain.Entities.User user,
         Guid projectAuthorId,
         bool isModerator,
+        bool showDiffOnRevisit,
         CancellationToken ct = default)
     {
         await ProgressService.RecordOpenAsync(scene.Id, user.Id, ct);
 
-        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner) =
-            await ResolveSceneContentAndDiffAsync(scene, user.Id, ct);
+        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel,
+             resumeCaptureText, resumeRestoreTarget, diffParagraphs, diffClassification,
+             updatedSinceLastRead, showUpdateBanner, diffEnabled, wordCount) =
+            await ResolveSceneContentAndDiffAsync(scene, user.Id, showDiffOnRevisit, ct);
 
         var comments = await CommentService.GetThreadsForSectionAsync(scene.Id, user.Id, ct);
         var displayComments = await BuildCommentDisplayModelsAsync(comments, user.Id, projectAuthorId, isModerator);
 
         return new SceneWithComments
         {
-            Scene = scene,
-            Comments = displayComments,
-            ResolvedHtmlContent = resolvedHtml,
-            CurrentSectionVersionId = currentSectionVersionId,
-            ResumeCaptureText = resumeCaptureText,
-            HasResumeRestoreTarget = resumeRestoreTarget?.HasTarget ?? false,
-            ResumeRestoreStartOffset = resumeRestoreTarget?.StartOffset,
-            ResumeRestoreEndOffset = resumeRestoreTarget?.EndOffset,
-            ResumeRestoreStatus = resumeRestoreTarget?.Status,
+            Scene                        = scene,
+            Comments                     = displayComments,
+            ResolvedHtmlContent          = resolvedHtml,
+            CurrentSectionVersionId      = currentSectionVersionId,
+            ResumeCaptureText            = resumeCaptureText,
+            HasResumeRestoreTarget       = resumeRestoreTarget?.HasTarget ?? false,
+            ResumeRestoreStartOffset     = resumeRestoreTarget?.StartOffset,
+            ResumeRestoreEndOffset       = resumeRestoreTarget?.EndOffset,
+            ResumeRestoreStatus          = resumeRestoreTarget?.Status,
             ResumeRestoreConfidenceScore = resumeRestoreTarget?.ConfidenceScore,
-            ResumeRestoreMatchMethod = resumeRestoreTarget?.MatchMethod,
-            DiffParagraphs = diffParagraphs,
-            UpdatedSinceLastRead = updatedSinceLastRead,
-            ShowUpdateBanner = showUpdateBanner,
-            CurrentVersionNumber = currentVersionNumber,
-            VersionLabel = versionLabel
+            ResumeRestoreMatchMethod     = resumeRestoreTarget?.MatchMethod,
+            DiffParagraphs               = diffParagraphs,
+            DiffClassification           = diffClassification,
+            DiffEnabled                  = diffEnabled,
+            WordCount                    = wordCount,
+            UpdatedSinceLastRead         = updatedSinceLastRead,
+            ShowUpdateBanner             = showUpdateBanner,
+            CurrentVersionNumber         = currentVersionNumber,
+            VersionLabel                 = versionLabel
         };
     }
 
     /// <summary>
     /// Resolves scene content from the latest version (or fallback to working content),
-    /// computes diff if reader has a prior read version, and updates reader progress.
-    /// Returns: (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner)
+    /// and computes diff via ReaderDiffService (applies ShowDiffOnRevisit, cooldown, threshold).
+    /// LastReadVersionNumber is no longer advanced on open — only via explicit mark-as-read.
+    /// Returns: (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel,
+    ///           resumeCaptureText, resumeRestoreTarget, diffParagraphs, diffClassification,
+    ///           updatedSinceLastRead, showUpdateBanner, diffEnabled, wordCount)
     /// </summary>
-    private async Task<(string? resolvedHtml, Guid? currentSectionVersionId, int? currentVersionNumber, string? versionLabel, string resumeCaptureText, ResumeRestoreTargetDto? resumeRestoreTarget, IReadOnlyList<ParagraphDiffResult> diffParagraphs, bool updatedSinceLastRead, bool showUpdateBanner)>
+    private async Task<(string? resolvedHtml, Guid? currentSectionVersionId, int? currentVersionNumber, string? versionLabel, string resumeCaptureText, ResumeRestoreTargetDto? resumeRestoreTarget, IReadOnlyList<ParagraphDiffResult> diffParagraphs, ChangeClassification? diffClassification, bool updatedSinceLastRead, bool showUpdateBanner, bool diffEnabled, int wordCount)>
         ResolveSceneContentAndDiffAsync(
             Section scene,
             Guid userId,
+            bool showDiffOnRevisit,
             CancellationToken ct = default)
     {
         var latestVersion = await sectionVersionRepo.GetLatestAsync(scene.Id, ct);
@@ -776,37 +799,37 @@ public class ReaderController(
         var versionLabel = latestVersion?.VersionLabel;
         var resumeCaptureText = CanonicalizeForCapture(resolvedHtml);
         var resumeRestoreTarget = await ProgressService.GetResumeRestoreTargetAsync(
-            scene.Id,
-            currentSectionVersionId,
-            userId,
-            ct);
+            scene.Id, currentSectionVersionId, userId, ct);
         var readEvent = await readEventRepo.GetAsync(scene.Id, userId, ct);
-        var lastReadVersionNumber = readEvent?.LastReadVersionNumber;
 
-        var diffResult = await sectionDiffService.GetDiffForReaderAsync(
-            scene.Id, lastReadVersionNumber, ct);
-
-        var updatedSinceLastRead = diffResult is not null
-            && diffResult.HasChanges
-            && readEvent?.LastReadVersionNumber is not null
-            && currentVersionNumber.HasValue;
-
-        var showUpdateBanner = diffResult is not null
-            && diffResult.HasChanges
-            && readEvent?.LastReadVersionNumber is not null
+        // Banner and "updated since" are version-comparison concerns — independent of diff preferences.
+        var isUpdatedSinceLastRead = readEvent?.LastReadVersionNumber is not null
             && currentVersionNumber.HasValue
-            && readEvent?.BannerDismissedAtVersion != diffResult.CurrentVersionNumber;
+            && currentVersionNumber.Value > readEvent.LastReadVersionNumber;
 
-        if (latestVersion is not null)
-        {
-            await ProgressService.UpdateLastReadVersionAsync(scene.Id, userId, latestVersion.VersionNumber, ct);
-        }
+        var updatedSinceLastRead = isUpdatedSinceLastRead;
+        var showUpdateBanner = isUpdatedSinceLastRead
+            && readEvent?.BannerDismissedAtVersion != currentVersionNumber;
 
-        var diffParagraphs = latestVersion is null && diffResult?.HasChanges == true
+        // Diff paragraphs respect ShowDiffOnRevisit and ReadingStyle threshold.
+        var diffResult = await _readerDiffService.GetDiffAsync(scene.Id, userId, ct);
+        var diffParagraphs = diffResult?.HasChanges == true
             ? diffResult.Paragraphs
             : Array.Empty<ParagraphDiffResult>();
 
-        return (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, updatedSinceLastRead, showUpdateBanner);
+        var diffClassification = diffResult?.Classification;
+        var wordCount = CountWords(resolvedHtml);
+
+        return (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel,
+                resumeCaptureText, resumeRestoreTarget, diffParagraphs, diffClassification,
+                updatedSinceLastRead, showUpdateBanner, showDiffOnRevisit, wordCount);
+    }
+
+    private static int CountWords(string? html)
+    {
+        if (string.IsNullOrWhiteSpace(html)) return 0;
+        var text = HtmlTagRegex.Replace(html, " ");
+        return text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
     }
 
     /// <summary>

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -30,6 +30,7 @@ public class ReaderController(
     IAccessRequestRepository accessRequestRepo,
     IAccessRequestService accessRequestService,
     IReaderDashboardService readerDashboardService,
+    IReaderDiffService readerDiffService,
     ILogger<ReaderController> logger)
     : BaseReaderController(projectRepo, sectionRepo, commentService, progressService,
                            userRepository, readerAccessRepo, humanOverrideService, passageAnchorService,
@@ -37,6 +38,7 @@ public class ReaderController(
 {
     private readonly IUserPreferencesRepository _userPreferencesRepo = userPreferencesRepo;
     private readonly IPassageAnchorService _passageAnchorService = passageAnchorService;
+    private readonly IReaderDiffService _readerDiffService = readerDiffService;
     private readonly IReaderDashboardService _readerDashboardService = readerDashboardService;
     private static readonly Regex HtmlTagRegex = new("<[^>]+>", RegexOptions.Compiled);
     private static readonly Regex WhitespaceRegex = new("\\s+", RegexOptions.Compiled);
@@ -301,6 +303,36 @@ public class ReaderController(
             return Forbid();
 
         await ProgressService.DismissBannerAsync(sectionId, user.Id, versionNumber);
+        return Ok();
+    }
+
+    // -----------------------------------------------------------------------
+    // POST: /Reader/MarkAsRead
+    // -----------------------------------------------------------------------
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> MarkAsRead(Guid sectionId)
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null)
+            return Forbid();
+
+        await _readerDiffService.MarkAsReadAsync(sectionId, user.Id);
+        return Ok();
+    }
+
+    // -----------------------------------------------------------------------
+    // POST: /Reader/MarkAsUnread
+    // -----------------------------------------------------------------------
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> MarkAsUnread(Guid sectionId)
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null)
+            return Forbid();
+
+        await _readerDiffService.MarkAsUnreadAsync(sectionId, user.Id);
         return Ok();
     }
 

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -121,6 +121,7 @@ namespace DraftView.Web.Extensions
             services.AddScoped<IHtmlDiffService, HtmlDiffService>();
             services.AddScoped<ISectionDiffService, SectionDiffService>();
             services.AddScoped<IReaderDashboardService, ReaderDashboardService>();
+            services.AddScoped<IReaderDiffService, ReaderDiffService>();
             services.AddScoped<ISectionManagementService, SectionManagementService>();
             services.AddScoped<IProjectManagementService, ProjectManagementService>();
             services.AddScoped<ICommentDisplayService, CommentDisplayService>();

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -122,6 +122,7 @@ namespace DraftView.Web.Extensions
             services.AddScoped<ISectionDiffService, SectionDiffService>();
             services.AddScoped<IReaderDashboardService, ReaderDashboardService>();
             services.AddScoped<IReaderDiffService, ReaderDiffService>();
+            // Note: ReaderDashboardService and ReaderDiffService use repositories already registered above.
             services.AddScoped<ISectionManagementService, SectionManagementService>();
             services.AddScoped<IProjectManagementService, ProjectManagementService>();
             services.AddScoped<ICommentDisplayService, CommentDisplayService>();

--- a/DraftView.Web/Models/AccountViewModels.cs
+++ b/DraftView.Web/Models/AccountViewModels.cs
@@ -65,6 +65,19 @@ public class SettingsViewModel
     public string? ReaderBio { get; set; }
     public string? ReaderGenreInterests { get; set; }
     public string? ReaderPace { get; set; }
+    public bool ShowDiffOnRevisit { get; set; }
+    public string ReadingStyle { get; set; } = "StoryReader";
+    public int DiffCooldownHours { get; set; } = 24;
+}
+
+public class ChangeDiffPreferencesViewModel
+{
+    public bool ShowDiffOnRevisit { get; set; }
+
+    [Required(ErrorMessage = "Please select a reading style.")]
+    public string ReadingStyle { get; set; } = "StoryReader";
+
+    public int DiffCooldownHours { get; set; } = 24;
 }
 
 public class UpdateReaderProfileViewModel

--- a/DraftView.Web/Models/ReaderViewModels.cs
+++ b/DraftView.Web/Models/ReaderViewModels.cs
@@ -96,6 +96,25 @@ public class SceneWithComments
     public int? CurrentVersionNumber { get; set; }
     public string? VersionLabel { get; set; }
 
+    /// <summary>
+    /// The classification of the diff between the reader's last read version
+    /// and the current version. Null when no diff exists or diff is suppressed.
+    /// Used to render the coloured pill in the "This chapter" nav.
+    /// </summary>
+    public ChangeClassification? DiffClassification { get; set; }
+
+    /// <summary>
+    /// True when the reader's profile has ShowDiffOnRevisit enabled.
+    /// Controls whether the diff toggle and mark-as-read/unread controls are shown.
+    /// </summary>
+    public bool DiffEnabled { get; set; }
+
+    /// <summary>
+    /// Approximate word count of the scene's current content.
+    /// Passed to JS to compute estimated reading time for auto mark-as-read.
+    /// </summary>
+    public int WordCount { get; set; }
+
 }
 
 public class CommentDisplayViewModel
@@ -162,6 +181,13 @@ public class DesktopChapterProgressViewModel
     /// directly to Read rather than expecting a scenes sub-list.
     /// </summary>
     public bool IsLeaf { get; set; }
+
+    /// <summary>
+    /// The highest change classification across all scenes in this chapter since
+    /// the reader last read them, filtered by the reader's ReadingStyle threshold.
+    /// Null when the reader is up to date at their threshold level.
+    /// </summary>
+    public ChangeClassification? ChapterChangeClassification { get; set; }
 }
 
 public enum DiscoveryRequestStatus { None, Pending, Approved, Declined }

--- a/DraftView.Web/Views/Account/Settings.cshtml
+++ b/DraftView.Web/Views/Account/Settings.cshtml
@@ -101,6 +101,42 @@
 
             @if (Model.IsReader)
             {
+                <div class="card settings-card">
+                    <div class="card__header"><span class="card__title">Change Notifications</span></div>
+                    <div class="card__body">
+                        <p class="settings-hint">Control how you see updates when an author edits chapters you have already read.</p>
+                        <form asp-action="ChangeDiffPreferences" method="post">
+                            @Html.AntiForgeryToken()
+                            <div class="settings-form-stack">
+                                <div class="settings-form-group settings-form-group--toggle">
+                                    <label class="form-label">Show changes when I revisit a chapter</label>
+                                    <input type="checkbox" name="ShowDiffOnRevisit" value="true" @(Model.ShowDiffOnRevisit ? "checked" : "") class="form-checkbox" id="showDiffOnRevisit" />
+                                    <input type="hidden" name="ShowDiffOnRevisit" value="false" />
+                                </div>
+                                <div class="settings-form-group">
+                                    <label class="form-label" for="readingStyle">I am reading as</label>
+                                    <select name="ReadingStyle" id="readingStyle" class="form-input">
+                                        <option value="BetaReader" selected="@(Model.ReadingStyle == "BetaReader")">Beta reader — show everything, including typos</option>
+                                        <option value="StoryReader" selected="@(Model.ReadingStyle == "StoryReader")">Story reader — minor edits and above</option>
+                                        <option value="AlphaReader" selected="@(Model.ReadingStyle == "AlphaReader")">Alpha reader — meaningful revisions and above</option>
+                                        <option value="StructureOnly" selected="@(Model.ReadingStyle == "StructureOnly")">Structure only — major rewrites only</option>
+                                    </select>
+                                </div>
+                                <div class="settings-form-group">
+                                    <label class="form-label" for="diffCooldown">Show new changes after marking as read</label>
+                                    <select name="DiffCooldownHours" id="diffCooldown" class="form-input">
+                                        <option value="1" selected="@(Model.DiffCooldownHours == 1)">Immediately</option>
+                                        <option value="24" selected="@(Model.DiffCooldownHours == 24)">After 24 hours</option>
+                                        <option value="72" selected="@(Model.DiffCooldownHours == 72)">After 3 days</option>
+                                        <option value="168" selected="@(Model.DiffCooldownHours == 168)">After 1 week</option>
+                                    </select>
+                                </div>
+                                <button type="submit" class="btn btn--primary settings-form-button-inline">Save</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
                 <div class="card settings-card reader-profile-card">
                     <div class="card__header"><span class="card__title">Reader Profile</span></div>
                     <div class="card__body">

--- a/DraftView.Web/Views/Reader/DesktopDashboard.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopDashboard.cshtml
@@ -1,4 +1,5 @@
 ﻿@model DraftView.Web.Models.DesktopDashboardViewModel
+@using DraftView.Domain.Enumerations
 @{
     ViewData["Title"] = "My Reading";
     var selectedId = Context.Request.Query["projectId"].ToString();
@@ -135,13 +136,29 @@ else
                                                     }
                                                 </td>
                                                 <td class="reader-dashboard__cell reader-dashboard__cell--status">
-                                                    @if (item.HasRead)
+                                                    @if (!item.HasRead)
                                                     {
-                                                        <span class="reader-dashboard__status reader-dashboard__status--read">Read</span>
+                                                        <span class="reader-dashboard__status reader-dashboard__status--new">New</span>
+                                                    }
+                                                    else if (item.ChapterChangeClassification == ChangeClassification.Trivial)
+                                                    {
+                                                        <span class="reader-dashboard__status reader-dashboard__status--trivial">Minor fix</span>
+                                                    }
+                                                    else if (item.ChapterChangeClassification == ChangeClassification.Polish)
+                                                    {
+                                                        <span class="reader-dashboard__status reader-dashboard__status--polish">Minor edit</span>
+                                                    }
+                                                    else if (item.ChapterChangeClassification == ChangeClassification.Revision)
+                                                    {
+                                                        <span class="reader-dashboard__status reader-dashboard__status--revision">Revised</span>
+                                                    }
+                                                    else if (item.ChapterChangeClassification == ChangeClassification.Rewrite)
+                                                    {
+                                                        <span class="reader-dashboard__status reader-dashboard__status--rewrite">Rewritten</span>
                                                     }
                                                     else
                                                     {
-                                                        <span class="reader-dashboard__status reader-dashboard__status--new">New</span>
+                                                        <span class="reader-dashboard__status reader-dashboard__status--read">Read</span>
                                                     }
                                                 </td>
                                             </tr>

--- a/DraftView.Web/Views/Reader/DesktopRead.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopRead.cshtml
@@ -41,7 +41,20 @@
             <div class="reader__contents-label">This chapter</div>
             @foreach (var item in Model.Scenes)
             {
-                <a href="#scene-@item.Scene.Id" class="reader__contents-link">@item.Scene.Title@(item.VersionLabel != null ? $" ({item.VersionLabel})" : string.Empty)</a>
+                <a href="#scene-@item.Scene.Id" class="reader__contents-link">
+                    @item.Scene.Title@(item.VersionLabel != null ? $" ({item.VersionLabel})" : string.Empty)
+                    @if (item.DiffClassification.HasValue)
+                    {
+                        var pillClass = item.DiffClassification switch {
+                            DraftView.Domain.Enumerations.ChangeClassification.Trivial  => "change-pill change-pill--trivial",
+                            DraftView.Domain.Enumerations.ChangeClassification.Polish   => "change-pill change-pill--polish",
+                            DraftView.Domain.Enumerations.ChangeClassification.Revision => "change-pill change-pill--revision",
+                            DraftView.Domain.Enumerations.ChangeClassification.Rewrite  => "change-pill change-pill--rewrite",
+                            _ => "change-pill"
+                        };
+                        <span class="@pillClass" aria-hidden="true"></span>
+                    }
+                </a>
             }
             <a href="#chapter-comments"
                    class="reader__contents-link reader__contents-link--muted">
@@ -126,7 +139,20 @@
                 <div class="chapter-sidebar__label">This chapter</div>
                 @foreach (var item in Model.Scenes)
                 {
-                    <a href="#scene-@item.Scene.Id" class="chapter-sidebar__link">@item.Scene.Title@(item.VersionLabel != null ? $" ({item.VersionLabel})" : string.Empty)</a>
+                    <a href="#scene-@item.Scene.Id" class="chapter-sidebar__link">
+                        @item.Scene.Title@(item.VersionLabel != null ? $" ({item.VersionLabel})" : string.Empty)
+                        @if (item.DiffClassification.HasValue)
+                        {
+                            var pillClass = item.DiffClassification switch {
+                                DraftView.Domain.Enumerations.ChangeClassification.Trivial  => "change-pill change-pill--trivial",
+                                DraftView.Domain.Enumerations.ChangeClassification.Polish   => "change-pill change-pill--polish",
+                                DraftView.Domain.Enumerations.ChangeClassification.Revision => "change-pill change-pill--revision",
+                                DraftView.Domain.Enumerations.ChangeClassification.Rewrite  => "change-pill change-pill--rewrite",
+                                _ => "change-pill"
+                            };
+                            <span class="@pillClass" aria-hidden="true"></span>
+                        }
+                    </a>
                 }
 
                 <a href="#chapter-comments"
@@ -272,30 +298,45 @@
                             </div>
                         }
 
+                        @if (item.DiffEnabled && item.HasDiff)
+                        {
+                            <div class="diff-controls"
+                                 data-section-id="@item.Scene.Id"
+                                 data-word-count="@item.WordCount">
+                                <button type="button" class="diff-toggle-btn" data-diff-toggle="@item.Scene.Id">
+                                    <span class="diff-toggle-btn__show">Show changes</span>
+                                    <span class="diff-toggle-btn__hide" hidden>Hide changes</span>
+                                </button>
+                                <button type="button" class="diff-mark-btn diff-mark-btn--read" data-mark-read="@item.Scene.Id">Mark as read</button>
+                                <button type="button" class="diff-mark-btn diff-mark-btn--unread" data-mark-unread="@item.Scene.Id" hidden>Mark as unread</button>
+                            </div>
+                        }
+
                         <div class="scene-prose-shell">
-                            <div class="scene-prose-content prose">
-                                @if (item.HasDiff)
-                                {
-                                    @foreach (var para in item.DiffParagraphs)
-                                    {
-                                        if (para.Type == DiffResultType.Added)
+                            @if (item.DiffEnabled && item.HasDiff)
+                            {
+                                <div class="scene-diff-view" id="diff-@item.Scene.Id" hidden>
+                                    <div class="scene-prose-content prose">
+                                        @foreach (var para in item.DiffParagraphs)
                                         {
-                                            <div class="diff-para diff-para--added">@Html.Raw(para.Html)</div>
+                                            if (para.Type == DiffResultType.Added)
+                                            {
+                                                <div class="diff-para diff-para--added">@Html.Raw(para.Html)</div>
+                                            }
+                                            else if (para.Type == DiffResultType.Removed)
+                                            {
+                                                <div class="diff-para diff-para--removed">@Html.Raw(para.Html)</div>
+                                            }
+                                            else
+                                            {
+                                                @Html.Raw(para.Html)
+                                            }
                                         }
-                                        else if (para.Type == DiffResultType.Removed)
-                                        {
-                                            <div class="diff-para diff-para--removed"></div>
-                                        }
-                                        else
-                                        {
-                                            @Html.Raw(para.Html)
-                                        }
-                                    }
-                                }
-                                else
-                                {
-                                    @Html.Raw(item.ResolvedHtmlContent ?? "<p><em>The author has not added content to this scene yet.</em></p>")
-                                }
+                                    </div>
+                                </div>
+                            }
+                            <div class="scene-prose-content prose" id="prose-@item.Scene.Id">
+                                @Html.Raw(item.ResolvedHtmlContent ?? "<p><em>The author has not added content to this scene yet.</em></p>")
                             </div>
                         </div>
                     </div>
@@ -1645,6 +1686,101 @@
                     event.preventDefault();
                 }
             });
+        });
+    })();
+
+    // ── Diff toggle, mark-as-read / mark-as-unread ───────────────────────────
+    (function () {
+        var antiForgeryInput = document.querySelector('input[name="__RequestVerificationToken"]');
+        if (!antiForgeryInput) return;
+
+        function postToReader(path, sectionId) {
+            return fetch('/Reader/' + path + '?sectionId=' + sectionId, {
+                method: 'POST',
+                headers: { 'RequestVerificationToken': antiForgeryInput.value }
+            });
+        }
+
+        // Diff view toggle
+        document.querySelectorAll('[data-diff-toggle]').forEach(function (btn) {
+            var sectionId = btn.getAttribute('data-diff-toggle');
+            var diffView  = document.getElementById('diff-' + sectionId);
+            var proseView = document.getElementById('prose-' + sectionId);
+
+            btn.addEventListener('click', function () {
+                var showing = !diffView.hidden;
+                diffView.hidden  = showing;
+                proseView.hidden = !showing;
+                btn.querySelector('.diff-toggle-btn__show').hidden = !showing;
+                btn.querySelector('.diff-toggle-btn__hide').hidden =  showing;
+            });
+        });
+
+        // Mark as read (explicit button)
+        document.querySelectorAll('[data-mark-read]').forEach(function (btn) {
+            var sectionId = btn.getAttribute('data-mark-read');
+            btn.addEventListener('click', function () {
+                postToReader('MarkAsRead', sectionId).then(function () {
+                    // Show mark-as-unread, hide mark-as-read
+                    btn.hidden = true;
+                    var unreadBtn = document.querySelector('[data-mark-unread="' + sectionId + '"]');
+                    if (unreadBtn) unreadBtn.hidden = false;
+                });
+            });
+        });
+
+        // Mark as unread (explicit button)
+        document.querySelectorAll('[data-mark-unread]').forEach(function (btn) {
+            var sectionId = btn.getAttribute('data-mark-unread');
+            btn.addEventListener('click', function () {
+                postToReader('MarkAsUnread', sectionId).then(function () {
+                    btn.hidden = true;
+                    var readBtn = document.querySelector('[data-mark-read="' + sectionId + '"]');
+                    if (readBtn) readBtn.hidden = false;
+                });
+            });
+        });
+
+        // Auto mark-as-read: time + scroll per scene
+        document.querySelectorAll('.diff-controls[data-section-id]').forEach(function (controls) {
+            var sectionId       = controls.getAttribute('data-section-id');
+            var wordCount       = parseInt(controls.getAttribute('data-word-count') || '0', 10);
+            var estimatedSecs   = Math.max(30, Math.floor((wordCount / 200) * 60 * 0.8));
+            var sceneBlock      = document.querySelector('.scene-block[data-section-id="' + sectionId + '"]');
+            if (!sceneBlock) return;
+
+            var activeSeconds   = 0;
+            var scrolledPast75  = false;
+            var marked          = false;
+            var timer;
+
+            // Active time tracking via Page Visibility API
+            function tick() { if (!document.hidden && !marked) activeSeconds++; }
+            timer = setInterval(tick, 1000);
+
+            // Scroll depth tracking
+            function checkScroll() {
+                if (marked) return;
+                var rect   = sceneBlock.getBoundingClientRect();
+                var bottom = rect.bottom;
+                var trigger = window.innerHeight * 0.25;
+                if (bottom < trigger) scrolledPast75 = true;
+                if (scrolledPast75 && activeSeconds >= estimatedSecs) autoMarkAsRead();
+            }
+            window.addEventListener('scroll', checkScroll, { passive: true });
+
+            function autoMarkAsRead() {
+                if (marked) return;
+                marked = true;
+                clearInterval(timer);
+                postToReader('MarkAsRead', sectionId).then(function () {
+                    // Update button states
+                    var readBtn   = document.querySelector('[data-mark-read="' + sectionId + '"]');
+                    var unreadBtn = document.querySelector('[data-mark-unread="' + sectionId + '"]');
+                    if (readBtn)   readBtn.hidden   = true;
+                    if (unreadBtn) unreadBtn.hidden = false;
+                });
+            }
         });
     })();
 </script>

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-30-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-30-1" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-31-1" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-30-1" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-31-1" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-30-1";
+    --css-version: "v2026-08-31-1";
     /* Banner image focal point — overridden per theme for images that are not 3.2:1 panoramic.
        Default suits Noir / Crime / Contemporary (all correctly proportioned at ~2240x700).
        Historic and Adventure override this until replacement panoramic banners are available. */

--- a/DraftView.Web/wwwroot/css/DraftView.DesktopReader.css
+++ b/DraftView.Web/wwwroot/css/DraftView.DesktopReader.css
@@ -963,6 +963,78 @@
     font-weight: var(--font-medium);
 }
 
+.reader-dashboard__status--trivial { color: var(--color-text-muted); }
+.reader-dashboard__status--polish  { color: #b45309; font-weight: var(--font-medium); }
+.reader-dashboard__status--revision { color: #c2410c; font-weight: var(--font-medium); }
+.reader-dashboard__status--rewrite  { color: #dc2626; font-weight: var(--font-medium); }
+
+/* Scene change pill — "This chapter" nav (no text, colour only) */
+.change-pill {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-left: var(--space-2);
+    vertical-align: middle;
+    flex-shrink: 0;
+}
+
+.change-pill--trivial  { background: var(--color-text-muted); }
+.change-pill--polish   { background: #d97706; }
+.change-pill--revision { background: #ea580c; }
+.change-pill--rewrite  { background: #dc2626; }
+
+/* Diff controls — toggle + mark-as-read/unread */
+.diff-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+}
+
+.diff-toggle-btn {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--text-sm);
+}
+
+.diff-toggle-btn:hover { color: var(--color-text); border-color: var(--color-text-muted); }
+
+.diff-mark-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: var(--text-sm);
+    padding: 0;
+}
+
+.diff-mark-btn--read   { color: var(--color-text-muted); }
+.diff-mark-btn--unread { color: var(--color-text-muted); }
+.diff-mark-btn:hover   { color: var(--color-text); }
+
+/* Diff paragraph rendering */
+.diff-para--added   { background: #f0fdf4; border-left: 3px solid #22c55e; padding-left: var(--space-3); }
+.diff-para--removed { background: #fef2f2; border-left: 3px solid #ef4444; padding-left: var(--space-3); }
+
+/* Inline word-level diff (Modified paragraphs) */
+.prose del {
+    color: #dc2626;
+    text-decoration: line-through;
+    background: #fee2e2;
+}
+
+.prose ins {
+    color: #15803d;
+    text-decoration: none;
+    background: #dcfce7;
+}
+
 .reader-dashboard__chapter-link {
     color: var(--color-text);
     font-weight: var(--font-medium);


### PR DESCRIPTION
Closes #103

## Summary

Implements the reader-facing \"What's Changed\" feature: when a reader revisits a chapter that has been updated since they last read it, they can see a word-level diff showing what changed — red strikethrough for removed words, green highlight for inserted words.

- **Dashboard**: status column extended from binary Read/New to five states (Minor fix / Minor edit / Revised / Rewritten / Read), respecting each reader's ReadingStyle threshold
- **Reading pane**: coloured pills in the \"This chapter\" nav per scene (no text, colour only); diff toggle (Show/Hide changes); Mark as read / Mark as unread controls; JS time+scroll auto mark-as-read
- **Settings**: new \"Change Notifications\" card — show/hide diff on revisit, reading style (role labels), cooldown period
- All reader-owned preferences — the author has no control over how readers receive changes

## Phases

| Phase | Scope |
|-------|-------|
| 1 | Domain model: `ReadingStyle` enum, `Trivial` classification tier, `ReadEvent.MarkAsRead/MarkAsUnread`, `UserPreferences` diff fields, EF migration |
| 2 | Word-level LCS diff service; `Modified` paragraph type with inline `<del>`/`<ins>`; word-count classification (Trivial/Polish/Revision/Rewrite); cooldown gate and ReadingStyle threshold in `SectionDiffService` |
| 3 | `IReaderDiffService` orchestrator; `POST /Reader/MarkAsRead` and `POST /Reader/MarkAsUnread` endpoints |
| 4 | Dashboard badges; scene nav pills; diff toggle + mark controls; JS auto-mark; Settings card; CSS |

## Test plan

- [ ] 1,358 tests passing (0 failed, 1 skipped — SMTP integration, expected)
- [ ] Settings page shows Change Notifications card for reader accounts
- [ ] Dashboard status column shows correct labels per chapter (New / Minor edit / Revised / Rewritten / Read)
- [ ] Reading pane: coloured pill appears next to scene titles in both nav panels when diff exists
- [ ] Show/Hide changes toggle works; diff view renders del/ins inline
- [ ] Mark as read button fires silent POST and updates button state
- [ ] Mark as unread restores the diff view
- [ ] JS auto-mark fires after scroll + time thresholds are met
- [ ] EF migration applies cleanly against the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)