### PR TITLE
#126 -- Phase 6: author readership view per scene

### DIFF
--- a/DraftView.Application.Tests/Services/SectionManagementServiceTests.cs
+++ b/DraftView.Application.Tests/Services/SectionManagementServiceTests.cs
@@ -17,12 +17,13 @@ namespace DraftView.Application.Tests.Services;
 /// </summary>
 public class SectionManagementServiceTests
 {
-    private readonly Mock<IProjectRepository>  _projectRepo        = new();
-    private readonly Mock<ISectionRepository>  _sectionRepo        = new();
-    private readonly Mock<IPublicationService> _publicationService = new();
-    private readonly Mock<ICommentService>     _commentService     = new();
-    private readonly Mock<IUserRepository>     _userRepository     = new();
-    private readonly Mock<IReadEventRepository> _readEventRepository = new();
+    private readonly Mock<IProjectRepository>          _projectRepo         = new();
+    private readonly Mock<ISectionRepository>          _sectionRepo         = new();
+    private readonly Mock<IPublicationService>         _publicationService  = new();
+    private readonly Mock<ICommentService>             _commentService      = new();
+    private readonly Mock<IUserRepository>             _userRepository      = new();
+    private readonly Mock<IReadEventRepository>        _readEventRepository = new();
+    private readonly Mock<IReaderSnapshotRepository>   _snapshotRepo        = new();
 
     private SectionManagementService CreateSut() => new(
         _projectRepo.Object,
@@ -30,7 +31,8 @@ public class SectionManagementServiceTests
         _publicationService.Object,
         _commentService.Object,
         _userRepository.Object,
-        _readEventRepository.Object);
+        _readEventRepository.Object,
+        _snapshotRepo.Object);
 
     [Fact]
     public async Task GetSectionsSummaryAsync_ProjectNotFound_ReturnsNull()
@@ -150,33 +152,13 @@ public class SectionManagementServiceTests
         _sectionRepo.Setup(r => r.GetByIdAsync(chapter.Id, default)).ReturnsAsync(chapter);
         _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default)).ReturnsAsync([]);
         _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default)).ReturnsAsync([]);
+        _snapshotRepo.Setup(r => r.GetBySectionIdAsync(scene.Id, default)).ReturnsAsync([]);
 
         var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
 
         Assert.NotNull(result);
         Assert.Equal("Chapter One", result!.ChapterTitle);
         Assert.Same(scene, result.Section);
-    }
-
-    [Fact]
-    public async Task GetSectionDetailAsync_ReturnsReadCount()
-    {
-        var project  = Project.Create("Book", "/path", Guid.NewGuid(), "root-uuid");
-        var scene    = Section.CreateDocument(project.Id, "s1", "Scene 1", null, 0, "<p>a</p>", "h1", null);
-        var authorId = Guid.NewGuid();
-        var readerId = Guid.NewGuid();
-        var readEvent1 = ReadEvent.Create(scene.Id, readerId);
-        var readEvent2 = ReadEvent.Create(scene.Id, Guid.NewGuid());
-
-        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
-        _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default)).ReturnsAsync([]);
-        _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
-            .ReturnsAsync([readEvent1, readEvent2]);
-
-        var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
-
-        Assert.NotNull(result);
-        Assert.Equal(2, result!.ReadCount);
     }
 
     [Fact]
@@ -193,6 +175,7 @@ public class SectionManagementServiceTests
         _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default))
             .ReturnsAsync([comment]);
         _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default)).ReturnsAsync([]);
+        _snapshotRepo.Setup(r => r.GetBySectionIdAsync(scene.Id, default)).ReturnsAsync([]);
         _userRepository.Setup(r => r.GetByIdAsync(readerId, default)).ReturnsAsync(readerUser);
 
         var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
@@ -203,28 +186,127 @@ public class SectionManagementServiceTests
     }
 
     [Fact]
-    public async Task GetSectionDetailAsync_PopulatesReaderNamesFromReadEvents()
+    public async Task GetSectionDetailAsync_ReaderWithCurrentSnapshot_IsReadCurrent()
     {
+        const string currentHtml = "<p>Current content.</p>";
         var project   = Project.Create("Book", "/path", Guid.NewGuid(), "root-uuid");
-        var scene     = Section.CreateDocument(project.Id, "s1", "Scene 1", null, 0, "<p>a</p>", "h1", null);
+        var scene     = Section.CreateDocument(project.Id, "s1", "Scene 1", null, 0, currentHtml, "h1", null);
         var authorId  = Guid.NewGuid();
-        var reader1Id = Guid.NewGuid();
-        var reader2Id = Guid.NewGuid();
-        var reader1   = User.Create("r1@example.test", "Hilary", Role.BetaReader);
-        var reader2   = User.Create("r2@example.test", "Becca",  Role.BetaReader);
+        var readerId  = Guid.NewGuid();
+        var reader    = User.Create("r@example.test", "Hilary", Role.BetaReader);
+        var snapshot  = ReaderSnapshot.Create(scene.Id, readerId, currentHtml);
 
         _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
         _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default)).ReturnsAsync([]);
         _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
-            .ReturnsAsync([ReadEvent.Create(scene.Id, reader1Id), ReadEvent.Create(scene.Id, reader2Id)]);
-        _userRepository.Setup(r => r.GetByIdAsync(reader1Id, default)).ReturnsAsync(reader1);
-        _userRepository.Setup(r => r.GetByIdAsync(reader2Id, default)).ReturnsAsync(reader2);
+            .ReturnsAsync([ReadEvent.Create(scene.Id, readerId)]);
+        _snapshotRepo.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
+            .ReturnsAsync([snapshot]);
+        _userRepository.Setup(r => r.GetByIdAsync(readerId, default)).ReturnsAsync(reader);
 
         var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
 
         Assert.NotNull(result);
-        Assert.Equal(2, result!.ReaderNames.Count);
-        Assert.Contains("Hilary", result.ReaderNames);
-        Assert.Contains("Becca",  result.ReaderNames);
+        Assert.Equal(1, result!.ReadCurrentCount);
+        Assert.Equal(0, result.NotReadCurrentCount);
+        Assert.Contains("Hilary", result.ReadCurrentNames);
+        Assert.Empty(result.NotReadCurrentNames);
+    }
+
+    [Fact]
+    public async Task GetSectionDetailAsync_ReaderWithStaleSnapshot_IsNotReadCurrent()
+    {
+        const string currentHtml = "<p>Current content.</p>";
+        const string oldHtml     = "<p>Old content.</p>";
+        var project   = Project.Create("Book", "/path", Guid.NewGuid(), "root-uuid");
+        var scene     = Section.CreateDocument(project.Id, "s1", "Scene 1", null, 0, currentHtml, "h1", null);
+        var authorId  = Guid.NewGuid();
+        var readerId  = Guid.NewGuid();
+        var reader    = User.Create("r@example.test", "Becca", Role.BetaReader);
+        var snapshot  = ReaderSnapshot.Create(scene.Id, readerId, oldHtml);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
+        _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default)).ReturnsAsync([]);
+        _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
+            .ReturnsAsync([ReadEvent.Create(scene.Id, readerId)]);
+        _snapshotRepo.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
+            .ReturnsAsync([snapshot]);
+        _userRepository.Setup(r => r.GetByIdAsync(readerId, default)).ReturnsAsync(reader);
+
+        var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result!.ReadCurrentCount);
+        Assert.Equal(1, result.NotReadCurrentCount);
+        Assert.Empty(result.ReadCurrentNames);
+        Assert.Contains("Becca", result.NotReadCurrentNames);
+    }
+
+    [Fact]
+    public async Task GetSectionDetailAsync_ReaderWithNoSnapshot_IsNotReadCurrent()
+    {
+        const string currentHtml = "<p>Current content.</p>";
+        var project   = Project.Create("Book", "/path", Guid.NewGuid(), "root-uuid");
+        var scene     = Section.CreateDocument(project.Id, "s1", "Scene 1", null, 0, currentHtml, "h1", null);
+        var authorId  = Guid.NewGuid();
+        var readerId  = Guid.NewGuid();
+        var reader    = User.Create("r@example.test", "Hilary", Role.BetaReader);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
+        _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default)).ReturnsAsync([]);
+        _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
+            .ReturnsAsync([ReadEvent.Create(scene.Id, readerId)]);
+        _snapshotRepo.Setup(r => r.GetBySectionIdAsync(scene.Id, default)).ReturnsAsync([]);
+        _userRepository.Setup(r => r.GetByIdAsync(readerId, default)).ReturnsAsync(reader);
+
+        var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result!.ReadCurrentCount);
+        Assert.Equal(1, result.NotReadCurrentCount);
+        Assert.Contains("Hilary", result.NotReadCurrentNames);
+    }
+
+    [Fact]
+    public async Task GetSectionDetailAsync_MixedReaders_PartitionedCorrectly()
+    {
+        const string currentHtml = "<p>Current content.</p>";
+        const string oldHtml     = "<p>Old content.</p>";
+        var project   = Project.Create("Book", "/path", Guid.NewGuid(), "root-uuid");
+        var scene     = Section.CreateDocument(project.Id, "s1", "Scene 1", null, 0, currentHtml, "h1", null);
+        var authorId  = Guid.NewGuid();
+        var reader1Id = Guid.NewGuid();
+        var reader2Id = Guid.NewGuid();
+        var reader3Id = Guid.NewGuid();
+        var reader1   = User.Create("r1@example.test", "Alice",  Role.BetaReader);
+        var reader2   = User.Create("r2@example.test", "Becca",  Role.BetaReader);
+        var reader3   = User.Create("r3@example.test", "Carol",  Role.BetaReader);
+
+        _sectionRepo.Setup(r => r.GetByIdAsync(scene.Id, default)).ReturnsAsync(scene);
+        _commentService.Setup(s => s.GetThreadsForSectionAsync(scene.Id, authorId, default)).ReturnsAsync([]);
+        _readEventRepository.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
+            .ReturnsAsync([
+                ReadEvent.Create(scene.Id, reader1Id),
+                ReadEvent.Create(scene.Id, reader2Id),
+                ReadEvent.Create(scene.Id, reader3Id)
+            ]);
+        _snapshotRepo.Setup(r => r.GetBySectionIdAsync(scene.Id, default))
+            .ReturnsAsync([
+                ReaderSnapshot.Create(scene.Id, reader1Id, currentHtml),  // current
+                ReaderSnapshot.Create(scene.Id, reader2Id, oldHtml)        // stale
+                // reader3 has no snapshot
+            ]);
+        _userRepository.Setup(r => r.GetByIdAsync(reader1Id, default)).ReturnsAsync(reader1);
+        _userRepository.Setup(r => r.GetByIdAsync(reader2Id, default)).ReturnsAsync(reader2);
+        _userRepository.Setup(r => r.GetByIdAsync(reader3Id, default)).ReturnsAsync(reader3);
+
+        var result = await CreateSut().GetSectionDetailAsync(scene.Id, authorId);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.ReadCurrentCount);
+        Assert.Equal(2, result.NotReadCurrentCount);
+        Assert.Contains("Alice",  result.ReadCurrentNames);
+        Assert.Contains("Becca",  result.NotReadCurrentNames);
+        Assert.Contains("Carol",  result.NotReadCurrentNames);
     }
 }

--- a/DraftView.Application/Services/SectionManagementService.cs
+++ b/DraftView.Application/Services/SectionManagementService.cs
@@ -16,7 +16,8 @@ public class SectionManagementService(
     IPublicationService publicationService,
     ICommentService commentService,
     IUserRepository userRepository,
-    IReadEventRepository readEventRepository) : ISectionManagementService
+    IReadEventRepository readEventRepository,
+    IReaderSnapshotRepository snapshotRepository) : ISectionManagementService
 {
     /// <summary>
     /// Loads the project and its full section tree, evaluates publishability
@@ -96,8 +97,9 @@ public class SectionManagementService(
             chapterTitle = parent?.Title;
         }
 
-        var comments = await commentService.GetThreadsForSectionAsync(sectionId, authorId, ct);
-        var events   = await readEventRepository.GetBySectionIdAsync(sectionId, ct);
+        var comments  = await commentService.GetThreadsForSectionAsync(sectionId, authorId, ct);
+        var events    = await readEventRepository.GetBySectionIdAsync(sectionId, ct);
+        var snapshots = await snapshotRepository.GetBySectionIdAsync(sectionId, ct);
 
         var nameMap = new Dictionary<Guid, string>();
         foreach (var uid in comments.Select(c => c.AuthorId).Distinct())
@@ -106,21 +108,31 @@ public class SectionManagementService(
             nameMap[uid] = u?.DisplayName ?? "Unknown";
         }
 
-        var readerNames = new List<string>();
+        var snapshotByUser = snapshots.ToDictionary(s => s.UserId);
+        var readCurrentNames    = new List<string>();
+        var notReadCurrentNames = new List<string>();
+
         foreach (var uid in events.Select(e => e.UserId).Distinct())
         {
-            var u = await userRepository.GetByIdAsync(uid, ct);
-            readerNames.Add(u?.DisplayName ?? "Unknown");
+            var u    = await userRepository.GetByIdAsync(uid, ct);
+            var name = u?.DisplayName ?? "Unknown";
+            if (snapshotByUser.TryGetValue(uid, out var snap) &&
+                snap.HtmlContent == section.HtmlContent)
+                readCurrentNames.Add(name);
+            else
+                notReadCurrentNames.Add(name);
         }
 
         return new SectionDetailDto
         {
-            Section            = section,
-            ChapterTitle       = chapterTitle,
-            Comments           = comments,
-            CommentAuthorNames = nameMap,
-            ReadCount          = events.Count,
-            ReaderNames        = readerNames
+            Section               = section,
+            ChapterTitle          = chapterTitle,
+            Comments              = comments,
+            CommentAuthorNames    = nameMap,
+            ReadCurrentCount      = readCurrentNames.Count,
+            NotReadCurrentCount   = notReadCurrentNames.Count,
+            ReadCurrentNames      = readCurrentNames,
+            NotReadCurrentNames   = notReadCurrentNames
         };
     }
 

--- a/DraftView.Domain/Interfaces/Services/ISectionManagementService.cs
+++ b/DraftView.Domain/Interfaces/Services/ISectionManagementService.cs
@@ -27,7 +27,7 @@ public sealed class SectionsSummaryDto
 /// <summary>
 /// All data required to render the author's section detail page, including
 /// the section itself, its parent chapter title, comments with author names,
-/// and the read count.
+/// and per-reader snapshot-based read state.
 /// </summary>
 public sealed class SectionDetailDto
 {
@@ -35,8 +35,18 @@ public sealed class SectionDetailDto
     public string? ChapterTitle { get; init; }
     public required IReadOnlyList<Comment> Comments { get; init; }
     public required IReadOnlyDictionary<Guid, string> CommentAuthorNames { get; init; }
-    public required int ReadCount { get; init; }
-    public required IReadOnlyList<string> ReaderNames { get; init; }
+
+    /// <summary>Readers whose stored snapshot matches the current HtmlContent — up to date.</summary>
+    public required int ReadCurrentCount { get; init; }
+
+    /// <summary>Readers who have opened the scene but whose snapshot does not match current content.</summary>
+    public required int NotReadCurrentCount { get; init; }
+
+    /// <summary>Display names of readers on the current content version.</summary>
+    public required IReadOnlyList<string> ReadCurrentNames { get; init; }
+
+    /// <summary>Display names of readers not yet on the current content version.</summary>
+    public required IReadOnlyList<string> NotReadCurrentNames { get; init; }
 }
 
 public interface ISectionManagementService

--- a/DraftView.Web/Controllers/AuthorController.cs
+++ b/DraftView.Web/Controllers/AuthorController.cs
@@ -569,12 +569,14 @@ public class AuthorController(
 
         return View(new SectionViewModel
         {
-            Section            = detail.Section,
-            ChapterTitle       = detail.ChapterTitle,
-            Comments           = detail.Comments,
-            ReadCount          = detail.ReadCount,
-            CommentAuthorNames = detail.CommentAuthorNames,
-            ReaderNames        = detail.ReaderNames
+            Section              = detail.Section,
+            ChapterTitle         = detail.ChapterTitle,
+            Comments             = detail.Comments,
+            CommentAuthorNames   = detail.CommentAuthorNames,
+            ReadCurrentCount     = detail.ReadCurrentCount,
+            NotReadCurrentCount  = detail.NotReadCurrentCount,
+            ReadCurrentNames     = detail.ReadCurrentNames,
+            NotReadCurrentNames  = detail.NotReadCurrentNames
         });
     }
 

--- a/DraftView.Web/Models/AuthorViewModels.cs
+++ b/DraftView.Web/Models/AuthorViewModels.cs
@@ -23,8 +23,11 @@ public class SectionViewModel
     public string? ChapterTitle { get; set; }
     public IReadOnlyList<Comment> Comments { get; set; } = [];
     public IReadOnlyDictionary<Guid, string> CommentAuthorNames { get; set; } = new Dictionary<Guid, string>();
-    public int ReadCount { get; set; }
-    public IReadOnlyList<string> ReaderNames { get; set; } = [];
+    public int ReadCurrentCount { get; set; }
+    public int NotReadCurrentCount { get; set; }
+    public IReadOnlyList<string> ReadCurrentNames { get; set; } = [];
+    public IReadOnlyList<string> NotReadCurrentNames { get; set; } = [];
+    public int TotalReadCount => ReadCurrentCount + NotReadCurrentCount;
 }
 
 public class ReaderRowViewModel

--- a/DraftView.Web/Views/Author/Section.cshtml
+++ b/DraftView.Web/Views/Author/Section.cshtml
@@ -16,7 +16,19 @@
     <p class="author-section-view__meta">
         <span>@(Model.Section.ScrivenerStatus ?? "-")</span>
         <span class="author-section-view__meta-sep">|</span>
-        <span title="@(Model.ReaderNames.Any() ? string.Join(", ", Model.ReaderNames) : "")">Read by @Model.ReadCount reader(s)</span>
+        <span title="@(Model.ReadCurrentNames.Any() ? string.Join(", ", Model.ReadCurrentNames) : "No readers on current version")"
+              class="author-section-view__read-current">@Model.ReadCurrentCount on current</span>
+        @if (Model.NotReadCurrentCount > 0)
+        {
+            <span class="author-section-view__meta-sep">·</span>
+            <span title="@string.Join(", ", Model.NotReadCurrentNames)"
+                  class="author-section-view__read-stale">@Model.NotReadCurrentCount not on current</span>
+        }
+        @if (Model.TotalReadCount > 0)
+        {
+            <span class="author-section-view__meta-sep">·</span>
+            <span class="author-section-view__read-total">@Model.TotalReadCount total</span>
+        }
     </p>
 
     <div class="card author-section-view__content-card">


### PR DESCRIPTION
## Summary

- Extends `SectionDetailDto` with `ReadCurrentCount`, `NotReadCurrentCount`, `ReadCurrentNames`, `NotReadCurrentNames` — replacing the old flat `ReadCount`/`ReaderNames` with snapshot-aware partitioning
- `SectionManagementService.GetSectionDetailAsync`: loads snapshots via `IReaderSnapshotRepository.GetBySectionIdAsync`, cross-references with read events, and partitions each reader into "on current version" (snapshot.HtmlContent matches section.HtmlContent) vs "not on current"
- `Author/Section.cshtml`: shows `N on current · M not on current · T total` with hover tooltips listing reader names in each group
- `IReaderSnapshotRepository` is already DI-registered — no registration change needed

## Test plan

- [x] 1,245 tests pass, 1 skipped, 0 failed
- [x] 4 new tests: current snapshot, stale snapshot, no snapshot, mixed readers (3 readers across both groups)
- [x] Existing `GetSectionDetailAsync` tests updated for new DTO shape

Closes #126. Part of #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)