### PR TITLE
#127 -- Phase 7: email notifications with reader change-level threshold

### DIFF
--- a/DraftView.Application.Tests/Services/ChangeNotificationServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ChangeNotificationServiceTests.cs
@@ -1,0 +1,177 @@
+using Moq;
+using DraftView.Application.Services;
+using DraftView.Domain.Entities;
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Tests.Services;
+
+public class ChangeNotificationServiceTests
+{
+    private static readonly Guid SectionId = Guid.NewGuid();
+
+    private readonly Mock<IReadEventRepository>          _readEventRepo      = new();
+    private readonly Mock<IUserPreferencesRepository>    _prefsRepo          = new();
+    private readonly Mock<IChangeStateService>           _changeStateService = new();
+    private readonly Mock<INotificationService>          _notificationService = new();
+
+    private ChangeNotificationService CreateSut() => new(
+        _readEventRepo.Object,
+        _prefsRepo.Object,
+        _changeStateService.Object,
+        _notificationService.Object);
+
+    private static UserPreferences MakePrefs(
+        Guid userId,
+        bool notifyOnSectionChanged = true,
+        ReadingStyle style = ReadingStyle.StoryReader)
+    {
+        var prefs = UserPreferences.CreateForBetaReader(userId);
+        prefs.UpdateBetaReaderPreferences(
+            notifyOnNewSection: false,
+            notifyOnSectionChanged: notifyOnSectionChanged,
+            notifyOnReply: NotifyOnReply.Never);
+        prefs.UpdateDiffPreferences(showDiffOnRevisit: false, style, diffCooldownHours: 24);
+        return prefs;
+    }
+
+    [Fact]
+    public async Task SendChangeNotificationsAsync_NoReadEvents_DoesNotSend()
+    {
+        _readEventRepo.Setup(r => r.GetBySectionIdAsync(SectionId, default))
+            .ReturnsAsync([]);
+
+        await CreateSut().SendChangeNotificationsAsync(SectionId);
+
+        _notificationService.Verify(s => s.SendImmediateAsync(
+            It.IsAny<EmailType>(), It.IsAny<Guid>(), It.IsAny<Guid?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendChangeNotificationsAsync_ReaderNotifyOff_DoesNotSend()
+    {
+        var userId = Guid.NewGuid();
+        var ev = ReadEvent.Create(SectionId, userId);
+        _readEventRepo.Setup(r => r.GetBySectionIdAsync(SectionId, default))
+            .ReturnsAsync([ev]);
+        _prefsRepo.Setup(r => r.GetByUserIdAsync(userId, default))
+            .ReturnsAsync(MakePrefs(userId, notifyOnSectionChanged: false));
+
+        await CreateSut().SendChangeNotificationsAsync(SectionId);
+
+        _notificationService.Verify(s => s.SendImmediateAsync(
+            It.IsAny<EmailType>(), It.IsAny<Guid>(), It.IsAny<Guid?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendChangeNotificationsAsync_ReaderUpToDate_DoesNotSend()
+    {
+        var userId = Guid.NewGuid();
+        var ev = ReadEvent.Create(SectionId, userId);
+        _readEventRepo.Setup(r => r.GetBySectionIdAsync(SectionId, default))
+            .ReturnsAsync([ev]);
+        _prefsRepo.Setup(r => r.GetByUserIdAsync(userId, default))
+            .ReturnsAsync(MakePrefs(userId));
+        _changeStateService.Setup(s => s.GetChangeStateAsync(SectionId, userId, default))
+            .ReturnsAsync((ChangeClassification?)null);
+
+        await CreateSut().SendChangeNotificationsAsync(SectionId);
+
+        _notificationService.Verify(s => s.SendImmediateAsync(
+            It.IsAny<EmailType>(), It.IsAny<Guid>(), It.IsAny<Guid?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendChangeNotificationsAsync_ReaderNew_NoSnapshot_DoesNotSend()
+    {
+        var userId = Guid.NewGuid();
+        var ev = ReadEvent.Create(SectionId, userId);
+        _readEventRepo.Setup(r => r.GetBySectionIdAsync(SectionId, default))
+            .ReturnsAsync([ev]);
+        _prefsRepo.Setup(r => r.GetByUserIdAsync(userId, default))
+            .ReturnsAsync(MakePrefs(userId));
+        _changeStateService.Setup(s => s.GetChangeStateAsync(SectionId, userId, default))
+            .ReturnsAsync(ChangeClassification.New);
+
+        await CreateSut().SendChangeNotificationsAsync(SectionId);
+
+        _notificationService.Verify(s => s.SendImmediateAsync(
+            It.IsAny<EmailType>(), It.IsAny<Guid>(), It.IsAny<Guid?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendChangeNotificationsAsync_ClassificationMeetsThreshold_Sends()
+    {
+        // StoryReader threshold = Polish; Revision >= Polish → send
+        var userId = Guid.NewGuid();
+        var ev = ReadEvent.Create(SectionId, userId);
+        _readEventRepo.Setup(r => r.GetBySectionIdAsync(SectionId, default))
+            .ReturnsAsync([ev]);
+        _prefsRepo.Setup(r => r.GetByUserIdAsync(userId, default))
+            .ReturnsAsync(MakePrefs(userId, style: ReadingStyle.StoryReader));
+        _changeStateService.Setup(s => s.GetChangeStateAsync(SectionId, userId, default))
+            .ReturnsAsync(ChangeClassification.Revision);
+
+        await CreateSut().SendChangeNotificationsAsync(SectionId);
+
+        _notificationService.Verify(s => s.SendImmediateAsync(
+            EmailType.SectionChangedNotification, userId, SectionId,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendChangeNotificationsAsync_ClassificationBelowThreshold_DoesNotSend()
+    {
+        // AlphaReader threshold = Revision; Polish < Revision → no send
+        var userId = Guid.NewGuid();
+        var ev = ReadEvent.Create(SectionId, userId);
+        _readEventRepo.Setup(r => r.GetBySectionIdAsync(SectionId, default))
+            .ReturnsAsync([ev]);
+        _prefsRepo.Setup(r => r.GetByUserIdAsync(userId, default))
+            .ReturnsAsync(MakePrefs(userId, style: ReadingStyle.AlphaReader));
+        _changeStateService.Setup(s => s.GetChangeStateAsync(SectionId, userId, default))
+            .ReturnsAsync(ChangeClassification.Polish);
+
+        await CreateSut().SendChangeNotificationsAsync(SectionId);
+
+        _notificationService.Verify(s => s.SendImmediateAsync(
+            It.IsAny<EmailType>(), It.IsAny<Guid>(), It.IsAny<Guid?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendChangeNotificationsAsync_MultipleReaders_OnlySendToEligible()
+    {
+        var reader1Id = Guid.NewGuid();
+        var reader2Id = Guid.NewGuid();
+        var ev1 = ReadEvent.Create(SectionId, reader1Id);
+        var ev2 = ReadEvent.Create(SectionId, reader2Id);
+
+        _readEventRepo.Setup(r => r.GetBySectionIdAsync(SectionId, default))
+            .ReturnsAsync([ev1, ev2]);
+
+        // reader1: notify on, Revision >= Polish threshold → send
+        _prefsRepo.Setup(r => r.GetByUserIdAsync(reader1Id, default))
+            .ReturnsAsync(MakePrefs(reader1Id, notifyOnSectionChanged: true, style: ReadingStyle.StoryReader));
+        _changeStateService.Setup(s => s.GetChangeStateAsync(SectionId, reader1Id, default))
+            .ReturnsAsync(ChangeClassification.Revision);
+
+        // reader2: notify off → no send
+        _prefsRepo.Setup(r => r.GetByUserIdAsync(reader2Id, default))
+            .ReturnsAsync(MakePrefs(reader2Id, notifyOnSectionChanged: false));
+
+        await CreateSut().SendChangeNotificationsAsync(SectionId);
+
+        _notificationService.Verify(s => s.SendImmediateAsync(
+            EmailType.SectionChangedNotification, reader1Id, SectionId,
+            It.IsAny<CancellationToken>()), Times.Once);
+        _notificationService.Verify(s => s.SendImmediateAsync(
+            It.IsAny<EmailType>(), reader2Id, It.IsAny<Guid?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
+++ b/DraftView.Application.Tests/Services/ScrivenerSyncServiceTests.cs
@@ -25,8 +25,9 @@ public class ScrivenerSyncServiceTests
     private readonly Mock<IDropboxClientFactory>         _clientFactory     = new();
     private readonly Mock<IDropboxFileDownloader>        _fileDownloader    = new();
     private readonly Mock<ILogger<ScrivenerSyncService>>          _logger           = new();
-    private readonly Mock<IAuthorNotificationRepository> _notificationRepo = new();
-    private readonly Mock<IUserRepository>               _userRepo         = new();
+    private readonly Mock<IAuthorNotificationRepository> _notificationRepo       = new();
+    private readonly Mock<IUserRepository>               _userRepo               = new();
+    private readonly Mock<IChangeNotificationService>    _changeNotificationService = new();
 
     private ScrivenerSyncService CreateSut() => new(
         _projectRepo.Object,
@@ -41,7 +42,8 @@ public class ScrivenerSyncServiceTests
         _fileDownloader.Object,
         _logger.Object,
         _notificationRepo.Object,
-        _userRepo.Object);
+        _userRepo.Object,
+        _changeNotificationService.Object);
 
     public ScrivenerSyncServiceTests()
     {

--- a/DraftView.Application/Services/ChangeNotificationService.cs
+++ b/DraftView.Application/Services/ChangeNotificationService.cs
@@ -1,0 +1,40 @@
+using DraftView.Domain.Enumerations;
+using DraftView.Domain.Interfaces.Repositories;
+using DraftView.Domain.Interfaces.Services;
+
+namespace DraftView.Application.Services;
+
+public class ChangeNotificationService(
+    IReadEventRepository readEventRepo,
+    IUserPreferencesRepository prefsRepo,
+    IChangeStateService changeStateService,
+    INotificationService notificationService) : IChangeNotificationService
+{
+    public async Task SendChangeNotificationsAsync(Guid sectionId, CancellationToken ct = default)
+    {
+        var events = await readEventRepo.GetBySectionIdAsync(sectionId, ct);
+
+        foreach (var ev in events)
+        {
+            var prefs = await prefsRepo.GetByUserIdAsync(ev.UserId, ct);
+            if (prefs is null || !prefs.NotifyOnSectionChanged) continue;
+
+            var classification = await changeStateService.GetChangeStateAsync(sectionId, ev.UserId, ct);
+            if (classification is null || classification == ChangeClassification.New) continue;
+
+            if (classification < MinimumTier(prefs.ReadingStyle)) continue;
+
+            await notificationService.SendImmediateAsync(
+                EmailType.SectionChangedNotification, ev.UserId, sectionId, ct);
+        }
+    }
+
+    private static ChangeClassification MinimumTier(ReadingStyle style) => style switch
+    {
+        ReadingStyle.BetaReader    => ChangeClassification.Trivial,
+        ReadingStyle.StoryReader   => ChangeClassification.Polish,
+        ReadingStyle.AlphaReader   => ChangeClassification.Revision,
+        ReadingStyle.StructureOnly => ChangeClassification.Rewrite,
+        _                          => ChangeClassification.Polish
+    };
+}

--- a/DraftView.Application/Services/ScrivenerSyncService.cs
+++ b/DraftView.Application/Services/ScrivenerSyncService.cs
@@ -22,10 +22,12 @@ public class ScrivenerSyncService(
     IDropboxFileDownloader fileDownloader,
     ILogger<ScrivenerSyncService> logger,
     IAuthorNotificationRepository notificationRepo,
-    IUserRepository userRepo) : ISyncService
+    IUserRepository userRepo,
+    IChangeNotificationService changeNotificationService) : ISyncService
 {
     private bool _syncHadChanges;
     private Guid _currentAuthorId;
+    private readonly HashSet<Guid> _contentChangedPublishedSectionIds = [];
 
     public async Task ParseProjectAsync(Guid projectId, CancellationToken ct = default)
     {
@@ -49,6 +51,7 @@ public class ScrivenerSyncService(
 
         _syncHadChanges = false;
         _currentAuthorId = project.AuthorId;
+        _contentChangedPublishedSectionIds.Clear();
 
         try
         {
@@ -88,6 +91,12 @@ public class ScrivenerSyncService(
         }
 
         await unitOfWork.SaveChangesAsync(ct);
+
+        foreach (var sectionId in _contentChangedPublishedSectionIds)
+        {
+            try { await changeNotificationService.SendChangeNotificationsAsync(sectionId, ct); }
+            catch (Exception ex) { logger.LogError(ex, "Change notification failed for section {SectionId}", sectionId); }
+        }
     }
 
     public async Task DetectContentChangesAsync(Guid projectId, CancellationToken ct = default)
@@ -331,6 +340,8 @@ public class ScrivenerSyncService(
             {
                 existing.UpdateContent(rtf.Html, rtf.Hash);
                 _syncHadChanges = true;
+                if (existing.IsPublished)
+                    _contentChangedPublishedSectionIds.Add(existing.Id);
             }
         }
     }

--- a/DraftView.Domain/Interfaces/Services/IChangeNotificationService.cs
+++ b/DraftView.Domain/Interfaces/Services/IChangeNotificationService.cs
@@ -1,0 +1,16 @@
+namespace DraftView.Domain.Interfaces.Services;
+
+/// <summary>
+/// Sends email notifications to readers whose snapshot-based change state
+/// meets their notification threshold after a sync content update.
+/// </summary>
+public interface IChangeNotificationService
+{
+    /// <summary>
+    /// For each reader who has read the section, computes their change state
+    /// and sends a SectionChangedNotification email if the classification
+    /// meets the reader's ReadingStyle threshold and NotifyOnSectionChanged is enabled.
+    /// No-op for readers with no snapshot (New) or up-to-date snapshots.
+    /// </summary>
+    Task SendChangeNotificationsAsync(Guid sectionId, CancellationToken ct = default);
+}

--- a/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/DraftView.Web/Extensions/ServiceCollectionExtensions.cs
@@ -119,6 +119,7 @@ namespace DraftView.Web.Extensions
             services.AddScoped<IChangeClassificationService, ChangeClassificationService>();
             services.AddScoped<IHtmlDiffService, HtmlDiffService>();
             services.AddScoped<IChangeStateService, ChangeStateService>();
+            services.AddScoped<IChangeNotificationService, ChangeNotificationService>();
             services.AddScoped<IReaderDashboardService, ReaderDashboardService>();
             services.AddScoped<ISectionManagementService, SectionManagementService>();
             services.AddScoped<IProjectManagementService, ProjectManagementService>();


### PR DESCRIPTION
## Summary

- New `IChangeNotificationService` / `ChangeNotificationService`: iterates readers with `ReadEvent` for a section, checks their `NotifyOnSectionChanged` preference, computes change state via `IChangeStateService`, and sends `SectionChangedNotification` email when the classification meets their `ReadingStyle` threshold
- `ReadingStyle` threshold mapping: BetaReader→Trivial, StoryReader→Polish, AlphaReader→Revision, StructureOnly→Rewrite
- `New` (no snapshot baseline) and `null` (up to date) are both skipped — only actual content deltas trigger emails
- `ScrivenerSyncService`: tracks published sections with content changes during reconciliation (via new `_contentChangedPublishedSectionIds` set); after the unit-of-work save, calls `SendChangeNotificationsAsync` per changed section, with errors logged but not propagated
- DI registered as scoped; `IChangeNotificationService` injected into `ScrivenerSyncService`

## Test plan

- [x] 1,252 tests pass, 1 skipped, 0 failed
- [x] 7 new tests: no events, notify off, up to date, New state, meets threshold, below threshold, mixed readers

Closes #127. Part of #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)