### PR TITLE
fix: CHANGE-024 -- GetChapterChangeStatusesAsync null LastReadVersionNumber treated as pending

### DIFF
--- a/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
@@ -408,6 +408,52 @@ public class ReaderDashboardServiceTests
         Assert.Equal(ChangeClassification.Rewrite, result[chapterId]);
     }
 
+    [Fact]
+    public async Task ChapterChangeStatuses_WhenNullLastReadVersionNumber_WithVersionMeetingThreshold_ReturnsClassification()
+    {
+        // Backfill scenario: ReadEvent exists but LastReadVersionNumber is null
+        // (reader credited with a pre-versioning read). Any published version counts as pending.
+        var chapterId = Guid.NewGuid();
+        var scene = CreateScene(chapterId);
+        var readEvent = ReadEvent.Create(scene.Id, UserId); // LastReadVersionNumber stays null
+        var version = CreateVersion(scene, 1, ChangeClassification.Polish);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([scene]);
+        _readEventRepo.Setup(r => r.GetAsync(scene.Id, UserId, default))
+            .ReturnsAsync(readEvent);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(scene.Id, default))
+            .ReturnsAsync(version);
+
+        var result = await CreateSut().GetChapterChangeStatusesAsync(
+            UserId, [chapterId], ReadingStyle.StoryReader);
+
+        Assert.Equal(ChangeClassification.Polish, result[chapterId]);
+    }
+
+    [Fact]
+    public async Task ChapterChangeStatuses_WhenNullLastReadVersionNumber_WithClassificationBelowThreshold_ReturnsNull()
+    {
+        // Backfill scenario: ReadEvent exists, LastReadVersionNumber is null,
+        // but the published version is Trivial — below StoryReader threshold.
+        var chapterId = Guid.NewGuid();
+        var scene = CreateScene(chapterId);
+        var readEvent = ReadEvent.Create(scene.Id, UserId);
+        var version = CreateVersion(scene, 1, ChangeClassification.Trivial);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([scene]);
+        _readEventRepo.Setup(r => r.GetAsync(scene.Id, UserId, default))
+            .ReturnsAsync(readEvent);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(scene.Id, default))
+            .ReturnsAsync(version);
+
+        var result = await CreateSut().GetChapterChangeStatusesAsync(
+            UserId, [chapterId], ReadingStyle.StoryReader);
+
+        Assert.Null(result[chapterId]);
+    }
+
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------

--- a/DraftView.Application/Services/ReaderDashboardService.cs
+++ b/DraftView.Application/Services/ReaderDashboardService.cs
@@ -106,14 +106,17 @@ public class ReaderDashboardService(
             foreach (var scene in documents)
             {
                 var readEvent = await readEventRepo.GetAsync(scene.Id, userId, ct);
-                if (readEvent?.LastReadVersionNumber is null)
+                if (readEvent is null)
                     continue;
 
                 var latestVersion = await sectionVersionRepo.GetLatestAsync(scene.Id, ct);
                 if (latestVersion is null)
                     continue;
 
-                if (latestVersion.VersionNumber <= readEvent.LastReadVersionNumber)
+                // Null LastReadVersionNumber = baseline unknown (pre-versioning read or backfill).
+                // Any published version counts as pending for this reader.
+                if (readEvent.LastReadVersionNumber is not null &&
+                    latestVersion.VersionNumber <= readEvent.LastReadVersionNumber)
                     continue;
 
                 var classification = latestVersion.ChangeClassification;


### PR DESCRIPTION
## Summary

Design flaw in the CHANGE-024 implementation: `GetChapterChangeStatusesAsync` used a single null check that collapsed two distinct states into one:

- `readEvent is null` — reader has never opened the section → \"New\" (correct skip)
- `readEvent.LastReadVersionNumber is null` — reader was backfilled with a pre-versioning read but no version number → incorrectly skipped, shown as \"Read\"

The backfill inserted ReadEvents for Becca and Hilary crediting their March 2026 reads, but with `LastReadVersionNumber = null` (no published version existed at that point for most sections). The service then treated those scenes as up to date, hiding all post-March change badges.

## Fix

Split the null check:

- Skip only when `readEvent is null` (never opened = \"New\" state)
- When `LastReadVersionNumber is null`, skip the version-number comparison and proceed to classification — any published version counts as pending for this reader

## Tests

Two new tests covering the null-baseline scenario:
- `ChapterChangeStatuses_WhenNullLastReadVersionNumber_WithVersionMeetingThreshold_ReturnsClassification`
- `ChapterChangeStatuses_WhenNullLastReadVersionNumber_WithClassificationBelowThreshold_ReturnsNull`

## Test plan

- [ ] 1,360 tests passing (0 failed, 1 skipped — SMTP integration, expected)
- [ ] Becca and Hilary's dashboards show classification badges for post-March chapters
- [ ] Chapters with no published version still show \"New\" for readers with no ReadEvent

🤖 Generated with [Claude Code](https://claude.com/claude-code)