### PR TITLE
fix: scene nav pill uses stored ChangeClassification not diff computation

### DIFF
--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -823,7 +823,18 @@ public class ReaderController(
             ? diffResult.Paragraphs
             : Array.Empty<ParagraphDiffResult>();
 
-        var diffClassification = diffResult?.Classification;
+        // Pill classification: use the version's stored ChangeClassification when the reader
+        // has not confirmed reading this version. This is independent of ShowDiffOnRevisit
+        // and works for version 1 (no diff computed). Falls back to the computed diff
+        // classification for version 2+ where a real diff exists.
+        var hasUnreadVersion = latestVersion?.ChangeClassification is not null
+            && (readEvent?.LastReadVersionNumber is null
+                || currentVersionNumber > readEvent.LastReadVersionNumber);
+
+        var diffClassification = hasUnreadVersion
+            ? latestVersion!.ChangeClassification
+            : diffResult?.Classification;
+
         var wordCount = CountWords(resolvedHtml);
 
         return (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel,


### PR DESCRIPTION
## Problem

The coloured pill in the 'This Chapter' reading pane nav was not appearing even for scenes with `ChangeClassification = Polish` set in the database.

Root cause: the pill was driven by `diffResult?.Classification`, which is only populated when `SectionDiffService` can compute a real diff between two versions. For version 1 (no previous version to compare against), `Classification` is always null → no pill.

## Fix

Use `latestVersion.ChangeClassification` directly when:
- The version has a stored classification (non-null)
- AND the reader has not confirmed reading this version (`LastReadVersionNumber is null` or behind)

Falls back to `diffResult.Classification` for version 2+ where a real diff exists.

The pill is a status indicator — it does not require the full diff computation to have run.

## On the inline diff (red/green text)

The inline diff is separately gated by `ShowDiffOnRevisit` (reader setting) AND requires version 2 to compare against version 1. Since the manuscript is currently all version 1, inline diff cannot show until the author's next Scrivener edit creates version 2. This is correct design — the diff needs "before" and "after" content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)