### PR TITLE
feat: #82 -- EnsureInitialVersionAsync creates baseline versions for stable sections

### DIFF
--- a/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
@@ -738,6 +738,32 @@ public class ScrivenerSyncServiceTests
     }
 
     [Fact]
+    public async Task DetectContentChangesAsync_WhenPublishedSectionHashUnchanged_CallsEnsureInitialVersion()
+    {
+        // Stable sections (content hasn't changed) still need a baseline version
+        // if none exists. EnsureInitialVersionAsync is a no-op once version 1 exists.
+        var project = MakeProject();
+        var sut     = CreateSut();
+        var section = Section.CreateDocument(project.Id, "SCEN-001", "Scene 1",
+            null, 0, "<p>Same</p>", "samehash", "First Draft");
+        section.PublishAsPartOfChapter("samehash");
+
+        SetupPathResolver(project, "/fake/path");
+
+        _projectRepo.Setup(r => r.GetByIdAsync(project.Id, default)).ReturnsAsync(project);
+        _sectionRepo.Setup(r => r.GetPublishedByProjectIdAsync(project.Id, default))
+            .ReturnsAsync(new List<Section> { section });
+        _converter.Setup(c => c.ConvertAsync("/fake/path", "SCEN-001", default))
+            .ReturnsAsync(new RtfConversionResult { Html = "<p>Same</p>", Hash = "samehash" });
+
+        await sut.DetectContentChangesAsync(project.Id);
+
+        _versioningService.Verify(v =>
+            v.EnsureInitialVersionAsync(section, project.AuthorId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task DetectContentChangesAsync_WhenHashUnchanged_DoesNotMarkContentChanged()
     {
         var project = MakeProject();

--- a/DraftView.Application.Tests/Services/VersioningServiceTests.cs
+++ b/DraftView.Application.Tests/Services/VersioningServiceTests.cs
@@ -1105,6 +1105,72 @@ public class VersioningServiceTests
         Section.CreateDocument(projectId, Guid.NewGuid().ToString(),
             "Scene 1", chapterId, 0, "<p>content</p>", "hash", status);
 
+    // -----------------------------------------------------------------------
+    // EnsureInitialVersionAsync — creates version 1 if none exists yet
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task EnsureInitialVersionAsync_WhenNoVersionExists_CreatesVersion()
+    {
+        var chapter = MakeChapter(Guid.NewGuid());
+        chapter.MarkAsPublishedContainer();
+        var doc = MakeDocument(Guid.NewGuid(), chapter.Id);
+        doc.PublishAsPartOfChapter("hash");
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(0);
+        _versionRepo.Setup(r => r.GetVersionCountAsync(doc.Id, default)).ReturnsAsync(0);
+
+        SectionVersion? added = null;
+        _versionRepo.Setup(r => r.AddAsync(It.IsAny<SectionVersion>(), default))
+            .Callback<SectionVersion, CancellationToken>((v, _) => added = v);
+
+        await _sut.EnsureInitialVersionAsync(doc, Guid.NewGuid());
+
+        Assert.NotNull(added);
+    }
+
+    [Fact]
+    public async Task EnsureInitialVersionAsync_WhenVersionAlreadyExists_DoesNotCreateAnother()
+    {
+        var doc = MakeDocument(Guid.NewGuid(), null);
+        doc.PublishAsPartOfChapter("hash");
+
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(1);
+
+        await _sut.EnsureInitialVersionAsync(doc, Guid.NewGuid());
+
+        _versionRepo.Verify(r => r.AddAsync(It.IsAny<SectionVersion>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureInitialVersionAsync_WithUnpublishedDocument_DoesNotCreateVersion()
+    {
+        var doc = MakeDocument(Guid.NewGuid(), null);
+        // Not published
+
+        await _sut.EnsureInitialVersionAsync(doc, Guid.NewGuid());
+
+        _versionRepo.Verify(r => r.AddAsync(It.IsAny<SectionVersion>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureInitialVersionAsync_DoesNotCallSaveChanges()
+    {
+        var chapter = MakeChapter(Guid.NewGuid());
+        chapter.MarkAsPublishedContainer();
+        var doc = MakeDocument(Guid.NewGuid(), chapter.Id);
+        doc.PublishAsPartOfChapter("hash");
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
+        _versionRepo.Setup(r => r.GetMaxVersionNumberAsync(doc.Id, default)).ReturnsAsync(0);
+        _versionRepo.Setup(r => r.GetVersionCountAsync(doc.Id, default)).ReturnsAsync(0);
+
+        await _sut.EnsureInitialVersionAsync(doc, Guid.NewGuid());
+
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     private static Section MakeManualDocument(Guid projectId, Guid chapterId)
     {
         var section = Section.CreateDocumentForUpload(projectId, "Scene 1", chapterId, 0);

--- a/DraftView.Application/Services/ScrivenerSyncService.cs
+++ b/DraftView.Application/Services/ScrivenerSyncService.cs
@@ -120,6 +120,10 @@ public class ScrivenerSyncService(
                 else
                     section.MarkContentChanged();
             }
+            else if (section.IsPublished)
+            {
+                await versioningService.EnsureInitialVersionAsync(section, project.AuthorId, ct);
+            }
         }
 
         await unitOfWork.SaveChangesAsync(ct);

--- a/DraftView.Application/Services/VersioningService.cs
+++ b/DraftView.Application/Services/VersioningService.cs
@@ -79,6 +79,23 @@ public class VersioningService(
     }
 
     /// <summary>
+    /// Creates version 1 for a published Document if no SectionVersion exists yet.
+    /// No-op when a version already exists. Does not call SaveChanges.
+    /// </summary>
+    public async Task EnsureInitialVersionAsync(Section document, Guid authorId, CancellationToken ct = default)
+    {
+        if (document.NodeType != NodeType.Document || !document.IsPublished || document.IsSoftDeleted)
+            return;
+
+        var maxVersion = await sectionVersionRepository.GetMaxVersionNumberAsync(document.Id, ct);
+        if (maxVersion > 0)
+            return;
+
+        var subscriptionTier = GetSubscriptionTier();
+        await CreateVersionForDocumentAsync(document, authorId, subscriptionTier, 0, ct);
+    }
+
+    /// <summary>
     /// Creates a SectionVersion for a published Document whose content changed during a
     /// Scrivener sync. Silent no-op when the section is not eligible or the chapter is locked.
     /// Does not call SaveChanges — the sync service owns persistence for the cycle.

--- a/DraftView.Domain/Interfaces/Services/IVersioningService.cs
+++ b/DraftView.Domain/Interfaces/Services/IVersioningService.cs
@@ -70,6 +70,18 @@ public interface IVersioningService
         CancellationToken ct = default);
 
     /// <summary>
+    /// Creates version 1 for a published Document if no SectionVersion exists yet.
+    /// No-op when a version already exists. Called by ScrivenerSyncService for published
+    /// sections whose content hash is unchanged — ensuring every published section has a
+    /// baseline version even if its content has been stable since auto-versioning deployed.
+    /// Does not call SaveChanges — the sync service owns persistence.
+    /// </summary>
+    Task EnsureInitialVersionAsync(
+        Domain.Entities.Section document,
+        Guid authorId,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Creates a SectionVersion for a published Document whose content changed during a
     /// Scrivener sync. Called only by ScrivenerSyncService for ScrivenerDropbox projects.
     /// Silent no-op when the section is not published, not a Document, is soft-deleted,


### PR DESCRIPTION
## Problem

Auto-versioning (PR #109 + #110) fires when `rtf.Hash != section.ContentHash`. Sections whose content hasn't changed since the last sync before those PRs deployed have matching hashes — so no version is ever created for them through the change-detection path. They stay without a `SectionVersion` indefinitely, requiring the reader fallback to `section.HtmlContent`.

No manual database update is needed with this fix.

## Solution

### `IVersioningService.EnsureInitialVersionAsync`

Creates version 1 for a published Document if none exists yet (`GetMaxVersionNumberAsync` returns 0). No-op on every subsequent call. Does not call `SaveChanges` — the sync service owns persistence.

### `DetectContentChangesAsync` update

For each published section whose hash is **unchanged** (no content change to process), calls `EnsureInitialVersionAsync`. On the first sync cycle after deployment, every published section without a version gets one at no extra Dropbox cost — the content was already read from disk for the hash comparison.

## After this deploys

After the next sync cycle:
- All published sections have a `SectionVersion`
- The `section.HtmlContent` reader fallback can be safely removed (that removal is a separate PR — confirms via diagnostic query first)
- Hilary and Becca's dashboards will show classification badges for chapters where the author has made changes since they last read

## Tests

5 new tests:
- `VersioningServiceTests`: `EnsureInitialVersionAsync_WhenNoVersionExists_CreatesVersion`, `_WhenVersionAlreadyExists_DoesNotCreateAnother`, `_WithUnpublishedDocument_DoesNotCreateVersion`, `_DoesNotCallSaveChanges`
- `ScrivenerSyncServiceTests`: `DetectContentChangesAsync_WhenPublishedSectionHashUnchanged_CallsEnsureInitialVersion`

1,381 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)