### PR TITLE
feat: #82 PR3 -- hide Republish for ScrivenerDropbox + fix DetectContentChangesAsync

### DIFF
--- a/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
@@ -692,13 +692,37 @@ public class ScrivenerSyncServiceTests
     // ---------------------------------------------------------------------------
 
     [Fact]
-    public async Task DetectContentChangesAsync_WhenHashChanged_MarksContentChanged()
+    public async Task DetectContentChangesAsync_WhenPublishedSectionHashChanged_CallsCreateVersionFromSync()
     {
         var project = MakeProject();
         var sut     = CreateSut();
         var section = Section.CreateDocument(project.Id, "SCEN-001", "Scene 1",
             null, 0, "<p>Old</p>", "oldhash", "First Draft");
         section.PublishAsPartOfChapter("oldhash");
+
+        SetupPathResolver(project, "/fake/path");
+
+        _projectRepo.Setup(r => r.GetByIdAsync(project.Id, default)).ReturnsAsync(project);
+        _sectionRepo.Setup(r => r.GetPublishedByProjectIdAsync(project.Id, default))
+            .ReturnsAsync(new List<Section> { section });
+        _converter.Setup(c => c.ConvertAsync("/fake/path", "SCEN-001", default))
+            .ReturnsAsync(new RtfConversionResult { Html = "<p>New</p>", Hash = "newhash" });
+
+        await sut.DetectContentChangesAsync(project.Id);
+
+        _versioningService.Verify(v =>
+            v.CreateVersionFromSyncAsync(section, project.AuthorId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DetectContentChangesAsync_WhenUnpublishedSectionHashChanged_MarksContentChanged()
+    {
+        var project = MakeProject();
+        var sut     = CreateSut();
+        var section = Section.CreateDocument(project.Id, "SCEN-001", "Scene 1",
+            null, 0, "<p>Old</p>", "oldhash", "First Draft");
+        // Not published
 
         SetupPathResolver(project, "/fake/path");
 

--- a/DraftView.Application/Services/ScrivenerSyncService.cs
+++ b/DraftView.Application/Services/ScrivenerSyncService.cs
@@ -115,7 +115,10 @@ public class ScrivenerSyncService(
             if (result.Hash != section.ContentHash)
             {
                 section.UpdateContent(result.Html, result.Hash);
-                section.MarkContentChanged();
+                if (section.IsPublished)
+                    await versioningService.CreateVersionFromSyncAsync(section, project.AuthorId, ct);
+                else
+                    section.MarkContentChanged();
             }
         }
 

--- a/DraftView.Web/Views/Author/Publishing.cshtml
+++ b/DraftView.Web/Views/Author/Publishing.cshtml
@@ -1,6 +1,8 @@
 ﻿@model PublishingPageViewModel
+@using DraftView.Domain.Enumerations
 @{
     ViewData["Title"] = "Publishing — " + Model.Project.Name;
+    var isScrivener = Model.Project.ProjectType == ProjectType.ScrivenerDropbox;
 }
 
 <h2>@Model.Project.Name — Publishing</h2>
@@ -8,7 +10,14 @@
     <a asp-action="Sections" asp-route-projectId="@Model.Project.Id">&larr; Back to Sections</a>
 </p>
 <p class="page-subtitle">
-    Republish chapters or individual documents. Revoke rolls back to the previous version.
+    @if (isScrivener)
+    {
+        <span>Versions are created automatically when Scrivener syncs. Revoke rolls back to the previous version.</span>
+    }
+    else
+    {
+        <span>Republish chapters or individual documents. Revoke rolls back to the previous version.</span>
+    }
 </p>
 
 <div class="discovery-panel">
@@ -98,7 +107,7 @@ else
                 }
 
                 <div class="publishing-chapter__actions">
-                    @if (chapter.HasChanges && !chapter.Chapter.IsLocked)
+                    @if (!isScrivener && chapter.HasChanges && !chapter.Chapter.IsLocked)
                     {
                         <form asp-action="RepublishChapter" method="post" style="display:inline">
                             @Html.AntiForgeryToken()
@@ -151,7 +160,7 @@ else
                             }
 
                             <div class="publishing-doc__actions">
-                                @if (doc.HasChanges)
+                                @if (!isScrivener && doc.HasChanges)
                                 {
                                     <form asp-action="RepublishDocument" method="post" style="display:inline">
                                         @Html.AntiForgeryToken()


### PR DESCRIPTION
## Summary

PR3 of #82 (V-Sprint 1 revision: auto-version on sync).

### 1. Publishing page — Republish buttons hidden for ScrivenerDropbox projects

For projects synced via Scrivener/Dropbox, the author never needs to click Republish — sync creates versions automatically (PR #109). Showing the button would be confusing and redundant.

- **Republish Chapter** button: hidden when `ProjectType == ScrivenerDropbox`
- **Republish Document** button: hidden when `ProjectType == ScrivenerDropbox`  
- Page subtitle updated: "Versions are created automatically when Scrivener syncs."
- `Manual` projects: unchanged — both buttons still shown

### 2. `DetectContentChangesAsync` — gap fix from PR #109

The background sync service calls both `ParseProjectAsync` (fixed in PR #109) and `DetectContentChangesAsync`. The latter still used `MarkContentChanged()` for published sections instead of `CreateVersionFromSyncAsync`, leaving a gap where content changes detected by the full-scan path would not generate versions.

Fixed to match PR #109: published sections call `CreateVersionFromSyncAsync`; unpublished sections still call `MarkContentChanged` (for the author "has changes" indicator).

### 3. Fallback retained

`ResolveSceneContentAndDiffAsync` still falls back to `section.HtmlContent` for sections with no `SectionVersion`. This is removed once production confirms all published sections have at least one version after a sync cycle.

## Tests

2 new / 1 renamed tests in `ScrivenerSyncServiceTests`:
- `DetectContentChangesAsync_WhenPublishedSectionHashChanged_CallsCreateVersionFromSync` (new)
- `DetectContentChangesAsync_WhenUnpublishedSectionHashChanged_MarksContentChanged` (new)

1,376 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)