### PR TITLE
fix: null ChangeClassification on v1 suppressed badges for pre-versioning readers

### DIFF
--- a/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
@@ -546,11 +546,40 @@ public class ReaderDashboardServiceTests
         return scene;
     }
 
+    [Fact]
+    public async Task ChapterChangeStatuses_WhenNullLastReadVersionNumber_AndNullClassification_ReturnsPolish()
+    {
+        // Production scenario: reader has null LastReadVersionNumber (pre-versioning read)
+        // AND version 1 has null ChangeClassification (no baseline to diff against).
+        // Must still show a badge — we cannot confirm content matches what they read.
+        var chapterId = Guid.NewGuid();
+        var scene = CreateScene(chapterId);
+        var readEvent = ReadEvent.Create(scene.Id, UserId); // LastReadVersionNumber stays null
+
+        _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
+            .ReturnsAsync([scene]);
+        _readEventRepo.Setup(r => r.GetAsync(scene.Id, UserId, default))
+            .ReturnsAsync(readEvent);
+        _sectionVersionRepo.Setup(r => r.GetLatestAsync(scene.Id, default))
+            .ReturnsAsync(CreateVersionNullClassification(scene, 1));
+
+        var result = await CreateSut().GetChapterChangeStatusesAsync(
+            UserId, [chapterId], ReadingStyle.StoryReader);
+
+        Assert.Equal(ChangeClassification.Polish, result[chapterId]);
+    }
+
     private static SectionVersion CreateVersion(Section section, int versionNumber, ChangeClassification classification)
     {
         section.UpdateContent("<p>content</p>", "hash");
         var version = SectionVersion.Create(section, Guid.NewGuid(), versionNumber, 1, 0);
         version.SetChangeClassification(classification);
         return version;
+    }
+
+    private static SectionVersion CreateVersionNullClassification(Section section, int versionNumber)
+    {
+        section.UpdateContent("<p>content</p>", "hash");
+        return SectionVersion.Create(section, Guid.NewGuid(), versionNumber, 1, 0);
     }
 }

--- a/DraftView.Application/Services/ReaderDashboardService.cs
+++ b/DraftView.Application/Services/ReaderDashboardService.cs
@@ -156,6 +156,14 @@ public class ReaderDashboardService(
                     continue;
 
                 var classification = latestVersion.ChangeClassification;
+
+                // When the reader has no confirmed read version, we cannot verify the
+                // version content matches what they actually read. Default to Polish so
+                // any unclassified version (e.g. version 1 with no baseline to diff
+                // against) still surfaces as a badge rather than silently showing "Read".
+                if (readEvent.LastReadVersionNumber is null)
+                    classification ??= ChangeClassification.Polish;
+
                 if (classification is null || classification < minimumTier)
                     continue;
 


### PR DESCRIPTION
## Root cause

`GetChapterChangeStatusesAsync` skipped any scene where `ChangeClassification` was null:

```csharp
if (classification is null || classification < minimumTier)
    continue;
```

Version 1 **always** has null classification — there is no previous version to diff against. For readers with `LastReadVersionNumber = null` (pre-versioning reads, backfilled), this meant every scene was skipped and every chapter showed **Read** instead of a badge.

Confirmed by diagnostic query against production: 140 scenes, all `LastReadVersionNumber = null`, all `ChangeClassification = null`. Zero "Behind — should badge" rows.

## Fix

When `LastReadVersionNumber is null`, default null classification to `Polish`:

```csharp
if (readEvent.LastReadVersionNumber is null)
    classification ??= ChangeClassification.Polish;
```

We cannot confirm the version 1 content matches what the reader read before versioning existed. Any unclassified version surfaces as **Minor edit** rather than silently showing **Read**.

## What this means for readers

- **Hilary and Becca** — will see "Minor edit" on all chapters after deploy. This is correct: they have no confirmed read at a specific version, so anything published could be different from what they read.
- Once the author makes actual changes in Scrivener → version 2 is created with a real diff → classification becomes precise (Trivial/Polish/Revision/Rewrite) and replaces the Polish default.
- Readers with a confirmed `LastReadVersionNumber` who are up to date: **unaffected** — the fallback only applies when `LastReadVersionNumber is null`.

## Test

`ChapterChangeStatuses_WhenNullLastReadVersionNumber_AndNullClassification_ReturnsPolish` — the exact production scenario: null LastReadVersionNumber + version 1 with null classification → expects Polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)