### PR TITLE
#124 -- Phase 4: web layer for reader snapshot model

### DIFF
--- a/DraftView.Application.Tests/Services/ReadingProgressServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ReadingProgressServiceTests.cs
@@ -239,6 +239,55 @@ public class ReadingProgressServiceTests
     }
 
     // ---------------------------------------------------------------------------
+    // IsMarkedReadAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task IsMarkedReadAsync_ReadEventExistsAndIsRead_ReturnsTrue()
+    {
+        var sectionId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        var sut       = CreateSut();
+        var readEvent = ReadEvent.Create(sectionId, userId);
+        readEvent.MarkRead();
+
+        _readEventRepo.Setup(r => r.GetAsync(sectionId, userId, default)).ReturnsAsync(readEvent);
+
+        var result = await sut.IsMarkedReadAsync(sectionId, userId);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsMarkedReadAsync_ReadEventExistsButNotRead_ReturnsFalse()
+    {
+        var sectionId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        var sut       = CreateSut();
+        var readEvent = ReadEvent.Create(sectionId, userId);
+
+        _readEventRepo.Setup(r => r.GetAsync(sectionId, userId, default)).ReturnsAsync(readEvent);
+
+        var result = await sut.IsMarkedReadAsync(sectionId, userId);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsMarkedReadAsync_NoReadEvent_ReturnsFalse()
+    {
+        var sectionId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        var sut       = CreateSut();
+
+        _readEventRepo.Setup(r => r.GetAsync(sectionId, userId, default)).ReturnsAsync((ReadEvent?)null);
+
+        var result = await sut.IsMarkedReadAsync(sectionId, userId);
+
+        Assert.False(result);
+    }
+
+    // ---------------------------------------------------------------------------
     // MarkReadAsync
     // ---------------------------------------------------------------------------
 

--- a/DraftView.Application/Services/ReadingProgressService.cs
+++ b/DraftView.Application/Services/ReadingProgressService.cs
@@ -42,6 +42,12 @@ public class ReadingProgressService(
         await unitOfWork.SaveChangesAsync(ct);
     }
 
+    public async Task<bool> IsMarkedReadAsync(Guid sectionId, Guid userId, CancellationToken ct = default)
+    {
+        var readEvent = await readEventRepo.GetAsync(sectionId, userId, ct);
+        return readEvent?.IsRead ?? false;
+    }
+
     public async Task MarkReadAsync(Guid sectionId, Guid userId, CancellationToken ct = default)
     {
         var readEvent = await readEventRepo.GetAsync(sectionId, userId, ct);

--- a/DraftView.Domain/Interfaces/Services/IReadingProgressService.cs
+++ b/DraftView.Domain/Interfaces/Services/IReadingProgressService.cs
@@ -17,6 +17,7 @@ public interface IReadingProgressService
     /// ReaderSnapshot of the current content as the reader's new baseline.
     /// No-op if no ReadEvent exists (reader has not opened the scene).
     /// </summary>
+    Task<bool> IsMarkedReadAsync(Guid sectionId, Guid userId, CancellationToken ct = default);
     Task MarkReadAsync(Guid sectionId, Guid userId, CancellationToken ct = default);
 
     /// <summary>

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -682,8 +682,8 @@ public class ReaderController(
         var preferences       = await _userPreferencesRepo.GetByUserIdAsync(user.Id);
         var showDiffMobile    = preferences?.ShowDiffOnRevisit ?? false;
 
-        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel, resumeCaptureText, resumeRestoreTarget, diffParagraphs, _, updatedSinceLastRead, showUpdateBanner, _, _) =
-            await ResolveSceneContentAndDiffAsync(scene, user.Id, showDiffMobile);
+        var (resolvedHtml, resumeCaptureText, resumeRestoreTarget) =
+            await ResolveSceneContentAsync(scene, user.Id, showDiffMobile);
 
         var (prevSceneId, nextSceneId) = section.NodeType == NodeType.Document
             ? GetPrevNextSceneIds(scene.Id, chapter.Id, allSections)
@@ -691,6 +691,8 @@ public class ReaderController(
 
         var commentsRaw       = await CommentService.GetThreadsForSectionAsync(id, user.Id);
         var sceneCommentCount = commentsRaw.Count(c => !c.IsSoftDeleted);
+
+        var isRead = await ProgressService.IsMarkedReadAsync(scene.Id, user.Id);
 
         return View("MobileRead", new MobileReadViewModel {
             Scene                    = scene,
@@ -702,7 +704,6 @@ public class ReaderController(
             ProseFont                = preferences?.ProseFont ?? ProseFont.SystemSerif,
             ProseFontSize            = preferences?.ProseFontSize ?? ProseFontSize.Medium,
             ResolvedHtmlContent      = resolvedHtml,
-            CurrentSectionVersionId  = currentSectionVersionId,
             ResumeCaptureText        = resumeCaptureText,
             HasResumeRestoreTarget   = resumeRestoreTarget?.HasTarget ?? false,
             ResumeRestoreStartOffset = resumeRestoreTarget?.StartOffset,
@@ -710,18 +711,10 @@ public class ReaderController(
             ResumeRestoreStatus      = resumeRestoreTarget?.Status,
             ResumeRestoreConfidenceScore = resumeRestoreTarget?.ConfidenceScore,
             ResumeRestoreMatchMethod = resumeRestoreTarget?.MatchMethod,
-            CurrentVersionNumber     = currentVersionNumber,
-            VersionLabel             = versionLabel,
-            DiffParagraphs           = diffParagraphs,
-            UpdatedSinceLastRead     = updatedSinceLastRead,
-            ShowUpdateBanner         = showUpdateBanner
+            IsRead                   = isRead
         });
     }
 
-    /// <summary>
-    /// Builds a SceneWithComments view model by resolving content, computing diff,
-    /// and loading comments for a scene.
-    /// </summary>
     private async Task<SceneWithComments> BuildSceneWithCommentsAsync(
         Section scene,
         Domain.Entities.User user,
@@ -732,11 +725,10 @@ public class ReaderController(
     {
         await ProgressService.RecordOpenAsync(scene.Id, user.Id, ct);
 
-        var (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel,
-             resumeCaptureText, resumeRestoreTarget, diffParagraphs, diffClassification,
-             updatedSinceLastRead, showUpdateBanner, diffEnabled, wordCount) =
-            await ResolveSceneContentAndDiffAsync(scene, user.Id, showDiffOnRevisit, ct);
+        var (resolvedHtml, resumeCaptureText, resumeRestoreTarget) =
+            await ResolveSceneContentAsync(scene, user.Id, showDiffOnRevisit, ct);
 
+        var isRead = await ProgressService.IsMarkedReadAsync(scene.Id, user.Id, ct);
         var comments = await CommentService.GetThreadsForSectionAsync(scene.Id, user.Id, ct);
         var displayComments = await BuildCommentDisplayModelsAsync(comments, user.Id, projectAuthorId, isModerator);
 
@@ -745,7 +737,6 @@ public class ReaderController(
             Scene                        = scene,
             Comments                     = displayComments,
             ResolvedHtmlContent          = resolvedHtml,
-            CurrentSectionVersionId      = currentSectionVersionId,
             ResumeCaptureText            = resumeCaptureText,
             HasResumeRestoreTarget       = resumeRestoreTarget?.HasTarget ?? false,
             ResumeRestoreStartOffset     = resumeRestoreTarget?.StartOffset,
@@ -753,27 +744,14 @@ public class ReaderController(
             ResumeRestoreStatus          = resumeRestoreTarget?.Status,
             ResumeRestoreConfidenceScore = resumeRestoreTarget?.ConfidenceScore,
             ResumeRestoreMatchMethod     = resumeRestoreTarget?.MatchMethod,
-            DiffParagraphs               = diffParagraphs,
-            DiffClassification           = diffClassification,
-            DiffEnabled                  = diffEnabled,
-            WordCount                    = wordCount,
-            UpdatedSinceLastRead         = updatedSinceLastRead,
-            ShowUpdateBanner             = showUpdateBanner,
-            CurrentVersionNumber         = currentVersionNumber,
-            VersionLabel                 = versionLabel
+            DiffEnabled                  = showDiffOnRevisit,
+            WordCount                    = CountWords(resolvedHtml),
+            IsRead                       = isRead
         };
     }
 
-    /// <summary>
-    /// Resolves scene content from the latest version (or fallback to working content),
-    /// and computes diff via ReaderDiffService (applies ShowDiffOnRevisit, cooldown, threshold).
-    /// LastReadVersionNumber is no longer advanced on open — only via explicit mark-as-read.
-    /// Returns: (resolvedHtml, currentSectionVersionId, currentVersionNumber, versionLabel,
-    ///           resumeCaptureText, resumeRestoreTarget, diffParagraphs, diffClassification,
-    ///           updatedSinceLastRead, showUpdateBanner, diffEnabled, wordCount)
-    /// </summary>
-    private async Task<(string? resolvedHtml, Guid? currentSectionVersionId, int? currentVersionNumber, string? versionLabel, string resumeCaptureText, ResumeRestoreTargetDto? resumeRestoreTarget, IReadOnlyList<ParagraphDiffResult> diffParagraphs, ChangeClassification? diffClassification, bool updatedSinceLastRead, bool showUpdateBanner, bool diffEnabled, int wordCount)>
-        ResolveSceneContentAndDiffAsync(
+    private async Task<(string? resolvedHtml, string resumeCaptureText, ResumeRestoreTargetDto? resumeRestoreTarget)>
+        ResolveSceneContentAsync(
             Section scene,
             Guid userId,
             bool showDiffOnRevisit,
@@ -782,12 +760,7 @@ public class ReaderController(
         var resolvedHtml = scene.HtmlContent;
         var resumeCaptureText = CanonicalizeForCapture(resolvedHtml);
         var resumeRestoreTarget = await ProgressService.GetResumeRestoreTargetAsync(scene.Id, userId, ct);
-        var wordCount = CountWords(resolvedHtml);
-
-        return (resolvedHtml, null, null, null,
-                resumeCaptureText, resumeRestoreTarget,
-                Array.Empty<ParagraphDiffResult>(), null,
-                false, false, showDiffOnRevisit, wordCount);
+        return (resolvedHtml, resumeCaptureText, resumeRestoreTarget);
     }
 
     private static int CountWords(string? html)

--- a/DraftView.Web/Models/MobileReaderViewModels.cs
+++ b/DraftView.Web/Models/MobileReaderViewModels.cs
@@ -93,12 +93,7 @@ public class MobileReadViewModel
     public bool HasPrev => PrevSceneId.HasValue;
     public bool HasNext => NextSceneId.HasValue;
 
-    /// <summary>
-    /// The HTML content to render. Latest SectionVersion if exists,
-    /// fallback to Scene.HtmlContent for pre-versioning sections.
-    /// </summary>
     public string? ResolvedHtmlContent { get; set; }
-    public Guid? CurrentSectionVersionId { get; set; }
     public string ResumeCaptureText { get; set; } = string.Empty;
     public bool HasResumeRestoreTarget { get; set; }
     public int? ResumeRestoreStartOffset { get; set; }
@@ -108,27 +103,14 @@ public class MobileReadViewModel
     public PassageAnchorMatchMethod? ResumeRestoreMatchMethod { get; set; }
 
     /// <summary>
-    /// The VersionNumber of the SectionVersion used to resolve content.
-    /// Null if no version exists yet (pre-versioning section).
+    /// Snapshot-based change state for this scene. Null when reader is up to date.
+    /// Populated by IChangeStateService in Phase 5.
     /// </summary>
-    public int? CurrentVersionNumber { get; set; }
-    public string? VersionLabel { get; set; }
+    public ChangeClassification? ChangeClassification { get; set; }
 
     /// <summary>
-    /// Paragraph-level diff results for this scene. Empty when no changes.
+    /// True when the reader's ReadEvent has IsRead = true for this scene.
     /// </summary>
-    public IReadOnlyList<ParagraphDiffResult> DiffParagraphs { get; set; }
-        = Array.Empty<ParagraphDiffResult>();
-
-    /// <summary>True when the reader has changes to see.</summary>
-    public bool HasDiff => DiffParagraphs.Any(p => p.Type != DiffResultType.Unchanged);
-
-    /// <summary>
-    /// True when the reader has previously read this scene and a newer version exists.
-    /// </summary>
-    public bool UpdatedSinceLastRead { get; set; }
-
-    /// <summary>True when the update banner should be shown.</summary>
-    public bool ShowUpdateBanner { get; set; }
+    public bool IsRead { get; set; }
 
 }

--- a/DraftView.Web/Models/ReaderViewModels.cs
+++ b/DraftView.Web/Models/ReaderViewModels.cs
@@ -47,14 +47,7 @@ public class SceneWithComments
 {
     public Section Scene { get; set; } = default!;
     public IReadOnlyList<CommentDisplayViewModel> Comments { get; set; } = new List<CommentDisplayViewModel>();
-
-    /// <summary>
-    /// The HTML content to render for this scene. Resolved from the latest
-    /// SectionVersion if one exists, falling back to Section.HtmlContent
-    /// for pre-versioning published sections.
-    /// </summary>
     public string? ResolvedHtmlContent { get; set; }
-    public Guid? CurrentSectionVersionId { get; set; }
     public string ResumeCaptureText { get; set; } = string.Empty;
     public bool HasResumeRestoreTarget { get; set; }
     public int? ResumeRestoreStartOffset { get; set; }
@@ -64,56 +57,36 @@ public class SceneWithComments
     public PassageAnchorMatchMethod? ResumeRestoreMatchMethod { get; set; }
 
     /// <summary>
-    /// Paragraph-level diff results when the reader has a prior read version
-    /// and a newer version exists. Empty when no diff or no changes.
-    /// When non-empty, the view renders diff paragraphs instead of ResolvedHtmlContent.
+    /// Paragraph-level diff results. Empty until Phase 5 wires up IChangeStateService diff computation.
+    /// When non-empty, the view renders diff paragraphs alongside ResolvedHtmlContent.
     /// </summary>
     public IReadOnlyList<ParagraphDiffResult> DiffParagraphs { get; set; }
         = Array.Empty<ParagraphDiffResult>();
 
-    /// <summary>
-    /// True when DiffParagraphs contains highlighted changes to show the reader.
-    /// </summary>
     public bool HasDiff => DiffParagraphs.Any(p => p.Type != DiffResultType.Unchanged);
 
     /// <summary>
-    /// True when the reader has previously read this section and a newer version
-    /// now exists. Drives the "Updated since you last read" inline message.
-    /// False on first read or when the reader is already on the latest version.
-    /// </summary>
-    public bool UpdatedSinceLastRead { get; set; }
-
-    /// <summary>
-    /// True when the update banner should be shown for this scene.
-    /// Requires: reader has read before, a newer version exists, and
-    /// the reader has not yet dismissed the banner at the current version.
-    /// </summary>
-    public bool ShowUpdateBanner { get; set; }
-
-    /// <summary>
-    /// The current version number. Used in the banner label.
-    /// </summary>
-    public int? CurrentVersionNumber { get; set; }
-    public string? VersionLabel { get; set; }
-
-    /// <summary>
-    /// The classification of the diff between the reader's last read version
-    /// and the current version. Null when no diff exists or diff is suppressed.
-    /// Used to render the coloured pill in the "This chapter" nav.
-    /// </summary>
-    public ChangeClassification? DiffClassification { get; set; }
-
-    /// <summary>
-    /// True when the reader's profile has ShowDiffOnRevisit enabled.
+    /// True when the reader has ShowDiffOnRevisit enabled.
     /// Controls whether the diff toggle and mark-as-read/unread controls are shown.
     /// </summary>
     public bool DiffEnabled { get; set; }
 
     /// <summary>
-    /// Approximate word count of the scene's current content.
-    /// Passed to JS to compute estimated reading time for auto mark-as-read.
+    /// Approximate word count passed to JS for auto mark-as-read timing.
     /// </summary>
     public int WordCount { get; set; }
+
+    /// <summary>
+    /// Snapshot-based change state for this scene. Null when reader is up to date.
+    /// New/Trivial/Polish/Revision/Rewrite when content has changed since last read.
+    /// Populated by IChangeStateService in Phase 5.
+    /// </summary>
+    public ChangeClassification? ChangeClassification { get; set; }
+
+    /// <summary>
+    /// True when the reader's ReadEvent has IsRead = true for this scene.
+    /// </summary>
+    public bool IsRead { get; set; }
 
 }
 

--- a/DraftView.Web/Views/Reader/DesktopDashboard.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopDashboard.cshtml
@@ -136,7 +136,7 @@ else
                                                     }
                                                 </td>
                                                 <td class="reader-dashboard__cell reader-dashboard__cell--status">
-                                                    @if (!item.HasRead)
+                                                    @if (!item.HasRead || item.ChapterChangeClassification == ChangeClassification.New)
                                                     {
                                                         <span class="reader-dashboard__status reader-dashboard__status--new">New</span>
                                                     }

--- a/DraftView.Web/Views/Reader/DesktopRead.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopRead.cshtml
@@ -42,17 +42,19 @@
             @foreach (var item in Model.Scenes)
             {
                 <a href="#scene-@item.Scene.Id" class="reader__contents-link">
-                    @item.Scene.Title@(item.VersionLabel != null ? $" ({item.VersionLabel})" : string.Empty)
-                    @if (item.DiffClassification.HasValue)
+                    @item.Scene.Title
+                    @if (item.ChangeClassification.HasValue)
                     {
-                        var pillClass = item.DiffClassification switch {
+                        var pillClass = item.ChangeClassification switch {
+                            DraftView.Domain.Enumerations.ChangeClassification.New      => "change-pill change-pill--new",
                             DraftView.Domain.Enumerations.ChangeClassification.Trivial  => "change-pill change-pill--trivial",
                             DraftView.Domain.Enumerations.ChangeClassification.Polish   => "change-pill change-pill--polish",
                             DraftView.Domain.Enumerations.ChangeClassification.Revision => "change-pill change-pill--revision",
                             DraftView.Domain.Enumerations.ChangeClassification.Rewrite  => "change-pill change-pill--rewrite",
                             _ => "change-pill"
                         };
-                        var pillTitle = item.DiffClassification switch {
+                        var pillTitle = item.ChangeClassification switch {
+                            DraftView.Domain.Enumerations.ChangeClassification.New      => "New — you have not yet read this scene",
                             DraftView.Domain.Enumerations.ChangeClassification.Trivial  => "Minor fix — small corrections only",
                             DraftView.Domain.Enumerations.ChangeClassification.Polish   => "Minor edit — light edits to wording or phrasing",
                             DraftView.Domain.Enumerations.ChangeClassification.Revision => "Revised — significant reworking of this scene",
@@ -147,17 +149,19 @@
                 @foreach (var item in Model.Scenes)
                 {
                     <a href="#scene-@item.Scene.Id" class="chapter-sidebar__link">
-                        @item.Scene.Title@(item.VersionLabel != null ? $" ({item.VersionLabel})" : string.Empty)
-                        @if (item.DiffClassification.HasValue)
+                        @item.Scene.Title
+                        @if (item.ChangeClassification.HasValue)
                         {
-                            var pillClass = item.DiffClassification switch {
+                            var pillClass = item.ChangeClassification switch {
+                                DraftView.Domain.Enumerations.ChangeClassification.New      => "change-pill change-pill--new",
                                 DraftView.Domain.Enumerations.ChangeClassification.Trivial  => "change-pill change-pill--trivial",
                                 DraftView.Domain.Enumerations.ChangeClassification.Polish   => "change-pill change-pill--polish",
                                 DraftView.Domain.Enumerations.ChangeClassification.Revision => "change-pill change-pill--revision",
                                 DraftView.Domain.Enumerations.ChangeClassification.Rewrite  => "change-pill change-pill--rewrite",
                                 _ => "change-pill"
                             };
-                            var pillTitle = item.DiffClassification switch {
+                            var pillTitle = item.ChangeClassification switch {
+                                DraftView.Domain.Enumerations.ChangeClassification.New      => "New — you have not yet read this scene",
                                 DraftView.Domain.Enumerations.ChangeClassification.Trivial  => "Minor fix — small corrections only",
                                 DraftView.Domain.Enumerations.ChangeClassification.Polish   => "Minor edit — light edits to wording or phrasing",
                                 DraftView.Domain.Enumerations.ChangeClassification.Revision => "Revised — significant reworking of this scene",
@@ -267,7 +271,6 @@
                 <div class="scene-block"
                      id="scene-@item.Scene.Id"
                      data-section-id="@item.Scene.Id"
-                     data-section-version-id="@(item.CurrentSectionVersionId?.ToString() ?? string.Empty)"
                      data-resume-capture-text="@item.ResumeCaptureText"
                      data-resume-restore-has-target="@item.HasResumeRestoreTarget.ToString().ToLowerInvariant()"
                      data-resume-restore-start-offset="@(item.ResumeRestoreStartOffset?.ToString() ?? string.Empty)"
@@ -285,32 +288,7 @@
 
                         <div class="scene-heading">
                             <span>@item.Scene.Title</span>
-                            @if (item.VersionLabel != null)
-                            {
-                                <span class="scene-heading__version">@item.VersionLabel</span>
-                            }
                         </div>
-
-                        @if (item.ShowUpdateBanner && item.CurrentVersionNumber.HasValue)
-                        {
-                            <div class="update-banner" data-section-id="@item.Scene.Id" data-version="@item.CurrentVersionNumber">
-                                <div class="update-banner__content">
-                                    <span class="update-banner__version">
-                                        @(item.VersionLabel ?? $"Version {item.CurrentVersionNumber}")
-                                    </span>
-                                </div>
-                                <button type="button" class="update-banner__dismiss" aria-label="Dismiss update notice">
-                                    Dismiss
-                                </button>
-                            </div>
-                        }
-
-                        @if (item.UpdatedSinceLastRead)
-                        {
-                            <div class="scene-updated-notice">
-                                Updated since you last read
-                            </div>
-                        }
 
                         @if (item.DiffEnabled && item.HasDiff)
                         {
@@ -533,7 +511,6 @@
                                                 <input type="hidden" name="sceneId" value="@item.Scene.Id" />
                                                 <input type="hidden" name="SectionId" value="@item.Scene.Id" />
                                                 <input type="hidden" name="PassageAnchorRequest.SectionId" value="@item.Scene.Id" />
-                                                <input type="hidden" name="PassageAnchorRequest.OriginalSectionVersionId" value="@(item.CurrentSectionVersionId?.ToString() ?? string.Empty)" />
                                                 <input type="hidden" name="PassageAnchorRequest.Purpose" value="@c.PassageAnchor.Purpose" />
                                                 <input type="hidden" name="PassageAnchorRequest.SelectedText" value="" />
                                                 <input type="hidden" name="PassageAnchorRequest.NormalizedSelectedText" value="" />

--- a/DraftView.Web/Views/Reader/MobileRead.cshtml
+++ b/DraftView.Web/Views/Reader/MobileRead.cshtml
@@ -1,5 +1,4 @@
 ﻿@model DraftView.Web.Models.MobileReadViewModel
-@using DraftView.Domain.Enumerations
 @{
     ViewData["Title"] = Model.Scene.Title;
 }
@@ -25,7 +24,7 @@
 
         <a asp-action="Scenes" asp-route-chapterId="@Model.Chapter.Id"
            class="mobile-read__nav-up">
-            &#8593; Scenes@(Model.VersionLabel != null ? $" · {Model.VersionLabel}" : string.Empty)
+            &#8593; Scenes
         </a>
 
         @if (Model.HasNext)
@@ -44,10 +43,6 @@
     <div class="mobile-read__chapter">@Model.Chapter.Title</div>
     <div class="mobile-read__scene-header">
         <h1 class="mobile-read__title">@Model.Scene.Title</h1>
-        @if (Model.VersionLabel != null)
-        {
-            <span class="mobile-read__version">@Model.VersionLabel</span>
-        }
     </div>
 
     @if (Model.Chapter.IsLocked)
@@ -57,31 +52,9 @@
         </div>
     }
 
-    @if (Model.ShowUpdateBanner && Model.CurrentVersionNumber.HasValue)
-    {
-        <div class="update-banner" data-section-id="@Model.Scene.Id" data-version="@Model.CurrentVersionNumber">
-            <div class="update-banner__content">
-                <span class="update-banner__version">
-                    @(Model.VersionLabel ?? $"Version {Model.CurrentVersionNumber}")
-                </span>
-            </div>
-            <button type="button" class="update-banner__dismiss" aria-label="Dismiss update notice">
-                Dismiss
-            </button>
-        </div>
-    }
-
-    @if (Model.UpdatedSinceLastRead)
-    {
-        <div class="scene-updated-notice">
-            Updated since you last read
-        </div>
-    }
-
     <div class="mobile-read__prose"
          id="mobile-scene-@Model.Scene.Id"
          data-section-id="@Model.Scene.Id"
-         data-section-version-id="@(Model.CurrentSectionVersionId?.ToString() ?? string.Empty)"
          data-resume-capture-text="@Model.ResumeCaptureText"
          data-resume-restore-has-target="@Model.HasResumeRestoreTarget.ToString().ToLowerInvariant()"
          data-resume-restore-start-offset="@(Model.ResumeRestoreStartOffset?.ToString() ?? string.Empty)"
@@ -89,28 +62,7 @@
          data-resume-restore-status="@(Model.ResumeRestoreStatus?.ToString() ?? string.Empty)"
          data-resume-restore-confidence="@(Model.ResumeRestoreConfidenceScore?.ToString() ?? string.Empty)"
          data-resume-restore-match-method="@(Model.ResumeRestoreMatchMethod?.ToString() ?? string.Empty)">
-        @if (Model.HasDiff)
-        {
-            @foreach (var para in Model.DiffParagraphs)
-            {
-                if (para.Type == DiffResultType.Added)
-                {
-                    <div class="diff-para diff-para--added">@Html.Raw(para.Html)</div>
-                }
-                else if (para.Type == DiffResultType.Removed)
-                {
-                    <div class="diff-para diff-para--removed"></div>
-                }
-                else
-                {
-                    @Html.Raw(para.Html)
-                }
-            }
-        }
-        else
-        {
-            @Html.Raw(Model.ResolvedHtmlContent ?? "<p><em>The author has not added content to this scene yet.</em></p>")
-        }
+        @Html.Raw(Model.ResolvedHtmlContent ?? "<p><em>The author has not added content to this scene yet.</em></p>")
     </div>
 
     <a asp-action="SceneComments" asp-route-sceneId="@Model.Scene.Id"


### PR DESCRIPTION
## Summary

- Removes stale versioning fields from `SceneWithComments` and `MobileReadViewModel` (`ShowUpdateBanner`, `CurrentVersionNumber`, `VersionLabel`, `CurrentSectionVersionId`, `UpdatedSinceLastRead`, `DiffClassification`)
- Adds `ChangeClassification?` and `IsRead` to both ViewModels
- Adds `IReadingProgressService.IsMarkedReadAsync` so the web layer can read `IsRead` without direct repository access (3 tests added)
- Simplifies `ResolveSceneContentAndDiffAsync` into `ResolveSceneContentAsync` — removes the 12-element tuple return
- `DesktopRead.cshtml`: removes update banner, version labels, `section-version-id` data attribute, `OriginalSectionVersionId` hidden input; updates nav pills to use `ChangeClassification` with full New/Trivial/Polish/Revision/Rewrite switch
- `MobileRead.cshtml`: removes version labels, update banner, old diff rendering block; simplifies to direct prose rendering
- `DesktopDashboard.cshtml`: adds `ChangeClassification.New` case to status pill condition alongside `!HasRead`

## Test plan

- [x] 1,239 tests pass, 1 skipped (email integration), 0 failed
- [x] 3 new tests for `IsMarkedReadAsync`
- [x] Solution builds clean with no warnings

Closes #124. Part of #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)