### PR TITLE
fix: #139 removed paragraphs render as red strikethrough not clipped overlay

### DIFF
--- a/DraftView.Web/Views/Shared/_Layout.cshtml
+++ b/DraftView.Web/Views/Shared/_Layout.cshtml
@@ -80,18 +80,18 @@ All css files are included here to ensure consistent styling across the site.
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Merriweather:wght@400;700&family=Lato:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="@themeCss?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-09-01-2" />
-    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-09-01-2" />
+    <link rel="stylesheet" href="@themeCss?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.Core.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.Settings.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.Navigation.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.Components.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.DesktopReader.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.MobileReader.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.Dashboard.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.Notifications.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.Mobile.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.ManualUpload.css?v=v2026-09-01-3" />
+    <link rel="stylesheet" href="/css/DraftView.Onboarding.css?v=v2026-09-01-3" />
     
     <link rel="icon" type="image/png" href="~/images/DraftView.Logo.web.png" />
 
@@ -99,7 +99,7 @@ All css files are included here to ensure consistent styling across the site.
         if (Context.Request.Query["debug"] == "css" ||
             Context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment())
         {
-            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-09-01-2" />
+            <link rel="stylesheet" href="/css/DraftView.Debug.css?v=v2026-09-01-3" />
         }
     }
 </head>

--- a/DraftView.Web/wwwroot/css/DraftView.Core.css
+++ b/DraftView.Web/wwwroot/css/DraftView.Core.css
@@ -13,7 +13,7 @@
    -------------------------------------------------------------------------- */
 :root {
     /* Update for every change */
-    --css-version: "v2026-09-01-2";
+    --css-version: "v2026-09-01-3";
     /* Banner image focal point — overridden per theme for images that are not 3.2:1 panoramic.
        Default suits Noir / Crime / Contemporary (all correctly proportioned at ~2240x700).
        Historic and Adventure override this until replacement panoramic banners are available. */
@@ -61,6 +61,13 @@
     --shadow-lg: 0 4px 16px rgba(0,0,0,0.10);
     /* Transitions */
     --transition: 150ms ease;
+    /* Diff colours — inline change view */
+    --color-diff-added: #22c55e;
+    --color-diff-added-bg: #f0fdf4;
+    --color-diff-added-inline-bg: rgba(34, 197, 94, 0.10);
+    --color-diff-removed: #ef4444;
+    --color-diff-removed-bg: rgba(239, 68, 68, 0.06);
+    --color-diff-removed-inline-bg: rgba(239, 68, 68, 0.08);
 }
 
 /* Version history â€” Author/Publishing.cshtml (V-Sprint 9 Phase 3) */
@@ -480,20 +487,23 @@ a {
    Reader diff highlighting â€” DesktopRead.cshtml / MobileRead.cshtml
    -------------------------------------------------------------------------- */
 .diff-para--added {
-    background: var(--color-diff-added-bg, #f0fdf4);
-    border-left: 3px solid var(--color-diff-added, #22c55e);
+    background: var(--color-diff-added-bg);
+    border-left: 3px solid var(--color-diff-added);
     padding-left: var(--space-3);
     margin-bottom: var(--space-2);
 }
 
-/* Removed paragraph marker â€” DesktopRead.cshtml / MobileRead.cshtml
-   Renders as a thin red left bar only. Content is intentionally hidden â€”
-   beta readers focus on what is present, not what was deleted. */
+/* Removed paragraph — DesktopRead.cshtml
+   Shows the deleted paragraph as red strikethrough text, clearly separated
+   from the replacement prose below it, matching VS Code deleted line style. */
 .diff-para--removed {
-    border-left: 3px solid var(--color-diff-removed, #ef4444);
-    height: var(--space-3, 12px);
+    background: var(--color-diff-removed-bg);
+    border-left: 3px solid var(--color-diff-removed);
+    padding-left: var(--space-3);
     margin-bottom: var(--space-2);
-    opacity: 0.5;
+    color: var(--color-diff-removed);
+    text-decoration: line-through;
+    opacity: 0.8;
 }
 
 /* Margin indicators — DesktopRead.cshtml
@@ -520,37 +530,37 @@ a {
 }
 
 .diff-margin__mark--added {
-    background: var(--color-diff-added, #22c55e);
+    background: var(--color-diff-added);
     opacity: 0.7;
 }
 
 .diff-margin__mark--removed {
-    background: var(--color-diff-removed, #ef4444);
+    background: var(--color-diff-removed);
     opacity: 0.7;
 }
 
 .diff-margin__mark--modified {
     background: linear-gradient(
         to bottom,
-        var(--color-diff-removed, #ef4444) 50%,
-        var(--color-diff-added, #22c55e) 50%
+        var(--color-diff-removed) 50%,
+        var(--color-diff-added) 50%
     );
     opacity: 0.7;
 }
 
 /* Inline diff markup — del/ins within Modified paragraphs */
 .scene-prose-content del {
-    color: var(--color-diff-removed, #ef4444);
+    color: var(--color-diff-removed);
     text-decoration: line-through;
-    background: rgba(239, 68, 68, 0.08);
+    background: var(--color-diff-removed-inline-bg);
     border-radius: 2px;
     padding: 0 1px;
 }
 
 .scene-prose-content ins {
-    color: var(--color-diff-added, #16a34a);
+    color: var(--color-diff-added);
     text-decoration: none;
-    background: rgba(34, 197, 94, 0.10);
+    background: var(--color-diff-added-inline-bg);
     border-radius: 2px;
     padding: 0 1px;
 }


### PR DESCRIPTION
## Problem

Removed paragraphs in the diff view were rendering with `height: 12px`, clipping the content and causing it to overflow as a ghost overlay on top of the replacement prose below — see issue #139.

## Changes

- Define all diff colours as design tokens in `:root` (`--color-diff-added`, `--color-diff-added-bg`, `--color-diff-added-inline-bg`, `--color-diff-removed`, `--color-diff-removed-bg`, `--color-diff-removed-inline-bg`)
- Replace all raw `rgba`/hex values in diff CSS with the defined tokens
- `.diff-para--removed`: remove the `height: 12px` constraint; render as a full-height paragraph with red strikethrough text and subtle red background — clearly separated from the replacement prose below, matching VS Code deleted-line style
- CSS version bumped to `v2026-09-01-3`

Fixes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)