### PR TITLE
#115 Scene nav pills: add hover tooltip for change classification

### DIFF
--- a/DraftView.Web/Views/Reader/DesktopRead.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopRead.cshtml
@@ -52,7 +52,14 @@
                             DraftView.Domain.Enumerations.ChangeClassification.Rewrite  => "change-pill change-pill--rewrite",
                             _ => "change-pill"
                         };
-                        <span class="@pillClass" aria-hidden="true"></span>
+                        var pillTitle = item.DiffClassification switch {
+                            DraftView.Domain.Enumerations.ChangeClassification.Trivial  => "Minor fix — small corrections only",
+                            DraftView.Domain.Enumerations.ChangeClassification.Polish   => "Minor edit — light edits to wording or phrasing",
+                            DraftView.Domain.Enumerations.ChangeClassification.Revision => "Revised — significant reworking of this scene",
+                            DraftView.Domain.Enumerations.ChangeClassification.Rewrite  => "Rewritten — major changes throughout this scene",
+                            _ => "Changed"
+                        };
+                        <span class="@pillClass" title="@pillTitle" aria-hidden="true"></span>
                     }
                 </a>
             }
@@ -150,7 +157,14 @@
                                 DraftView.Domain.Enumerations.ChangeClassification.Rewrite  => "change-pill change-pill--rewrite",
                                 _ => "change-pill"
                             };
-                            <span class="@pillClass" aria-hidden="true"></span>
+                            var pillTitle = item.DiffClassification switch {
+                                DraftView.Domain.Enumerations.ChangeClassification.Trivial  => "Minor fix — small corrections only",
+                                DraftView.Domain.Enumerations.ChangeClassification.Polish   => "Minor edit — light edits to wording or phrasing",
+                                DraftView.Domain.Enumerations.ChangeClassification.Revision => "Revised — significant reworking of this scene",
+                                DraftView.Domain.Enumerations.ChangeClassification.Rewrite  => "Rewritten — major changes throughout this scene",
+                                _ => "Changed"
+                            };
+                            <span class="@pillClass" title="@pillTitle" aria-hidden="true"></span>
                         }
                     </a>
                 }


### PR DESCRIPTION
## Summary
- Adds a `title` attribute to the colour-coded change pills in both the left TOC and right sidebar of the reader view (`DesktopRead.cshtml`)
- Hovering a pill now shows: **Minor fix**, **Minor edit**, **Revised**, or **Rewritten** with a brief plain-English description
- Labels are consistent with the existing dashboard status badge text

## Test plan
- [ ] Open a chapter with versioned scenes in the reader view
- [ ] Hover each pill colour — confirm the tooltip text appears and matches the classification
- [ ] Confirm the left-nav TOC and right sidebar both show tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)