### PR TITLE
feat: #82 -- auto-version on sync for ScrivenerDropbox projects

### DIFF
--- a/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
@@ -27,6 +27,7 @@ public class ScrivenerSyncServiceTests
     private readonly Mock<ILogger<ScrivenerSyncService>>          _logger            = new();
     private readonly Mock<IAuthorNotificationRepository> _notificationRepo  = new();
     private readonly Mock<IUserRepository>               _userRepo          = new();
+    private readonly Mock<IVersioningService>            _versioningService = new();
 
     private ScrivenerSyncService CreateSut() => new(
         _projectRepo.Object,
@@ -41,7 +42,8 @@ public class ScrivenerSyncServiceTests
         _fileDownloader.Object,
         _logger.Object,
         _notificationRepo.Object,
-        _userRepo.Object);
+        _userRepo.Object,
+        _versioningService.Object);
 
     public ScrivenerSyncServiceTests()
     {
@@ -859,6 +861,103 @@ public class ScrivenerSyncServiceTests
                 n.EventType == NotificationEventType.SyncCompleted),
                 default),
             Times.Once);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Auto-versioning on sync (V-Sprint 1 revision — #82)
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ParseProjectAsync_WhenPublishedSceneContentChanges_CallsCreateVersionFromSync()
+    {
+        var project = MakeProject();
+        project.UpdateDropboxCursor("cursor-old");
+
+        var scene = Section.CreateDocument(project.Id, "SCEN-001", "Scene 1", null, 0, "<p>Old</p>", "oldhash", "First Draft");
+        scene.PublishAsPartOfChapter("oldhash");
+
+        SetupPathResolver(project);
+        SetupParserWithTree(project, new ParsedBinderNode
+        {
+            Uuid = "ROOT-001", Title = "Manuscript", NodeType = ParsedNodeType.Folder,
+            Children = new() { new() { Uuid = "SCEN-001", Title = "Scene 1", NodeType = ParsedNodeType.Document, SortOrder = 0, Children = new() } }
+        });
+
+        _sectionRepo.Setup(r => r.GetByScrivenerUuidAsync(project.Id, "ROOT-001", default)).ReturnsAsync((Section?)null);
+        _sectionRepo.Setup(r => r.GetByScrivenerUuidAsync(project.Id, "SCEN-001", default)).ReturnsAsync(scene);
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, default)).ReturnsAsync(new List<Section> { scene });
+        _converter.Setup(c => c.ConvertAsync(It.IsAny<string>(), "SCEN-001", default))
+            .ReturnsAsync(new RtfConversionResult { Html = "<p>New</p>", Hash = "newhash" });
+        _fileDownloader.Setup(x => x.ListChangedEntriesAsync(project.AuthorId, "cursor-old", default))
+            .ReturnsAsync((new List<DropboxChangedEntry>(), "cursor-new"));
+
+        await CreateSut().ParseProjectAsync(project.Id);
+
+        _versioningService.Verify(v =>
+            v.CreateVersionFromSyncAsync(scene, project.AuthorId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ParseProjectAsync_WhenUnpublishedSceneContentChanges_DoesNotCallCreateVersionFromSync()
+    {
+        var project = MakeProject();
+        project.UpdateDropboxCursor("cursor-old");
+
+        var scene = Section.CreateDocument(project.Id, "SCEN-001", "Scene 1", null, 0, "<p>Old</p>", "oldhash", "First Draft");
+        // Not published
+
+        SetupPathResolver(project);
+        SetupParserWithTree(project, new ParsedBinderNode
+        {
+            Uuid = "ROOT-001", Title = "Manuscript", NodeType = ParsedNodeType.Folder,
+            Children = new() { new() { Uuid = "SCEN-001", Title = "Scene 1", NodeType = ParsedNodeType.Document, SortOrder = 0, Children = new() } }
+        });
+
+        _sectionRepo.Setup(r => r.GetByScrivenerUuidAsync(project.Id, "ROOT-001", default)).ReturnsAsync((Section?)null);
+        _sectionRepo.Setup(r => r.GetByScrivenerUuidAsync(project.Id, "SCEN-001", default)).ReturnsAsync(scene);
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, default)).ReturnsAsync(new List<Section> { scene });
+        _converter.Setup(c => c.ConvertAsync(It.IsAny<string>(), "SCEN-001", default))
+            .ReturnsAsync(new RtfConversionResult { Html = "<p>New</p>", Hash = "newhash" });
+        _fileDownloader.Setup(x => x.ListChangedEntriesAsync(project.AuthorId, "cursor-old", default))
+            .ReturnsAsync((new List<DropboxChangedEntry>(), "cursor-new"));
+
+        await CreateSut().ParseProjectAsync(project.Id);
+
+        _versioningService.Verify(v =>
+            v.CreateVersionFromSyncAsync(It.IsAny<Section>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ParseProjectAsync_WhenContentUnchanged_DoesNotCallCreateVersionFromSync()
+    {
+        var project = MakeProject();
+        project.UpdateDropboxCursor("cursor-old");
+
+        var scene = Section.CreateDocument(project.Id, "SCEN-001", "Scene 1", null, 0, "<p>Same</p>", "samehash", "First Draft");
+        scene.PublishAsPartOfChapter("samehash");
+
+        SetupPathResolver(project);
+        SetupParserWithTree(project, new ParsedBinderNode
+        {
+            Uuid = "ROOT-001", Title = "Manuscript", NodeType = ParsedNodeType.Folder,
+            Children = new() { new() { Uuid = "SCEN-001", Title = "Scene 1", NodeType = ParsedNodeType.Document, SortOrder = 0, Children = new() } }
+        });
+
+        _sectionRepo.Setup(r => r.GetByScrivenerUuidAsync(project.Id, "ROOT-001", default)).ReturnsAsync((Section?)null);
+        _sectionRepo.Setup(r => r.GetByScrivenerUuidAsync(project.Id, "SCEN-001", default)).ReturnsAsync(scene);
+        _sectionRepo.Setup(r => r.GetByProjectIdAsync(project.Id, default)).ReturnsAsync(new List<Section> { scene });
+        _converter.Setup(c => c.ConvertAsync(It.IsAny<string>(), "SCEN-001", default))
+            .ReturnsAsync(new RtfConversionResult { Html = "<p>Same</p>", Hash = "samehash" });
+        _fileDownloader.Setup(x => x.ListChangedEntriesAsync(project.AuthorId, "cursor-old", default))
+            .ReturnsAsync((new List<DropboxChangedEntry>(), "cursor-new"));
+
+        await CreateSut().ParseProjectAsync(project.Id);
+
+        _versioningService.Verify(v =>
+            v.CreateVersionFromSyncAsync(It.IsAny<Section>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     // ---------------------------------------------------------------------------

--- a/DraftView.Application.Tests/Services/VersioningServiceTests.cs
+++ b/DraftView.Application.Tests/Services/VersioningServiceTests.cs
@@ -1111,4 +1111,132 @@ public class VersioningServiceTests
         section.UpdateContent("<p>content</p>", "hash");
         return section;
     }
+
+    // -----------------------------------------------------------------------
+    // CreateVersionFromSyncAsync — auto-versioning for ScrivenerDropbox sync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateVersionFromSyncAsync_WithPublishedDocument_CreatesVersion()
+    {
+        var chapter = MakeChapter(Guid.NewGuid());
+        chapter.MarkAsPublishedContainer();
+        var doc = MakeDocument(Guid.NewGuid(), chapter.Id);
+        doc.PublishAsPartOfChapter("hash");
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(0);
+        _versionRepo.Setup(r => r.GetVersionCountAsync(doc.Id, default)).ReturnsAsync(0);
+
+        SectionVersion? added = null;
+        _versionRepo.Setup(r => r.AddAsync(It.IsAny<SectionVersion>(), default))
+            .Callback<SectionVersion, CancellationToken>((v, _) => added = v);
+
+        await _sut.CreateVersionFromSyncAsync(doc, Guid.NewGuid());
+
+        Assert.NotNull(added);
+        Assert.Equal(doc.Id, added!.SectionId);
+    }
+
+    [Fact]
+    public async Task CreateVersionFromSyncAsync_WithUnpublishedDocument_DoesNotCreateVersion()
+    {
+        var doc = MakeDocument(Guid.NewGuid(), null);
+        // Not published — IsPublished = false
+
+        await _sut.CreateVersionFromSyncAsync(doc, Guid.NewGuid());
+
+        _versionRepo.Verify(r => r.AddAsync(It.IsAny<SectionVersion>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateVersionFromSyncAsync_WithFolderNode_DoesNotCreateVersion()
+    {
+        var folder = MakeChapter(Guid.NewGuid());
+        folder.MarkAsPublishedContainer();
+
+        await _sut.CreateVersionFromSyncAsync(folder, Guid.NewGuid());
+
+        _versionRepo.Verify(r => r.AddAsync(It.IsAny<SectionVersion>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateVersionFromSyncAsync_WithSoftDeletedDocument_DoesNotCreateVersion()
+    {
+        var chapter = MakeChapter(Guid.NewGuid());
+        var doc = MakeDocument(Guid.NewGuid(), chapter.Id);
+        doc.PublishAsPartOfChapter("hash");
+        doc.SoftDelete();
+
+        await _sut.CreateVersionFromSyncAsync(doc, Guid.NewGuid());
+
+        _versionRepo.Verify(r => r.AddAsync(It.IsAny<SectionVersion>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateVersionFromSyncAsync_WithLockedParentChapter_DoesNotCreateVersion()
+    {
+        var chapter = MakeChapter(Guid.NewGuid());
+        chapter.MarkAsPublishedContainer();
+        chapter.Lock();
+        var doc = MakeDocument(Guid.NewGuid(), chapter.Id);
+        doc.PublishAsPartOfChapter("hash");
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+
+        await _sut.CreateVersionFromSyncAsync(doc, Guid.NewGuid());
+
+        _versionRepo.Verify(r => r.AddAsync(It.IsAny<SectionVersion>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateVersionFromSyncAsync_DoesNotCallSaveChanges()
+    {
+        // Sync service owns the save — CreateVersionFromSyncAsync must not save independently.
+        var chapter = MakeChapter(Guid.NewGuid());
+        chapter.MarkAsPublishedContainer();
+        var doc = MakeDocument(Guid.NewGuid(), chapter.Id);
+        doc.PublishAsPartOfChapter("hash");
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(0);
+        _versionRepo.Setup(r => r.GetVersionCountAsync(doc.Id, default)).ReturnsAsync(0);
+
+        await _sut.CreateVersionFromSyncAsync(doc, Guid.NewGuid());
+
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateVersionFromSyncAsync_SetsClassification_WhenPreviousVersionExists()
+    {
+        var authorId = Guid.NewGuid();
+        var chapter = MakeChapter(Guid.NewGuid());
+        chapter.MarkAsPublishedContainer();
+        var doc = MakeDocument(Guid.NewGuid(), chapter.Id);
+        doc.PublishAsPartOfChapter("hash");
+
+        var previousVersion = SectionVersion.Create(doc, authorId, 1, 1, 0);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(1);
+        _versionRepo.Setup(r => r.GetVersionCountAsync(doc.Id, default)).ReturnsAsync(1);
+        _versionRepo.Setup(r => r.GetLatestAsync(doc.Id, default)).ReturnsAsync(previousVersion);
+        _versionRepo.Setup(r => r.GetAllBySectionIdAsync(doc.Id, default))
+            .ReturnsAsync(new List<SectionVersion> { previousVersion });
+
+        _htmlDiffService.Setup(d => d.Compute(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new List<DraftView.Domain.Diff.ParagraphDiffResult>());
+        _changeClassificationService.Setup(c => c.Classify(It.IsAny<IReadOnlyList<DraftView.Domain.Diff.ParagraphDiffResult>>()))
+            .Returns(ChangeClassification.Polish);
+
+        SectionVersion? added = null;
+        _versionRepo.Setup(r => r.AddAsync(It.IsAny<SectionVersion>(), default))
+            .Callback<SectionVersion, CancellationToken>((v, _) => added = v);
+
+        await _sut.CreateVersionFromSyncAsync(doc, authorId);
+
+        Assert.NotNull(added);
+        Assert.Equal(ChangeClassification.Polish, added!.ChangeClassification);
+    }
 }

--- a/DraftView.Application/Services/ScrivenerSyncService.cs
+++ b/DraftView.Application/Services/ScrivenerSyncService.cs
@@ -22,9 +22,11 @@ public class ScrivenerSyncService(
     IDropboxFileDownloader fileDownloader,
     ILogger<ScrivenerSyncService> logger,
     IAuthorNotificationRepository notificationRepo,
-    IUserRepository userRepo) : ISyncService
+    IUserRepository userRepo,
+    IVersioningService versioningService) : ISyncService
 {
     private bool _syncHadChanges;
+    private Guid _currentAuthorId;
 
     public async Task ParseProjectAsync(Guid projectId, CancellationToken ct = default)
     {
@@ -47,6 +49,7 @@ public class ScrivenerSyncService(
         }
 
         _syncHadChanges = false;
+        _currentAuthorId = project.AuthorId;
 
         try
         {
@@ -230,7 +233,7 @@ public class ScrivenerSyncService(
             {
                 section.UpdateContent(rtf.Html, rtf.Hash);
                 if (section.IsPublished)
-                    section.MarkContentChanged();
+                    await versioningService.CreateVersionFromSyncAsync(section, _currentAuthorId, ct);
             }
         }
     }
@@ -330,7 +333,7 @@ public class ScrivenerSyncService(
             {
                 existing.UpdateContent(rtf.Html, rtf.Hash);
                 if (existing.IsPublished)
-                    existing.MarkContentChanged();
+                    await versioningService.CreateVersionFromSyncAsync(existing, _currentAuthorId, ct);
                 _syncHadChanges = true;
             }
         }

--- a/DraftView.Application/Services/VersioningService.cs
+++ b/DraftView.Application/Services/VersioningService.cs
@@ -79,6 +79,27 @@ public class VersioningService(
     }
 
     /// <summary>
+    /// Creates a SectionVersion for a published Document whose content changed during a
+    /// Scrivener sync. Silent no-op when the section is not eligible or the chapter is locked.
+    /// Does not call SaveChanges — the sync service owns persistence for the cycle.
+    /// </summary>
+    public async Task CreateVersionFromSyncAsync(Section document, Guid authorId, CancellationToken ct = default)
+    {
+        if (document.NodeType != NodeType.Document || !document.IsPublished || document.IsSoftDeleted)
+            return;
+
+        if (document.ParentId.HasValue)
+        {
+            var parent = await sectionRepository.GetByIdAsync(document.ParentId.Value, ct);
+            if (parent?.IsLocked == true)
+                return;
+        }
+
+        var subscriptionTier = GetSubscriptionTier();
+        await CreateVersionForDocumentAsync(document, authorId, subscriptionTier, null, ct);
+    }
+
+    /// <summary>
     /// Revokes the latest SectionVersion for a single Document section.
     /// </summary>
     public async Task RevokeLatestVersionAsync(Guid sectionId, Guid authorId, CancellationToken ct = default)

--- a/DraftView.Domain/Interfaces/Services/IVersioningService.cs
+++ b/DraftView.Domain/Interfaces/Services/IVersioningService.cs
@@ -70,6 +70,18 @@ public interface IVersioningService
         CancellationToken ct = default);
 
     /// <summary>
+    /// Creates a SectionVersion for a published Document whose content changed during a
+    /// Scrivener sync. Called only by ScrivenerSyncService for ScrivenerDropbox projects.
+    /// Silent no-op when the section is not published, not a Document, is soft-deleted,
+    /// or the parent chapter is locked. Does not call SaveChanges — the sync service
+    /// owns persistence for the entire sync cycle.
+    /// </summary>
+    Task CreateVersionFromSyncAsync(
+        Domain.Entities.Section document,
+        Guid authorId,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Permanently deletes a single historical version.
     /// Throws <see cref="DraftView.Domain.Exceptions.InvariantViolationException"/> if
     /// <paramref name="versionId"/> is the current (latest) version for <paramref name="sectionId"/> —


### PR DESCRIPTION
## Summary

Closes #82 (PR 2 of 3)

Implements the v5.0 versioning model: for `ScrivenerDropbox` projects, Scrivener sync automatically creates a `SectionVersion` when a published Document's content changes. This makes the CHANGE-024 diff/badge system work without requiring a manual Republish after every sync.

## What changed

### New: `IVersioningService.CreateVersionFromSyncAsync`

Called only by `ScrivenerSyncService`. Silent no-op for:
- Unpublished Documents
- Soft-deleted Documents  
- Folder nodes
- Documents whose parent chapter is locked by the author

Does **not** call `SaveChanges` — the sync service's existing save at the end of the cycle covers all changes in one transaction.

### `ScrivenerSyncService` changes

- `IVersioningService` injected (already registered as scoped — no DI changes)
- `_currentAuthorId` field set per-sync from `project.AuthorId`
- Both content-change paths (`UpdateSectionAsync` and `ProcessSyncEntriesAsync`) call `CreateVersionFromSyncAsync` after updating a published Document's content
- `MarkContentChanged()` removed from published-section path — superseded by version creation

### Architecture

PR 1 (merged to main as chore): `Publishing And Versioning Architecture.md` updated to v5.0; `versioning.instructions.md` updated with new sync rule.

PR 3 (future): Hide Republish button for ScrivenerDropbox projects in author UI; remove reader content fallback to `section.HtmlContent` once all sections have a version.

## Tests

10 new tests:
- `VersioningServiceTests`: 7 tests covering all CreateVersionFromSyncAsync paths
- `ScrivenerSyncServiceTests`: 3 tests verifying sync calls the versioning service correctly

## Test plan

- [ ] 1,375 tests passing (0 failed, 1 skipped — SMTP integration, expected)
- [ ] After deployment and next Scrivener sync: `SectionVersions` table has new rows for published changed scenes
- [ ] Reader dashboard shows classification badges for chapters with sync-updated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)