### PR TITLE
#125 -- Phase 5: diff view with inline and margin indicators

### DIFF
--- a/DraftView.Application.Tests/Services/ChangeStateServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ChangeStateServiceTests.cs
@@ -144,4 +144,72 @@ public class ChangeStateServiceTests
 
         _htmlDiffService.Verify(s => s.Compute(OldHtml, CurrentHtml), Times.Once);
     }
+
+    // ---------------------------------------------------------------------------
+    // GetChangeStateWithDiffAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetChangeStateWithDiffAsync_NullSection_ReturnsNewAndEmptyParagraphs()
+    {
+        _sectionRepo.Setup(r => r.GetByIdAsync(SectionId, default))
+            .ReturnsAsync((Section?)null);
+
+        var (classification, paragraphs) = await CreateSut().GetChangeStateWithDiffAsync(SectionId, UserId);
+
+        Assert.Equal(ChangeClassification.New, classification);
+        Assert.Empty(paragraphs);
+    }
+
+    [Fact]
+    public async Task GetChangeStateWithDiffAsync_NoSnapshot_ReturnsNewAndEmptyParagraphs()
+    {
+        _sectionRepo.Setup(r => r.GetByIdAsync(SectionId, default))
+            .ReturnsAsync(MakeSection(CurrentHtml));
+        _snapshotRepo.Setup(r => r.GetAsync(SectionId, UserId, default))
+            .ReturnsAsync((ReaderSnapshot?)null);
+
+        var (classification, paragraphs) = await CreateSut().GetChangeStateWithDiffAsync(SectionId, UserId);
+
+        Assert.Equal(ChangeClassification.New, classification);
+        Assert.Empty(paragraphs);
+        _htmlDiffService.Verify(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetChangeStateWithDiffAsync_ContentUnchanged_ReturnsNullAndEmptyParagraphs()
+    {
+        _sectionRepo.Setup(r => r.GetByIdAsync(SectionId, default))
+            .ReturnsAsync(MakeSection(CurrentHtml));
+        _snapshotRepo.Setup(r => r.GetAsync(SectionId, UserId, default))
+            .ReturnsAsync(ReaderSnapshot.Create(SectionId, UserId, CurrentHtml));
+
+        var (classification, paragraphs) = await CreateSut().GetChangeStateWithDiffAsync(SectionId, UserId);
+
+        Assert.Null(classification);
+        Assert.Empty(paragraphs);
+        _htmlDiffService.Verify(s => s.Compute(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetChangeStateWithDiffAsync_ContentDiffers_ReturnsBothClassificationAndParagraphs()
+    {
+        _sectionRepo.Setup(r => r.GetByIdAsync(SectionId, default))
+            .ReturnsAsync(MakeSection(CurrentHtml));
+        _snapshotRepo.Setup(r => r.GetAsync(SectionId, UserId, default))
+            .ReturnsAsync(ReaderSnapshot.Create(SectionId, UserId, OldHtml));
+
+        var diffResult = new[] { new ParagraphDiffResult(
+            "current", CurrentHtml, DiffResultType.Modified,
+            wordsAdded: 20, wordsRemoved: 5, totalWords: 100) };
+        _htmlDiffService.Setup(s => s.Compute(OldHtml, CurrentHtml)).Returns(diffResult);
+        _classificationService.Setup(s => s.Classify(diffResult))
+            .Returns(ChangeClassification.Revision);
+
+        var (classification, paragraphs) = await CreateSut().GetChangeStateWithDiffAsync(SectionId, UserId);
+
+        Assert.Equal(ChangeClassification.Revision, classification);
+        Assert.Single(paragraphs);
+        Assert.Same(diffResult[0], paragraphs[0]);
+    }
 }

--- a/DraftView.Application/Services/ChangeStateService.cs
+++ b/DraftView.Application/Services/ChangeStateService.cs
@@ -1,3 +1,4 @@
+using DraftView.Domain.Diff;
 using DraftView.Domain.Enumerations;
 using DraftView.Domain.Interfaces.Repositories;
 using DraftView.Domain.Interfaces.Services;
@@ -13,18 +14,25 @@ public class ChangeStateService(
     public async Task<ChangeClassification?> GetChangeStateAsync(
         Guid sectionId, Guid userId, CancellationToken ct = default)
     {
+        var (classification, _) = await GetChangeStateWithDiffAsync(sectionId, userId, ct);
+        return classification;
+    }
+
+    public async Task<(ChangeClassification? Classification, IReadOnlyList<ParagraphDiffResult> Paragraphs)>
+        GetChangeStateWithDiffAsync(Guid sectionId, Guid userId, CancellationToken ct = default)
+    {
         var section = await sectionRepo.GetByIdAsync(sectionId, ct);
         if (section is null || string.IsNullOrEmpty(section.HtmlContent))
-            return ChangeClassification.New;
+            return (ChangeClassification.New, Array.Empty<ParagraphDiffResult>());
 
         var snapshot = await snapshotRepo.GetAsync(sectionId, userId, ct);
         if (snapshot is null)
-            return ChangeClassification.New;
+            return (ChangeClassification.New, Array.Empty<ParagraphDiffResult>());
 
         if (snapshot.HtmlContent == section.HtmlContent)
-            return null;
+            return (null, Array.Empty<ParagraphDiffResult>());
 
         var paragraphs = htmlDiffService.Compute(snapshot.HtmlContent, section.HtmlContent);
-        return classificationService.Classify(paragraphs);
+        return (classificationService.Classify(paragraphs), paragraphs);
     }
 }

--- a/DraftView.Domain/Interfaces/Services/IChangeStateService.cs
+++ b/DraftView.Domain/Interfaces/Services/IChangeStateService.cs
@@ -1,3 +1,4 @@
+using DraftView.Domain.Diff;
 using DraftView.Domain.Enumerations;
 
 namespace DraftView.Domain.Interfaces.Services;
@@ -18,4 +19,15 @@ public interface IChangeStateService
         Guid sectionId,
         Guid userId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns both the change classification and the paragraph-level diff results.
+    /// Used by the read view to populate diff toggle and margin indicators.
+    /// Paragraphs is empty when classification is null (up to date) or New (no baseline).
+    /// </summary>
+    Task<(ChangeClassification? Classification, IReadOnlyList<ParagraphDiffResult> Paragraphs)>
+        GetChangeStateWithDiffAsync(
+            Guid sectionId,
+            Guid userId,
+            CancellationToken ct = default);
 }

--- a/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
+++ b/DraftView.Web.Tests/Controllers/ReaderControllerTests.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using DraftView.Domain.Contracts;
+using DraftView.Domain.Diff;
 using DraftView.Domain.Entities;
 using DraftView.Domain.Enumerations;
 using DraftView.Domain.Exceptions;
@@ -43,9 +44,17 @@ public class ReaderControllerTests
     private readonly Mock<IAccessRequestRepository> accessRequestRepo = new();
     private readonly Mock<IAccessRequestService> accessRequestService = new();
     private readonly Mock<IReaderDashboardService> readerDashboardService = new();
+    private readonly Mock<IChangeStateService> changeStateService = new();
     private readonly Mock<ILogger<ReaderController>> logger = new();
     private ICommentDisplayService CommentDisplayService =>
         new DraftView.Application.Services.CommentDisplayService(userRepo.Object, passageAnchorService.Object);
+
+    public ReaderControllerTests()
+    {
+        changeStateService.Setup(s => s.GetChangeStateWithDiffAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(((ChangeClassification?)null, (IReadOnlyList<ParagraphDiffResult>)Array.Empty<ParagraphDiffResult>())));
+    }
 
     [Fact]
     public async Task Read_DesktopRead_PopulatesModelWithStoredProsePreferences()
@@ -935,6 +944,7 @@ public class ReaderControllerTests
             accessRequestRepo.Object,
             accessRequestService.Object,
             readerDashboardService.Object,
+            changeStateService.Object,
             logger.Object);
 
         controller.ControllerContext = new ControllerContext
@@ -972,6 +982,7 @@ public class ReaderControllerTests
             accessRequestRepo.Object,
             accessRequestService.Object,
             readerDashboardService.Object,
+            changeStateService.Object,
             logger.Object);
 
         controller.ControllerContext = new ControllerContext
@@ -1299,6 +1310,13 @@ public class ReaderReadRenderingRegressionTests : IClassFixture<ReaderReadRender
                         reader.Id,
                         It.IsAny<CancellationToken>()))
                     .ReturnsAsync((ResumeRestoreTargetDto?)null);
+                progressService.Setup(r => r.IsMarkedReadAsync(It.IsAny<Guid>(), reader.Id, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(false);
+
+                var changeStateService = new Mock<IChangeStateService>();
+                changeStateService.Setup(s => s.GetChangeStateWithDiffAsync(
+                        It.IsAny<Guid>(), reader.Id, It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(((ChangeClassification?)null, (IReadOnlyList<ParagraphDiffResult>)Array.Empty<ParagraphDiffResult>())));
 
                 var readEventRepo = new Mock<IReadEventRepository>();
                 readEventRepo.Setup(r => r.GetAsync(It.IsAny<Guid>(), reader.Id, It.IsAny<CancellationToken>()))
@@ -1317,6 +1335,7 @@ public class ReaderReadRenderingRegressionTests : IClassFixture<ReaderReadRender
                 services.RemoveAll<IReaderAccessRepository>();
                 services.RemoveAll<IReadEventRepository>();
                 services.RemoveAll<ISystemStateMessageService>();
+                services.RemoveAll<IChangeStateService>();
 
                 services.AddSingleton(userRepo.Object);
                 services.AddSingleton(prefsRepo.Object);
@@ -1329,6 +1348,7 @@ public class ReaderReadRenderingRegressionTests : IClassFixture<ReaderReadRender
                 services.AddSingleton(systemStateMessageService.Object);
                 services.AddSingleton(humanOverrideService.Object);
                 services.AddSingleton(passageAnchorService.Object);
+                services.AddSingleton(changeStateService.Object);
             });
         }
     }

--- a/DraftView.Web/Controllers/ReaderController.cs
+++ b/DraftView.Web/Controllers/ReaderController.cs
@@ -27,6 +27,7 @@ public class ReaderController(
     IAccessRequestRepository accessRequestRepo,
     IAccessRequestService accessRequestService,
     IReaderDashboardService readerDashboardService,
+    IChangeStateService changeStateService,
     ILogger<ReaderController> logger)
     : BaseReaderController(projectRepo, sectionRepo, commentService, progressService,
                            userRepository, readerAccessRepo, humanOverrideService, passageAnchorService,
@@ -35,6 +36,7 @@ public class ReaderController(
     private readonly IUserPreferencesRepository _userPreferencesRepo = userPreferencesRepo;
     private readonly IPassageAnchorService _passageAnchorService = passageAnchorService;
     private readonly IReaderDashboardService _readerDashboardService = readerDashboardService;
+    private readonly IChangeStateService _changeStateService = changeStateService;
     private static readonly Regex HtmlTagRegex = new("<[^>]+>", RegexOptions.Compiled);
     private static readonly Regex WhitespaceRegex = new("\\s+", RegexOptions.Compiled);
 
@@ -729,6 +731,8 @@ public class ReaderController(
             await ResolveSceneContentAsync(scene, user.Id, showDiffOnRevisit, ct);
 
         var isRead = await ProgressService.IsMarkedReadAsync(scene.Id, user.Id, ct);
+        var (changeClassification, diffParagraphs) =
+            await _changeStateService.GetChangeStateWithDiffAsync(scene.Id, user.Id, ct);
         var comments = await CommentService.GetThreadsForSectionAsync(scene.Id, user.Id, ct);
         var displayComments = await BuildCommentDisplayModelsAsync(comments, user.Id, projectAuthorId, isModerator);
 
@@ -744,8 +748,10 @@ public class ReaderController(
             ResumeRestoreStatus          = resumeRestoreTarget?.Status,
             ResumeRestoreConfidenceScore = resumeRestoreTarget?.ConfidenceScore,
             ResumeRestoreMatchMethod     = resumeRestoreTarget?.MatchMethod,
+            DiffParagraphs               = diffParagraphs,
             DiffEnabled                  = showDiffOnRevisit,
             WordCount                    = CountWords(resolvedHtml),
+            ChangeClassification         = changeClassification,
             IsRead                       = isRead
         };
     }

--- a/DraftView.Web/Views/Reader/DesktopRead.cshtml
+++ b/DraftView.Web/Views/Reader/DesktopRead.cshtml
@@ -305,6 +305,26 @@
                         }
 
                         <div class="scene-prose-shell">
+                            @if (item.HasDiff)
+                            {
+                                <div class="diff-margin" aria-hidden="true">
+                                    @foreach (var para in item.DiffParagraphs)
+                                    {
+                                        if (para.Type == DiffResultType.Added)
+                                        {
+                                            <div class="diff-margin__mark diff-margin__mark--added"></div>
+                                        }
+                                        else if (para.Type == DiffResultType.Removed)
+                                        {
+                                            <div class="diff-margin__mark diff-margin__mark--removed"></div>
+                                        }
+                                        else
+                                        {
+                                            <div class="diff-margin__mark"></div>
+                                        }
+                                    }
+                                </div>
+                            }
                             @if (item.DiffEnabled && item.HasDiff)
                             {
                                 <div class="scene-diff-view" id="diff-@item.Scene.Id" hidden>

--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-08-31-1" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-08-31-1" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-09-01-1" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-09-01-1" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-08-31-1" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-09-01-1" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-08-31-1";
+    --css-version: "v2026-09-01-1";
     /* Banner image focal point — overridden per theme for images that are not 3.2:1 panoramic.
        Default suits Noir / Crime / Contemporary (all correctly proportioned at ~2240x700).
        Historic and Adventure override this until replacement panoramic banners are available. */
@@ -494,6 +494,39 @@ a {
     height: var(--space-3, 12px);
     margin-bottom: var(--space-2);
     opacity: 0.5;
+}
+
+/* Margin indicators — DesktopRead.cshtml
+   A narrow column of coloured marks to the left of the prose showing at a glance
+   which paragraphs have been added, removed, or are unchanged. Visible without
+   requiring the diff toggle to be open. */
+.scene-prose-shell {
+    display: flex;
+    gap: 0;
+}
+
+.diff-margin {
+    display: flex;
+    flex-direction: column;
+    width: 4px;
+    flex-shrink: 0;
+    margin-right: var(--space-3, 12px);
+}
+
+.diff-margin__mark {
+    flex: 1;
+    min-height: 4px;
+    background: transparent;
+}
+
+.diff-margin__mark--added {
+    background: var(--color-diff-added, #22c55e);
+    opacity: 0.7;
+}
+
+.diff-margin__mark--removed {
+    background: var(--color-diff-removed, #ef4444);
+    opacity: 0.7;
 }
 
 /* Change classification indicator â€” Author/Sections.cshtml */


### PR DESCRIPTION
## Summary

- Adds `IChangeStateService.GetChangeStateWithDiffAsync`: returns both `ChangeClassification?` and `IReadOnlyList<ParagraphDiffResult>` in one pass, avoiding a redundant snapshot lookup
- Refactors `GetChangeStateAsync` to delegate to `GetChangeStateWithDiffAsync` (no behaviour change)
- Injects `IChangeStateService` into `ReaderController`; `BuildSceneWithCommentsAsync` now populates both `DiffParagraphs` and `ChangeClassification` from the reader's snapshot vs current section content
- `DesktopRead.cshtml`: adds `.diff-margin` gutter alongside the prose — a 4px-wide column of coloured marks (green = added, red = removed) per paragraph, always visible without requiring the diff toggle
- The existing inline diff toggle (show/hide changed paragraphs) was already wired up; it now has data to display
- CSS: adds `.scene-prose-shell` flex layout, `.diff-margin`, `.diff-margin__mark`, `--added`, `--removed` rules; version bumped to `v2026-09-01-1`

## Test plan

- [x] 1,243 tests pass, 1 skipped (email integration), 0 failed
- [x] 4 new tests for `GetChangeStateWithDiffAsync` (null section, no snapshot, unchanged, differs)
- [x] `ReaderControllerTests` updated with `IChangeStateService` mock; integration factory updated

Closes #125. Part of #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)