### PR TITLE
fix: Jenny-Bug (#107) -- dashboard HasRead checks chapter folder AND descendant scenes

### DIFF
--- a/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
@@ -277,6 +277,85 @@ public class ReaderDashboardServiceTests
     }
 
     // -----------------------------------------------------------------------
+    // GetChapterHasReadStatusesAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ChapterHasReadStatuses_EmptyChapterIds_ReturnsEmptyDictionary()
+    {
+        var result = await CreateSut().GetChapterHasReadStatusesAsync(UserId, []);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ChapterHasReadStatuses_ChapterFolderHasReadEvent_ReturnsTrue()
+    {
+        var chapterId = Guid.NewGuid();
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default)).ReturnsAsync([]);
+        _readEventRepo.Setup(r => r.HasReadAsync(chapterId, UserId, default)).ReturnsAsync(true);
+
+        var result = await CreateSut().GetChapterHasReadStatusesAsync(UserId, [chapterId]);
+
+        Assert.True(result[chapterId]);
+    }
+
+    [Fact]
+    public async Task ChapterHasReadStatuses_OnlySceneHasReadEvent_ReturnsTrue()
+    {
+        // Jenny-Bug: reader opened a scene via mobile — no ReadEvent on chapter folder.
+        var chapterId = Guid.NewGuid();
+        var scene = CreateScene(chapterId);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default)).ReturnsAsync([scene]);
+        _readEventRepo.Setup(r => r.HasReadAsync(chapterId, UserId, default)).ReturnsAsync(false);
+        _readEventRepo.Setup(r => r.HasReadAsync(scene.Id, UserId, default)).ReturnsAsync(true);
+
+        var result = await CreateSut().GetChapterHasReadStatusesAsync(UserId, [chapterId]);
+
+        Assert.True(result[chapterId]);
+    }
+
+    [Fact]
+    public async Task ChapterHasReadStatuses_NoReadEventsAnywhere_ReturnsFalse()
+    {
+        var chapterId = Guid.NewGuid();
+        var scene = CreateScene(chapterId);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default)).ReturnsAsync([scene]);
+        _readEventRepo.Setup(r => r.HasReadAsync(chapterId, UserId, default)).ReturnsAsync(false);
+        _readEventRepo.Setup(r => r.HasReadAsync(scene.Id, UserId, default)).ReturnsAsync(false);
+
+        var result = await CreateSut().GetChapterHasReadStatusesAsync(UserId, [chapterId]);
+
+        Assert.False(result[chapterId]);
+    }
+
+    [Fact]
+    public async Task ChapterHasReadStatuses_MultipleChapters_CorrectDistribution()
+    {
+        var ch1Id = Guid.NewGuid();
+        var ch2Id = Guid.NewGuid();
+        var scene1 = CreateScene(ch1Id);
+        var scene2 = CreateScene(ch2Id);
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(ch1Id, default)).ReturnsAsync([scene1]);
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(ch2Id, default)).ReturnsAsync([scene2]);
+
+        // ch1: scene has been read (mobile path), folder has not
+        _readEventRepo.Setup(r => r.HasReadAsync(ch1Id, UserId, default)).ReturnsAsync(false);
+        _readEventRepo.Setup(r => r.HasReadAsync(scene1.Id, UserId, default)).ReturnsAsync(true);
+
+        // ch2: nothing read
+        _readEventRepo.Setup(r => r.HasReadAsync(ch2Id, UserId, default)).ReturnsAsync(false);
+        _readEventRepo.Setup(r => r.HasReadAsync(scene2.Id, UserId, default)).ReturnsAsync(false);
+
+        var result = await CreateSut().GetChapterHasReadStatusesAsync(UserId, [ch1Id, ch2Id]);
+
+        Assert.True(result[ch1Id]);
+        Assert.False(result[ch2Id]);
+    }
+
+    // -----------------------------------------------------------------------
     // GetChapterChangeStatusesAsync
     // -----------------------------------------------------------------------
 

--- a/DraftView.Application/Services/ReaderDashboardService.cs
+++ b/DraftView.Application/Services/ReaderDashboardService.cs
@@ -77,6 +77,42 @@ public class ReaderDashboardService(
         return result;
     }
 
+    public async Task<IReadOnlyDictionary<Guid, bool>> GetChapterHasReadStatusesAsync(
+        Guid userId, IReadOnlyList<Guid> chapterIds, CancellationToken ct = default)
+    {
+        var result = new Dictionary<Guid, bool>();
+
+        if (chapterIds.Count == 0)
+            return result;
+
+        foreach (var chapterId in chapterIds)
+        {
+            if (result.ContainsKey(chapterId))
+                continue;
+
+            if (await readEventRepo.HasReadAsync(chapterId, userId, ct))
+            {
+                result[chapterId] = true;
+                continue;
+            }
+
+            var descendants = await sectionRepo.GetAllDescendantsAsync(chapterId, ct);
+            var hasReadScene = false;
+            foreach (var scene in descendants.Where(s => s.NodeType == NodeType.Document))
+            {
+                if (await readEventRepo.HasReadAsync(scene.Id, userId, ct))
+                {
+                    hasReadScene = true;
+                    break;
+                }
+            }
+
+            result[chapterId] = hasReadScene;
+        }
+
+        return result;
+    }
+
     /// <summary>
     /// Returns the highest ChangeClassification across all Document scenes in each chapter
     /// that have been updated since the reader's last read version, filtered by ReadingStyle.

--- a/DraftView.Domain/Interfaces/Services/IReaderDashboardService.cs
+++ b/DraftView.Domain/Interfaces/Services/IReaderDashboardService.cs
@@ -24,6 +24,15 @@ public interface IReaderDashboardService
         Guid userId, IReadOnlyList<Guid> chapterIds, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns true for a chapter if the reader has any ReadEvent on the chapter
+    /// folder OR on any descendant Document scene. Covers both the desktop path
+    /// (where the chapter folder gets a ReadEvent) and the mobile path (where only
+    /// scene nodes get ReadEvents). Every requested chapterId appears as a key.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, bool>> GetChapterHasReadStatusesAsync(
+        Guid userId, IReadOnlyList<Guid> chapterIds, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns the highest ChangeClassification across all scenes updated since
     /// the reader last read them, filtered by the reader's ReadingStyle threshold.
     /// Null means the reader is up to date (or has never read) at their threshold level.

--- a/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
@@ -858,7 +858,8 @@ public class ReaderControllerTests
         projectRepo.Setup(r => r.GetByIdAsync(project.Id, It.IsAny<CancellationToken>())).ReturnsAsync(project);
         sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, It.IsAny<CancellationToken>())).ReturnsAsync([chapter, scene]);
         progressService.Setup(r => r.GetLastReadEventAsync(user.Id, project.Id, It.IsAny<CancellationToken>())).ReturnsAsync(readEvent);
-        progressService.Setup(r => r.HasReadSectionAsync(user.Id, chapter.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        readerDashboardService.Setup(r => r.GetChapterHasReadStatusesAsync(user.Id, It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, bool> { { chapter.Id, true } });
 
         var result = await sut.Dashboard();
 
@@ -890,7 +891,8 @@ public class ReaderControllerTests
         projectRepo.Setup(r => r.GetByIdAsync(project.Id, It.IsAny<CancellationToken>())).ReturnsAsync(project);
         sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, It.IsAny<CancellationToken>())).ReturnsAsync([chapter, scene]);
         progressService.Setup(r => r.GetLastReadEventAsync(user.Id, project.Id, It.IsAny<CancellationToken>())).ReturnsAsync((ReadEvent?)null);
-        progressService.Setup(r => r.HasReadSectionAsync(user.Id, chapter.Id, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        readerDashboardService.Setup(r => r.GetChapterHasReadStatusesAsync(user.Id, It.IsAny<IReadOnlyList<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, bool> { { chapter.Id, false } });
 
         var result = await sut.Dashboard();
 

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -88,16 +88,18 @@ public class ReaderController(
             .ThenBy(s => s.SortOrder)
             .ToList();
 
+        var chapterIds = publishedChapters.Select(c => c.Id).ToList();
+        var hasReadStatuses = await _readerDashboardService.GetChapterHasReadStatusesAsync(user.Id, chapterIds);
+
         var chapterRows = new List<MobileChapterRowViewModel>();
         foreach (var chapter in publishedChapters)
         {
-            var hasRead    = await ProgressService.HasReadSectionAsync(user.Id, chapter.Id);
             var sceneCount = allSections.Count(s => s.ParentId == chapter.Id
                                                     && s.NodeType == NodeType.Document
                                                     && s.IsPublished && !s.IsSoftDeleted);
             chapterRows.Add(new MobileChapterRowViewModel {
                 Chapter    = chapter,
-                HasRead    = hasRead,
+                HasRead    = hasReadStatuses.GetValueOrDefault(chapter.Id),
                 SceneCount = sceneCount,
                 IsLeaf     = sceneCount == 0
             });
@@ -439,10 +441,9 @@ public class ReaderController(
             var chaptersWithProgress = new List<DesktopChapterProgressViewModel>();
             foreach (var chapter in publishedChapters)
             {
-                var hasRead = await ProgressService.HasReadSectionAsync(user.Id, chapter.Id);
                 chaptersWithProgress.Add(new DesktopChapterProgressViewModel {
                     Chapter = chapter,
-                    HasRead = hasRead,
+                    HasRead = false,  // populated in batch below
                     IsLeaf  = IsLeafChapter(chapter, allSections)
                 });
             }
@@ -451,12 +452,12 @@ public class ReaderController(
                 ProjectId         = project.Id,
                 ProjectName       = project.Name,
                 TotalChapters     = publishedChapters.Count,
-                ReadChapters      = chaptersWithProgress.Count(c => c.HasRead),
+                ReadChapters      = 0,  // populated in batch below
                 PublishedChapters = chaptersWithProgress
             });
         }
 
-        // Populate comment counts and chapter change statuses via application service
+        // Populate all chapter-level data in batch via application service
         var allChapterIds = viewModel.Projects
             .SelectMany(p => p.PublishedChapters.Select(c => c.Chapter.Id))
             .ToList();
@@ -466,6 +467,7 @@ public class ReaderController(
 
         var commentCounts   = await _readerDashboardService.GetReaderChapterCommentCountsAsync(user.Id, allChapterIds);
         var changeStatuses  = await _readerDashboardService.GetChapterChangeStatusesAsync(user.Id, allChapterIds, readingStyle);
+        var hasReadStatuses = await _readerDashboardService.GetChapterHasReadStatusesAsync(user.Id, allChapterIds);
 
         foreach (var proj in viewModel.Projects)
         {
@@ -475,7 +477,10 @@ public class ReaderController(
                     ch.ReaderCommentCount = count;
                 if (changeStatuses.TryGetValue(ch.Chapter.Id, out var status))
                     ch.ChapterChangeClassification = status;
+                if (hasReadStatuses.TryGetValue(ch.Chapter.Id, out var hasRead))
+                    ch.HasRead = hasRead;
             }
+            proj.ReadChapters = proj.PublishedChapters.Count(c => c.HasRead);
         }
 
         // Resolve resume target via application service
@@ -525,16 +530,18 @@ public class ReaderController(
             .ThenBy(s => s.SortOrder)
             .ToList();
 
+        var chapterIds = publishedChapters.Select(c => c.Id).ToList();
+        var hasReadStatuses = await _readerDashboardService.GetChapterHasReadStatusesAsync(user.Id, chapterIds);
+
         var chapterRows = new List<MobileChapterRowViewModel>();
         foreach (var chapter in publishedChapters)
         {
-            var hasRead    = await ProgressService.HasReadSectionAsync(user.Id, chapter.Id);
             var sceneCount = allSections.Count(s => s.ParentId == chapter.Id
                                                     && s.NodeType == NodeType.Document
                                                     && s.IsPublished && !s.IsSoftDeleted);
             chapterRows.Add(new MobileChapterRowViewModel {
                 Chapter    = chapter,
-                HasRead    = hasRead,
+                HasRead    = hasReadStatuses.GetValueOrDefault(chapter.Id),
                 SceneCount = sceneCount,
                 IsLeaf     = sceneCount == 0
             });


### PR DESCRIPTION
## Summary

Closes #107

Readers who opened scenes via the mobile path (`/Reader/Read/{sceneId}`) got `ReadEvent`s on Document (scene) nodes only — the chapter Folder node got no `ReadEvent`. On the dashboard, `HasReadSectionAsync(userId, chapter.Id)` is a point lookup on the chapter Folder, so those chapters always showed **New** regardless of how many scenes the reader had opened.

## Fix

Adds `GetChapterHasReadStatusesAsync(userId, chapterIds)` to `IReaderDashboardService`. A chapter is `HasRead = true` if either:
- The chapter Folder has a `ReadEvent`, **or**
- Any descendant Document (scene) has a `ReadEvent`

Replaces `HasReadSectionAsync` calls in all three controller actions that determine chapter read state:
- Desktop Dashboard
- Mobile Dashboard (Chapters list)
- Mobile Projects entry-point Chapters list

The `ReadChapters` count on the desktop dashboard is now computed after the batch call rather than during the chapter loop, so it reflects the correct value.

## Tests

Five new tests in `ReaderDashboardServiceTests`:
- Empty chapter list → empty result
- Chapter folder has ReadEvent → true
- Only a descendant scene has ReadEvent (Jenny-Bug case) → true
- No ReadEvents anywhere → false
- Multiple chapters → correct distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)