### PR TITLE
revert: remove incorrect Polish default for null classification on v1

### DIFF
--- a/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReaderDashboardServiceTests.cs
@@ -547,14 +547,14 @@ public class ReaderDashboardServiceTests
     }
 
     [Fact]
-    public async Task ChapterChangeStatuses_WhenNullLastReadVersionNumber_AndNullClassification_ReturnsPolish()
+    public async Task ChapterChangeStatuses_WhenNullLastReadVersionNumber_AndNullClassification_ReturnsNull()
     {
-        // Production scenario: reader has null LastReadVersionNumber (pre-versioning read)
-        // AND version 1 has null ChangeClassification (no baseline to diff against).
-        // Must still show a badge — we cannot confirm content matches what they read.
+        // Version 1 with null classification = content has not been flagged as changed
+        // (e.g. stable scene, no diff available). Unchanged scenes show "Read".
+        // The reclassify-changed-scenes script sets Polish on scenes the author changed.
         var chapterId = Guid.NewGuid();
         var scene = CreateScene(chapterId);
-        var readEvent = ReadEvent.Create(scene.Id, UserId); // LastReadVersionNumber stays null
+        var readEvent = ReadEvent.Create(scene.Id, UserId);
 
         _sectionRepo.Setup(r => r.GetAllDescendantsAsync(chapterId, default))
             .ReturnsAsync([scene]);
@@ -566,7 +566,7 @@ public class ReaderDashboardServiceTests
         var result = await CreateSut().GetChapterChangeStatusesAsync(
             UserId, [chapterId], ReadingStyle.StoryReader);
 
-        Assert.Equal(ChangeClassification.Polish, result[chapterId]);
+        Assert.Null(result[chapterId]);
     }
 
     private static SectionVersion CreateVersion(Section section, int versionNumber, ChangeClassification classification)

--- a/DraftView.Application/Services/ReaderDashboardService.cs
+++ b/DraftView.Application/Services/ReaderDashboardService.cs
@@ -156,14 +156,6 @@ public class ReaderDashboardService(
                     continue;
 
                 var classification = latestVersion.ChangeClassification;
-
-                // When the reader has no confirmed read version, we cannot verify the
-                // version content matches what they actually read. Default to Polish so
-                // any unclassified version (e.g. version 1 with no baseline to diff
-                // against) still surfaces as a badge rather than silently showing "Read".
-                if (readEvent.LastReadVersionNumber is null)
-                    classification ??= ChangeClassification.Polish;
-
                 if (classification is null || classification < minimumTier)
                     continue;
 


### PR DESCRIPTION
## Summary

Reverts the incorrect fix from PR #112 which defaulted all null-classification version 1 records to Polish, causing unchanged scenes to show 'Minor edit' for pre-versioning readers.

## Correct approach

Dropbox file modification dates are the reliable signal for which scenes the author actually changed after the March 2026 read. A one-time script (`Temp/reclassify-changed-scenes.py`) uses these dates to set `ChangeClassification = 'Polish'` on exactly the 27 scenes modified after 2026-03-25, leaving all unchanged scenes at null classification (shows 'Read').

Result:
- **27 changed scenes** → 'Minor edit' badge for Hillary and Becca  
- **~113 unchanged scenes** → 'Read' (correct)
- **Jenny** → 'New' for unread chapters, 'Read' for Chapter 3 (unchanged)

Going forward, all author changes in Scrivener will create version 2 with a real diff and accurate classification automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)